### PR TITLE
Add a reproducible Docker runtime for Talox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+node_modules
+dist
+coverage
+artifacts
+reports
+test-results
+playwright-report
+.talox
+.talox-profiles
+*.log
+.env
+.env.*
+.DS_Store
+npm-debug.log*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,8 +35,15 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
+      - name: Resolve locked Playwright version
+        id: playwright
+        run: |
+          version=$(node -p 'require("./package-lock.json").packages["node_modules/playwright-core"].version')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Locked playwright-core: $version"
+
       - name: Build Talox image
-        run: docker build --tag talox:ci .
+        run: docker build --build-arg PLAYWRIGHT_VERSION=${{ steps.playwright.outputs.version }} --tag talox:ci .
 
       - name: Verify non-root runtime
         run: test "$(docker run --rm --entrypoint id talox:ci -u)" != "0"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,20 @@ jobs:
       - name: Smoke Talox CLI
         run: docker run --rm --init talox:ci init --help
 
+      - name: Probe Playwright-managed Chromium
+        run: |
+          docker run --rm --init --entrypoint node talox:ci --input-type=module -e '
+            import { chromium } from "/opt/talox/node_modules/playwright-core/index.js";
+            console.log(`PLAYWRIGHT_BROWSERS_PATH=${process.env.PLAYWRIGHT_BROWSERS_PATH ?? "unset"}`);
+            console.log(`chromium.executablePath=${chromium.executablePath()}`);
+            const browser = await chromium.launch({ headless: true, timeout: 10000 });
+            try {
+              console.log(`Direct Chromium version: ${browser.version()}`);
+            } finally {
+              await browser.close();
+            }
+          '
+
       - name: Detect bundled Chromium through Talox
         run: |
           docker run --rm --init --entrypoint node talox:ci --input-type=module -e '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,61 @@
