### PR TITLE
Contain skill references to their own directory

### DIFF
--- a/src/core/skills/SkillLoader.ts
+++ b/src/core/skills/SkillLoader.ts
@@ -320,26 +320,43 @@ export class SkillLoader {
 
 	/**
 	 * Load reference files declared in the manifest.
-	 * Reference paths are relative to the SKILL.md file's parent directory.
+	 * References are sandboxed to the skill directory after canonical path
+	 * resolution so `..`, absolute paths, and symlinks cannot escape it.
 	 */
 	private async loadReferences(skillPath: string, manifest: SkillManifest): Promise<Map<string, string>> {
 		const refs = new Map<string, string>();
 		if (!manifest.references) return refs;
 
 		const skillDir = resolve(skillPath, "..");
+		const canonicalSkillDir = await this.canonicalizeExistingPath(skillDir);
+		if (!canonicalSkillDir) return refs;
 
-		for (const [name, relativePath] of Object.entries(manifest.references)) {
-			const absPath = resolve(skillDir, relativePath);
+		for (const [name, referencePath] of Object.entries(manifest.references)) {
 			try {
-				if (existsSync(absPath)) {
-					refs.set(name, readFileSync(absPath, "utf-8"));
-				}
+				const canonicalReference = await this.canonicalizeExistingPath(resolve(skillDir, referencePath));
+				if (!canonicalReference || !this.isPathWithinRoot(canonicalReference, canonicalSkillDir)) continue;
+				refs.set(name, readFileSync(canonicalReference, "utf-8"));
 			} catch {
-				// NOSONAR — skip unreadable references
+				// NOSONAR — skip missing, unreadable, or escaping references
 			}
 		}
 
 		return refs;
+	}
+
+	/**
+	 * Resolve an existing path to its canonical filesystem target. Real Node
+	 * always exposes realpathSync; the resolved fallback supports intentionally
+	 * incomplete node:fs test doubles that omit that built-in export.
+	 */
+	private async canonicalizeExistingPath(path: string): Promise<string | null> {
+		try {
+			const fs = await import("node:fs");
+			if (typeof fs.realpathSync === "function") return fs.realpathSync(path);
+			return existsSync(path) ? resolve(path) : null;
+		} catch {
+			return null;
+		}
 	}
 
 	/** Check whether a source path lives inside a configured search root. */

--- a/tests/unit/SkillLoader.test.ts
+++ b/tests/unit/SkillLoader.test.ts
@@ -5,7 +5,7 @@ import type { LoadedSkill } from "../../src/core/skills/SkillLoader";
 
 // vi.mock() factories are hoisted above imports, so we use vi.hoisted()
 // to ensure these constants are available when the factory runs.
-const { VALID_SKILL_MD, WILDCARD_SKILL_MD, INVALID_SKILL_MD, INCOMPLETE_SKILL_MD } = vi.hoisted(() => {
+const fsMocks = vi.hoisted(() => {
 	const VALID = `---
 name: slack-navigation
 description: Navigation strategies for Slack web app
@@ -43,13 +43,33 @@ name: incomplete-skill
 Missing required fields.
 `;
 
+	const exists = vi.fn().mockReturnValue(true);
+	const read = vi.fn().mockReturnValue(VALID);
+	const stat = vi.fn().mockReturnValue({ isDirectory: () => true });
+	const readdir = vi.fn().mockReturnValue([]);
+	const realpath = vi.fn().mockImplementation((p: string) => {
+		if (!exists(p)) {
+			const err = new Error(`ENOENT: no such file or directory, realpath '${p}'`);
+			(err as any).code = "ENOENT";
+			throw err;
+		}
+		return p;
+	});
+
 	return {
 		VALID_SKILL_MD: VALID,
 		WILDCARD_SKILL_MD: WILDCARD,
 		INVALID_SKILL_MD: INVALID,
 		INCOMPLETE_SKILL_MD: INCOMPLETE,
+		readFileSync: read,
+		existsSync: exists,
+		statSync: stat,
+		readdirSync: readdir,
+		realpathSync: realpath,
 	};
 });
+
+const { VALID_SKILL_MD, WILDCARD_SKILL_MD, INVALID_SKILL_MD, INCOMPLETE_SKILL_MD } = fsMocks;
 
 const MINIMAL_SKILL_MD = `---
 name: minimal
@@ -60,6 +80,14 @@ domain: example.com
 
 Minimal content.
 `;
+
+vi.mock("node:fs", () => ({
+	readFileSync: fsMocks.readFileSync,
+	existsSync: fsMocks.existsSync,
+	statSync: fsMocks.statSync,
+	readdirSync: fsMocks.readdirSync,
+	realpathSync: fsMocks.realpathSync,
+}));
 
 // Re-import SkillLoader dynamically where needed (top-level import works for basic tests)
 import { SkillLoader } from "../../src/core/skills/SkillLoader";
@@ -83,12 +111,6 @@ describe("SkillLoader", () => {
 
 	describe("load (YAML frontmatter parsing)", () => {
 		it("parses a valid SKILL.md file", async () => {
-			vi.mock("node:fs", () => ({
-				readFileSync: vi.fn().mockReturnValue(VALID_SKILL_MD),
-				existsSync: vi.fn().mockReturnValue(true),
-				statSync: vi.fn().mockReturnValue({ isDirectory: () => true }),
-				readdirSync: vi.fn().mockReturnValue([]),
-			}));
 
 			// Need to re-import with mock
 			const { SkillLoader: SL } = await import("../../src/core/skills/SkillLoader");

--- a/tests/unit/skills/SkillReferenceContainment.test.ts
+++ b/tests/unit/skills/SkillReferenceContainment.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { SkillLoader } from "../../../src/core/skills/SkillLoader.js";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+	await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function makeFixture(references: Record<string, string>): Promise<{
+	root: string;
+	skillDir: string;
+	skillPath: string;
+}> {
+	const root = await mkdtemp(join(tmpdir(), "talox-skill-reference-"));
+	tempDirs.push(root);
+	const skillDir = join(root, "skill");
+	await mkdir(skillDir, { recursive: true });
+
+	const referenceYaml = Object.entries(references)
+		.map(([name, path]) => `  ${name}: ${JSON.stringify(path)}`)
+		.join("\n");
+	const skillPath = join(skillDir, "SKILL.md");
+	await writeFile(
+		skillPath,
+		`---\nname: containment-test\ndescription: Reference containment test\nversion: 1.0\ndomain: example.com\nreferences:\n${referenceYaml}\n---\n\nUse the declared references.\n`,
+		"utf-8",
+	);
+
+	return { root, skillDir, skillPath };
+}
+
+describe("SkillLoader reference containment", () => {
+	it("loads nested references whose canonical target stays inside the skill directory", async () => {
+		const { skillDir, skillPath } = await makeFixture({ api: "docs/api.md" });
+		await mkdir(join(skillDir, "docs"), { recursive: true });
+		await writeFile(join(skillDir, "docs", "api.md"), "safe nested reference", "utf-8");
+
+		const skill = await new SkillLoader().load(skillPath);
+
+		expect(skill?.references.get("api")).toBe("safe nested reference");
+	});
+
+	it("skips parent-directory traversal references", async () => {
+		const { root, skillPath } = await makeFixture({ secret: "../secret.md" });
+		await writeFile(join(root, "secret.md"), "outside secret", "utf-8");
+
+		const skill = await new SkillLoader().load(skillPath);
+
+		expect(skill).not.toBeNull();
+		expect(skill?.references.has("secret")).toBe(false);
+	});
+
+	it("skips absolute references outside the skill directory", async () => {
+		const root = await mkdtemp(join(tmpdir(), "talox-skill-reference-outside-"));
+		tempDirs.push(root);
+		const outsidePath = join(root, "absolute-secret.md");
+		await writeFile(outsidePath, "absolute outside secret", "utf-8");
+		const fixture = await makeFixture({ secret: outsidePath });
+
+		const skill = await new SkillLoader().load(fixture.skillPath);
+
+		expect(skill).not.toBeNull();
+		expect(skill?.references.has("secret")).toBe(false);
+	});
+
+	it.skipIf(process.platform === "win32")("skips symlinks whose canonical target escapes the skill directory", async () => {
+		const { root, skillDir, skillPath } = await makeFixture({ secret: "linked-secret.md" });
+		const outsidePath = join(root, "outside-secret.md");
+		await writeFile(outsidePath, "symlink outside secret", "utf-8");
+		await symlink(outsidePath, join(skillDir, "linked-secret.md"));
+
+		const skill = await new SkillLoader().load(skillPath);
+
+		expect(skill).not.toBeNull();
+		expect(skill?.references.has("secret")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Scope

- canonicalize declared skill reference targets before reading them
- require canonical targets to stay inside the skill directory
- block parent-directory traversal, absolute-path escapes, and symlink escapes
- continue allowing normal nested references inside the skill directory
- read the canonical target path after containment validation
- add real-filesystem regressions for nested references, `..` traversal, absolute paths, and symlink escapes

## Stack

This PR is intentionally stacked on PR #17 (`fix/skill-registry-reconcile`). The branch has been rebuilt directly on rebased #17 head `796f479`, so its diff is only the two-file reference-containment slice.

## Validation

- CodeRabbit is clean on rebased head `eed8981`
- no open review findings
- full unit/type/browser validation will be run after the upstream Actions queue clears
