### PR TITLE
Fix CLI help semantics and Docker entrypoint routing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,18 @@ jobs:
       - name: Smoke Talox CLI
         run: docker run --rm --init talox:ci init --help
 
+      - name: Smoke top-level CLI help exit codes
+        run: |
+          docker run --rm --init talox:ci --help
+          docker run --rm --init talox:ci -h
+
+      - name: Reject unknown top-level commands
+        run: |
+          if docker run --rm --init talox:ci definitely-not-a-command; then
+            echo "Unknown command unexpectedly exited successfully"
+            exit 1
+          fi
+
       - name: Probe sandboxed Playwright-managed Chromium
         run: |
           docker run --rm --init --ipc=host \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,7 @@ WORKDIR /workspace
 
 VOLUME ["/workspace/.talox-profiles", "/home/talox/.talox"]
 
-ENTRYPOINT ["node", "/opt/talox/dist/cli/talox.js"]
+# Match package.json's published bin entry so Docker uses the same CLI router,
+# including top-level help normalization and multi-agent `run --agents N` dispatch.
+ENTRYPOINT ["node", "/opt/talox/dist/cli/entry.js"]
 CMD ["--help"]

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
 import { runMultiAgentRun, shouldUseMultiAgentRun } from "./multi-agent-run.js";
+import { normalizeTopLevelHelpArgv } from "./normalize-argv.js";
 
-const argv = process.argv.slice(2);
+const rawArgv = process.argv.slice(2);
+const argv = normalizeTopLevelHelpArgv(rawArgv);
+
+if (argv !== rawArgv) {
+	process.argv.splice(2, rawArgv.length, ...argv);
+}
 
 try {
 	if (shouldUseMultiAgentRun(argv)) {

--- a/src/cli/normalize-argv.ts
+++ b/src/cli/normalize-argv.ts
@@ -1,0 +1,11 @@
+export function normalizeTopLevelHelpArgv(argv: string[]): string[] {
+	const first = argv[0];
+	if (first === "--help" || first === "-h") {
+		// The legacy CLI owns the canonical usage text through its command parsers.
+		// Route top-level help through a no-side-effect command parser so it prints
+		// that same usage text and exits successfully instead of hitting the
+		// unknown-command branch.
+		return ["init", "--help"];
+	}
+	return argv;
+}

--- a/tests/unit/CliArgv.test.ts
+++ b/tests/unit/CliArgv.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTopLevelHelpArgv } from "../../src/cli/normalize-argv.js";
+
+describe("normalizeTopLevelHelpArgv", () => {
+	it("routes --help through the canonical legacy usage path", () => {
+		expect(normalizeTopLevelHelpArgv(["--help"])).toEqual(["init", "--help"]);
+	});
+
+	it("routes -h through the canonical legacy usage path", () => {
+		expect(normalizeTopLevelHelpArgv(["-h"])).toEqual(["init", "--help"]);
+	});
+
+	it("treats top-level help as authoritative even when trailing arguments are present", () => {
+		expect(normalizeTopLevelHelpArgv(["--help", "ignored"])).toEqual(["init", "--help"]);
+	});
+
+	it("leaves ordinary commands untouched", () => {
+		const argv = ["run", "Inspect the page", "--agents", "2"];
+		expect(normalizeTopLevelHelpArgv(argv)).toBe(argv);
+	});
+});


### PR DESCRIPTION
## Scope

- normalize top-level `--help` / `-h` before delegating into the legacy CLI so they use the canonical usage path and exit successfully
- leave ordinary command argv untouched, including multi-agent routing
- add pure unit coverage for help normalization
- make the Docker image use the same published CLI entrypoint as `package.json` (`dist/cli/entry.js`) instead of bypassing it through `dist/cli/talox.js`
- extend Docker smoke coverage to prove built `talox --help` and `talox -h` exit 0
- preserve non-zero failure semantics for genuinely unknown top-level commands

## Bugs fixed

1. Top-level `talox --help` printed usage but exited 1 because the legacy CLI treated `--help` as an unknown command.
2. The Docker image bypassed `src/cli/entry.ts` entirely, so it also bypassed the newer multi-agent `run --agents N` router and any entrypoint-level normalization.

The Docker `ENTRYPOINT` now matches the package's published `bin` target, eliminating the split between npm and container behavior.

## Final validation

- Docker build + packaged CLI help/invalid-command smoke: **success**
- Unit Tests: **success**
- Lint & Typecheck: **success**
- Browser controller/observe/smart/loop: **success**
- Browser root: first attempt had one transient Chromium launch miss; failed-job retry passed **success** without code changes
- Aggregate Browser Integration Tests: **success**
- Open review threads: **0**