+name: Docker
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker/**
+      - docs/DOCKER.md
+      - package.json
+      - package-lock.json
+      - src/**
+      - .github/workflows/docker.yml
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - docker/**
+      - docs/DOCKER.md
+      - package.json
+      - package-lock.json
+      - src/**
+      - .github/workflows/docker.yml
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build Talox image
+        run: docker build --tag talox:ci .
+
+      - name: Verify non-root runtime
+        run: test "$(docker run --rm --entrypoint id talox:ci -u)" != "0"
+
+      - name: Smoke Talox CLI
+        run: docker run --rm --init talox:ci --help
+
+      - name: Detect bundled Chromium through Talox
+        run: |
+          docker run --rm --init --entrypoint node talox:ci --input-type=module -e '
+            import { BrowserManager } from "/opt/talox/dist/core/BrowserManager.js";
+            const manager = new BrowserManager();
+            try {
+              const browsers = await manager.detectBrowsers();
+              const chromium = browsers.find((browser) => browser.type === "chromium");
+              if (!chromium) throw new Error("Talox did not detect bundled Chromium");
+              console.log(`Detected Chromium: ${chromium.executablePath ?? chromium.channel ?? "unknown"}`);
+            } finally {
+              await manager.closeAll();
+            }
+          '

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
         run: test "$(docker run --rm --entrypoint id talox:ci -u)" != "0"
 
       - name: Smoke Talox CLI
-        run: docker run --rm --init talox:ci --help
+        run: docker run --rm --init talox:ci init --help
 
       - name: Detect bundled Chromium through Talox
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Docker
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - Dockerfile
       - .dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,16 +53,21 @@ jobs:
 
       - name: Probe Playwright-managed Chromium
         run: |
-          docker run --rm --init --entrypoint node talox:ci --input-type=module -e '
-            import { chromium } from "/opt/talox/node_modules/playwright-core/index.js";
+          docker run --rm --init --entrypoint node talox:ci -e '
+            const { chromium } = require("/opt/talox/node_modules/playwright-core");
             console.log(`PLAYWRIGHT_BROWSERS_PATH=${process.env.PLAYWRIGHT_BROWSERS_PATH ?? "unset"}`);
             console.log(`chromium.executablePath=${chromium.executablePath()}`);
-            const browser = await chromium.launch({ headless: true, timeout: 10000 });
-            try {
-              console.log(`Direct Chromium version: ${browser.version()}`);
-            } finally {
-              await browser.close();
-            }
+            (async () => {
+              const browser = await chromium.launch({ headless: true, timeout: 10000 });
+              try {
+                console.log(`Direct Chromium version: ${browser.version()}`);
+              } finally {
+                await browser.close();
+              }
+            })().catch((error) => {
+              console.error(error);
+              process.exit(1);
+            });
           '
 
       - name: Detect bundled Chromium through Talox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7
+
+ARG NODE_VERSION=22
+ARG PLAYWRIGHT_VERSION=1.58.2
+
+FROM node:${NODE_VERSION}-bookworm-slim AS build
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+WORKDIR /src
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble AS runtime
+
+LABEL org.opencontainers.image.title="Talox" \
+      org.opencontainers.image.description="Local browser runtime for AI agents" \
+      org.opencontainers.image.source="https://github.com/AVANT-ICONIC/Talox" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+
+ENV NODE_ENV=production \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
+    HOME=/home/talox
+
+WORKDIR /opt/talox
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --omit=optional && npm cache clean --force
+
+COPY --from=build /src/dist ./dist
+COPY src/schema ./src/schema
+COPY LICENSE README.md CHANGELOG.md ./
+
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin talox \
+    && mkdir -p /workspace/.talox-profiles /home/talox/.talox \
+    && chown -R talox:talox /workspace /home/talox
+
+USER talox
+WORKDIR /workspace
+
+VOLUME ["/workspace/.talox-profiles", "/home/talox/.talox"]
+
+ENTRYPOINT ["node", "/opt/talox/dist/cli/talox.js"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1.7
 
 ARG NODE_VERSION=22
-ARG PLAYWRIGHT_VERSION=1.58.2
+# Keep this aligned with package-lock.json -> node_modules/playwright-core.
+ARG PLAYWRIGHT_VERSION=1.59.1
 
 FROM node:${NODE_VERSION}-bookworm-slim AS build
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,60 @@
+# Running Talox in Docker
+
+Talox ships a container definition pinned to the same Playwright version used by the project. The image includes the Playwright browser/runtime system dependencies, installs Talox production dependencies, and runs as an unprivileged `talox` user.
+
+## Build
+
+```bash
+docker build -t talox:local .
+```
+
+## Run
+
+The container entrypoint is the Talox CLI, so normal CLI arguments can be passed directly:
+
+```bash
+docker run --rm --init --ipc=host talox:local --help
+```
+
+For agent runs, pass provider credentials through the environment rather than baking them into the image:
+
+```bash
+docker run --rm --init --ipc=host \
+  -e OPENAI_API_KEY \
+  -v talox-profiles:/workspace/.talox-profiles \
+  -v talox-state:/home/talox/.talox \
+  talox:local run "Inspect the target page"
+```
+
+Mount a host working directory when Talox should read or write project artifacts:
+
+```bash
+docker run --rm --init --ipc=host \
+  -e OPENAI_API_KEY \
+  -v "$PWD:/workspace" \
+  -v talox-state:/home/talox/.talox \
+  talox:local run "Inspect the app in this workspace"
+```
+
+`--ipc=host` is recommended for Chromium workloads because constrained shared memory can make Chromium unstable. `--init` prevents zombie child processes when browsers exit.
+
+## Persistent state
+
+The image exposes two persistence locations:
+
+- `/workspace/.talox-profiles` for browser profiles created relative to the working directory.
+- `/home/talox/.talox` for Talox user-level state and skills.
+
+Use named volumes or bind mounts if sessions must survive container replacement.
+
+## Browser detection
+
+The image intentionally relies on Playwright's bundled Chromium rather than installing a second system Chrome. Talox's browser auto-detection probes the Playwright-managed browser first, so the image remains usable even when `/usr/bin/google-chrome` is absent.
+
+The Docker CI workflow verifies this by starting the built image and calling `BrowserManager.detectBrowsers()` as the unprivileged runtime user.
+
+## Security boundary
+
+The container process runs as the non-root `talox` user. That reduces host/container damage from a compromised browser process, but it is not yet a complete Chromium sandbox boundary: Talox currently passes Chromium's `--no-sandbox` flags in its general launch path. Treat the container itself as the isolation boundary until browser-sandbox hardening lands.
+
+Do not bake API keys, cookies, profile directories, or `.env` files into images. The repository `.dockerignore` excludes the common local state and secret paths for this reason.


### PR DESCRIPTION
## Scope

- add a multi-stage Docker build pinned to Playwright 1.58.2
- run the final image as an unprivileged `talox` user
- keep browser/profile and user-level Talox state mountable across container replacement
- exclude local profiles, `.env` files, reports, artifacts, and other development state from the build context
- document build, run, persistence, credential, and current sandbox-boundary behavior
- add Docker CI that builds the image, verifies the non-root UID, exercises the Talox CLI, and confirms BrowserManager detects Playwright-managed Chromium inside the image

## Stack

This PR is intentionally stacked on PR #15 (`fix/playwright-browser-autodetect`) because the image relies on Talox correctly detecting Playwright's bundled Chromium without a system Chrome installation.

## Security note

The container process is non-root, but Talox's general Chromium launch path still explicitly disables Chromium sandboxing. The Docker docs call this out rather than pretending process isolation and browser sandboxing are the same thing. Browser sandbox hardening remains a separate runtime change.

## Validation

Docker build/smoke and review status will be recorded on the final head.
