### PR TITLE
Refresh CI runtimes, split browser shards, and clean stale TODOs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,9 @@ jobs:
         run: npm run test:unit
 
   # ─── Browser integration tests — runs on every push / PR ──────────────────────
-  # The browser suite is intentionally serial inside each shard because multiple
-  # Chromium launches in one Vitest worker can deadlock resources. Separate CI
-  # runners let independent test areas execute concurrently without weakening
-  # that isolation. The aggregate `browser` job below preserves the stable check
-  # name used by branch protection.
+  # Browser tests remain serial inside each shard. The unusually slow error-path
+  # suite has its own runner so a transient browser-launch failure does not force
+  # the rest of the root suite to be repeated after ~18 minutes of work.
   browser-shard:
     name: Browser Integration · ${{ matrix.group }}
     runs-on: ubuntu-latest
@@ -75,14 +73,22 @@ jobs:
         include:
           - group: root
             target: 'tests/core/*.test.ts'
+            exclude: 'tests/core/error-paths.test.ts'
+          - group: error-paths
+            target: 'tests/core/error-paths.test.ts'
+            exclude: ''
           - group: loop
             target: 'tests/core/loop/*.test.ts'
+            exclude: ''
           - group: controller
             target: 'tests/core/controller/*.test.ts'
+            exclude: ''
           - group: observe
             target: 'tests/core/observe/*.test.ts'
+            exclude: ''
           - group: smart
             target: 'tests/core/smart/*.test.ts'
+            exclude: ''
     steps:
       - uses: actions/checkout@v7
 
@@ -99,7 +105,13 @@ jobs:
         run: npx playwright install --with-deps chromium
 
       - name: Run browser integration shard
-        run: npx vitest run --config vitest.config.browser.ts ${{ matrix.target }}
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.exclude }}" ]; then
+            npx vitest run --config vitest.config.browser.ts ${{ matrix.target }} --exclude ${{ matrix.exclude }}
+          else
+            npx vitest run --config vitest.config.browser.ts ${{ matrix.target }}
+          fi
 
   browser:
     name: Browser Integration Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -45,9 +45,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -84,9 +84,9 @@ jobs:
           - group: smart
             target: 'tests/core/smart/*.test.ts'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -124,9 +124,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ github.run_number }}
           path: playwright-report/
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload test videos (failures only)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-videos-${{ github.run_number }}
           path: test-results/

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Resolve locked Playwright version
         id: playwright

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-> v8.0.0 shipped. 106 test files, 1946 tests, CI green.
+> v8.1.0 shipped. Multi-agent coordination, skill loading hardening, Docker packaging, sandboxed Chromium support, and dependency-audit maintenance are in place.
 
 ---
 
@@ -32,15 +32,15 @@
 - Progress observers are isolated so reporting failures cannot terminate browser coordination.
 - Multi-agent browser launch is atomic and rejects invalid agent counts before starting browsers.
 - Browser integration coverage exercises two real Chromium-backed Talox agents across navigation, shared evidence, independent interaction, and replanning.
+- Single-agent `AutonomousLoop` loads configured skills before domain matching.
+- Skill manifests preserve numeric-looking versions such as `version: 1.0` as strings.
+- Docker packaging uses Playwright-managed Chromium, a non-root runtime, and an opt-in sandbox path proven with a matching seccomp profile.
+- Dependency maintenance keeps both the production and full npm graphs free of known advisories.
 
 ---
 
 ## 🟢 Later
 
-- [ ] Ensure single-agent `AutonomousLoop` calls `SkillLoader.loadAll()` before domain matching; the loader is constructed today but discovered skills are not explicitly loaded in the loop.
-- [ ] Accept unquoted numeric-looking skill manifest versions such as `version: 1.0`; the current mini-YAML parser converts them to numbers while `SkillManifest.version` requires a string.
-- [ ] Refresh `package-lock.json` root package metadata during the next dependency/install maintenance pass (its package version/bin metadata predates current `package.json`).
-- [ ] Docker image
 - [ ] MCP server
 - [ ] Headless-first mode
 - [ ] Plugin architecture (community rules + vision detectors)

--- a/TODO.md
+++ b/TODO.md
@@ -36,13 +36,13 @@
 - Skill manifests preserve numeric-looking versions such as `version: 1.0` as strings.
 - Docker packaging uses Playwright-managed Chromium, a non-root runtime, and an opt-in sandbox path proven with a matching seccomp profile.
 - Dependency maintenance keeps both the production and full npm graphs free of known advisories.
+- BrowserManager is headless-first by default; autonomous single- and multi-agent `run` paths stay headless while interactive `observe`/`chat` explicitly opt into headed mode.
 
 ---
 
 ## 🟢 Later
 
 - [ ] MCP server
-- [ ] Headless-first mode
 - [ ] Plugin architecture (community rules + vision detectors)
 - [ ] Replay UI (interactive session replay)
 - [ ] Cross-origin iframe trust detection (leverages `trust` field from v8.0.0)


### PR DESCRIPTION
## Scope

- move `actions/checkout` and `actions/setup-node` to the current Node-24-backed v7 majors
- move `docker/setup-buildx-action` to v4
- move nightly `actions/upload-artifact` usage to v7
- split `tests/core/error-paths.test.ts` into its own browser integration shard
- keep the remaining root-level browser tests in a separate shard using Vitest `--exclude`
- preserve the aggregate `Browser Integration Tests` branch-protection gate
- remove maintenance TODOs already implemented in v8.1

## Why

GitHub-hosted runners were forcing the older Node-20 action runtimes onto Node 24 and emitting deprecation warnings. Separately, the root browser shard can run for roughly 18 minutes, so one transient Chromium launch miss in `error-paths` forced a costly rerun of otherwise-passing root tests.

This PR does not ignore browser failures or add automatic retries. It narrows failure blast radius by running `error-paths` independently.

The TODO cleanup reflects verified shipped behavior: skill loading, numeric-looking manifest versions, lockfile metadata, Docker packaging, dependency cleanup, and headless-first runtime defaults are already in place.

## Validation target

- CI uses the refreshed JavaScript action majors without Node-20 runtime warnings
- browser CI exposes six shards: `root`, `error-paths`, `loop`, `controller`, `observe`, `smart`
- aggregate browser gate requires all six
- Docker build/sandbox smoke remains green on setup-buildx v4
- production dependency audit remains green
- no application runtime behavior is changed