### PR TITLE
feat: add community plugin architecture

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,91 @@
+# Talox MCP Server
+
+Talox exposes its local browser runtime as a Model Context Protocol (MCP) server over stdio.
+
+## Start
+
+Build Talox first:
+
+```bash
+npm install
+npm run build
+```
+
+Then start the server:
+
+```bash
+node dist/cli/entry.js mcp
+```
+
+When Talox is installed as a CLI package, the equivalent command is:
+
+```bash
+talox mcp
+```
+
+The MCP transport owns `stdout`; diagnostics and Talox logs are kept off the protocol stream.
+
+## Client configuration
+
+Point an MCP client at the built Talox CLI entry with `mcp` as its argument. A generic stdio configuration looks like:
+
+```json
+{
+  "command": "node",
+  "args": ["/absolute/path/to/Talox/dist/cli/entry.js", "mcp"]
+}
+```
+
+The exact wrapper object around `command` and `args` depends on the MCP client.
+
+## Tools
+
+| Tool | Purpose |
+| --- | --- |
+| `talox_launch` | Launch one persistent Talox browser session. |
+| `talox_navigate` | Navigate the active browser to a URL. |
+| `talox_click` | Click an element by selector. |
+| `talox_type` | Type text into an element. |
+| `talox_state` | Read structured page state. Defaults to the compact `agent` variant. |
+| `talox_screenshot` | Capture a page or element screenshot as MCP image content. |
+| `talox_stop` | Stop the active browser session and release resources. |
+
+A typical sequence is:
+
+```text
+talox_launch
+     |
+     v
+talox_navigate
+     |
+     +--> talox_state
+     +--> talox_click / talox_type
+     +--> talox_screenshot
+     |
+     v
+talox_stop
+```
+
+The browser session persists across tool calls inside the same MCP server process. `talox_state` intentionally defaults to Talox's `agent` state variant so an MCP client does not pay the context cost of the complete diagnostic state unless it asks for `debug` or `full`.
+
+## Protocol compatibility
+
+The stdio bridge supports the current MCP `2026-07-28` discovery flow and preserves compatibility with handshake-era MCP clients using supported 2024/2025 protocol versions.
+
+For modern clients Talox:
+
+- supports `server/discover`;
+- attaches server identity through the modern response metadata envelope;
+- supplies deterministic cache hints on the tool catalog;
+- returns `resultType: "complete"` for complete results;
+- rejects methods removed from the modern protocol rather than silently pretending they still exist.
+
+For legacy clients Talox preserves the `initialize` handshake and legacy server-info response shape.
+
+## Lifecycle and errors
+
+Only one Talox browser session is active per MCP stdio process. Calling `talox_launch` twice without stopping the first session returns a tool error.
+
+Malformed JSON receives a JSON-RPC parse error. Invalid request IDs and unknown RPC methods receive protocol errors. Tool execution failures remain MCP tool results with `isError: true`, allowing the calling agent to inspect and recover from browser-level failures without losing the MCP connection.
+
+The active Talox browser is closed when the MCP input stream ends or the process receives a normal shutdown signal.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -1,0 +1,119 @@
+# Talox plugins
+
+Talox plugins extend browser QA without patching Talox core. A plugin can contribute:
+
+- **Rules**: synchronous structured-state checks that run automatically inside `RulesEngine.analyze()`.
+- **Vision detectors**: asynchronous screenshot checks that run only when explicitly requested.
+
+The registry is process-wide and dependency-free. Import it from the dedicated public entrypoint:
+
+```ts
+import {
+  registerTaloxPlugin,
+  runTaloxVisionDetectors,
+} from "talox/plugins";
+```
+
+## Register a community rule
+
+```ts
+registerTaloxPlugin({
+  name: "acme-a11y",
+  version: "1.0.0",
+  rules: [
+    {
+      id: "empty-button-label",
+      analyze(state) {
+        return state.interactiveElements
+          .filter((element) => element.tagName === "button" && !element.text)
+          .map((element) => ({
+            id: element.id,
+            type: "MISSING_ACCESSIBLE_LABEL",
+            severity: "MAJOR",
+            description: "Button has no accessible label.",
+            evidence: { element },
+          }));
+      },
+    },
+  ],
+});
+```
+
+Plugin findings are automatically namespaced before they enter Talox state:
+
+```text
+plugin:acme-a11y:empty-button-label:#submit
+```
+
+Talox also adds plugin provenance to `bug.metadata.taloxPlugin`.
+
+### Rule contract
+
+Rules should be fast, synchronous, and side-effect free. They receive the current `TaloxPageState` as read-only input and may return:
+
+- an array of valid `TaloxBug` objects,
+- an empty array,
+- `null`, or
+- `undefined`.
+
+A rule exception, malformed return value, or malformed bug is isolated and logged. Other built-in and community rules continue to run.
+
+## Register a vision detector
+
+Vision detectors are intentionally opt-in. Talox does **not** run them every time state is collected because model-backed or image-heavy checks can be expensive.
+
+```ts
+registerTaloxPlugin({
+  name: "acme-visual-qa",
+  version: "1.0.0",
+  visionDetectors: [
+    {
+      id: "obscured-primary-cta",
+      async detect(screenshot, context) {
+        // Run a local model, remote model, OpenCV pipeline, etc.
+        return [
+          {
+            type: "OBSCURED_CTA",
+            description: `Primary CTA appears obscured on ${context.url}`,
+            confidence: 0.93,
+            evidence: { region: "bottom-right" },
+          },
+        ];
+      },
+    },
+  ],
+});
+```
+
+Run registered detectors explicitly:
+
+```ts
+const results = await runTaloxVisionDetectors(pngBuffer, {
+  url: "https://example.com/checkout",
+  title: "Checkout",
+});
+```
+
+Each detector gets its own screenshot buffer copy. Exceptions and malformed output are returned as an `error` on that detector's result instead of aborting the batch.
+
+## Registry lifecycle
+
+```ts
+import {
+  clearTaloxPlugins,
+  listTaloxPlugins,
+  unregisterTaloxPlugin,
+} from "talox/plugins";
+
+console.log(listTaloxPlugins());
+unregisterTaloxPlugin("acme-a11y");
+clearTaloxPlugins();
+```
+
+Registration order is preserved. Plugin names must be unique. Rule IDs are unique across registered rules, and vision detector IDs are unique across registered detectors. Registration is transactional: if validation fails, none of that plugin's hooks are installed.
+
+Because the registry is **process-wide**, a plugin becomes visible to all `RulesEngine` instances in that Node.js process. Hosts that need tenant isolation should run separate processes or explicitly register/unregister plugins around isolated work.
+
+## Why rules and vision detectors are separate
+
+Structured rules are cheap and deterministic, so they belong in the standard QA pass. Vision detectors may involve large image transforms or model inference, so callers decide when their cost is justified. This keeps the normal Talox state loop compact while still giving community extensions a first-class visual-analysis seam.

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -114,6 +114,17 @@ Registration order is preserved. Plugin names must be unique. Rule IDs are uniqu
 
 Because the registry is **process-wide**, a plugin becomes visible to all `RulesEngine` instances in that Node.js process. Hosts that need tenant isolation should run separate processes or explicitly register/unregister plugins around isolated work.
 
+## Plugin author checklist
+
+Before publishing a community plugin:
+
+- choose stable rule and detector IDs that will not collide with other installed plugins,
+- keep structured rules synchronous and cheap enough to run on every QA pass,
+- put network/model/image work in explicit vision detectors instead of rules,
+- return complete `TaloxBug` objects with deterministic evidence,
+- treat the supplied page state and screenshot as inputs rather than shared mutable state,
+- version behavior changes so hosts can report exactly which plugin produced a finding.
+
 ## Why rules and vision detectors are separate
 
 Structured rules are cheap and deterministic, so they belong in the standard QA pass. Vision detectors may involve large image transforms or model inference, so callers decide when their cost is justified. This keeps the normal Talox state loop compact while still giving community extensions a first-class visual-analysis seam.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./plugins": {
+      "import": "./dist/plugins.js",
+      "types": "./dist/plugins.d.ts"
     }
   },
   "files": [

--- a/src/cli/entry.ts
+++ b/src/cli/entry.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { runMcpCommand, shouldUseMcpCommand } from "./mcp.js";
 import { runMultiAgentRun, shouldUseMultiAgentRun } from "./multi-agent-run.js";
 import { normalizeTopLevelHelpArgv } from "./normalize-argv.js";
 
@@ -11,10 +12,12 @@ if (argv !== rawArgv) {
 }
 
 try {
-	if (shouldUseMultiAgentRun(argv)) {
+	if (shouldUseMcpCommand(argv)) {
+		await runMcpCommand(argv.slice(1));
+	} else if (shouldUseMultiAgentRun(argv)) {
 		await runMultiAgentRun(argv.slice(1));
 	} else {
-		// Preserve the existing CLI unchanged for every non-multi-agent command.
+		// Preserve the existing CLI unchanged for every other command.
 		// talox.ts executes its own main() at module load using the same process.argv.
 		await import("./talox.js");
 	}

--- a/src/cli/mcp.ts
+++ b/src/cli/mcp.ts
@@ -1,0 +1,47 @@
+import { setLogLevel } from "../core/Logger.js";
+import { TaloxMcpStdioServer } from "../core/mcp/TaloxMcpServer.js";
+
+const MCP_USAGE = `Usage:\n  talox mcp\n\nStarts the Talox MCP server over stdio. stdout is reserved for MCP JSON-RPC frames.`;
+
+export function shouldUseMcpCommand(argv: string[]): boolean {
+	return argv[0] === "mcp";
+}
+
+export async function runMcpCommand(args: string[]): Promise<void> {
+	if (args.includes("--help") || args.includes("-h")) {
+		console.log(MCP_USAGE);
+		return;
+	}
+	if (args.length > 0) {
+		throw new Error(`Unknown talox mcp option: ${args[0]}`);
+	}
+
+	// MCP stdio owns stdout. Talox core logs use the level-gated logger, and
+	// this redirect catches any remaining console.log calls from older modules.
+	setLogLevel("silent");
+	const originalConsoleLog = console.log;
+	console.log = (...values: unknown[]) => console.error(...values);
+
+	const server = new TaloxMcpStdioServer();
+	let shuttingDown = false;
+	const shutdown = async () => {
+		if (shuttingDown) return;
+		shuttingDown = true;
+		await server.close().catch((error: unknown) => {
+			console.error("[Talox MCP] shutdown failed", error);
+		});
+		process.exit(0);
+	};
+
+	process.once("SIGINT", shutdown);
+	process.once("SIGTERM", shutdown);
+	console.error("[Talox MCP] stdio server ready");
+
+	try {
+		await server.run();
+	} finally {
+		process.off("SIGINT", shutdown);
+		process.off("SIGTERM", shutdown);
+		console.log = originalConsoleLog;
+	}
+}

--- a/src/core/RulesEngine.ts
+++ b/src/core/RulesEngine.ts
@@ -1,10 +1,32 @@
 import type { TaloxBug, TaloxPageState } from "../types/index.js";
+import { createLogger } from "./Logger.js";
+import { getTaloxPluginRules } from "./plugins/PluginRegistry.js";
+
+const logger = createLogger("Rules");
+const BUG_SEVERITIES = new Set(["CRITICAL", "MAJOR", "MINOR"]);
+
+function isTaloxBug(value: unknown): value is TaloxBug {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Record<string, unknown>;
+	return (
+		typeof candidate.id === "string" &&
+		candidate.id.length > 0 &&
+		typeof candidate.type === "string" &&
+		candidate.type.length > 0 &&
+		typeof candidate.severity === "string" &&
+		BUG_SEVERITIES.has(candidate.severity) &&
+		typeof candidate.description === "string" &&
+		candidate.description.length > 0 &&
+		candidate.evidence !== null &&
+		typeof candidate.evidence === "object"
+	);
+}
 
 /**
  * Analyzes page states for quality-assurance bugs. Detects structural
  * regressions (missing AX-tree nodes or interactive elements between two
- * states), JavaScript console errors, overlapping UI elements, and viewport
- * clipping issues.
+ * states), JavaScript console errors, overlapping UI elements, viewport
+ * clipping issues, and registered synchronous community rules.
  */
 export class RulesEngine {
 	/**
@@ -100,6 +122,38 @@ export class RulesEngine {
 		}
 	}
 
+	private runPluginRules(state: TaloxPageState, bugs: TaloxBug[]): void {
+		for (const registration of getTaloxPluginRules()) {
+			const { pluginName, pluginVersion, rule } = registration;
+			try {
+				const result = rule.analyze(state);
+				if (result == null) continue;
+				if (!Array.isArray(result)) {
+					logger.warn(`Plugin rule ${pluginName}/${rule.id} returned a non-array result; ignoring it.`);
+					continue;
+				}
+
+				for (const bug of result) {
+					if (!isTaloxBug(bug)) {
+						logger.warn(`Plugin rule ${pluginName}/${rule.id} returned an invalid bug; ignoring it.`);
+						continue;
+					}
+					bugs.push({
+						...bug,
+						id: `plugin:${pluginName}:${rule.id}:${bug.id}`,
+						metadata: {
+							...bug.metadata,
+							taloxPlugin: { name: pluginName, version: pluginVersion, ruleId: rule.id },
+						},
+					});
+				}
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				logger.warn(`Plugin rule ${pluginName}/${rule.id} failed: ${message}`);
+			}
+		}
+	}
+
 	analyze(state: TaloxPageState): TaloxBug[] {
 		const bugs: TaloxBug[] = [];
 
@@ -120,6 +174,9 @@ export class RulesEngine {
 
 		// 3. Clipping Detection (Dynamic Viewport)
 		this.detectClipping(state.interactiveElements, bugs);
+
+		// 4. Community plugin rules (isolated per plugin rule)
+		this.runPluginRules(state, bugs);
 
 		return bugs;
 	}

--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -149,6 +149,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+	return value === null || typeof value === "string" || (typeof value === "number" && Number.isFinite(value));
+}
+
+function unexpectedArgument(args: Record<string, unknown>, allowed: readonly string[]): string | null {
+	const extra = Object.keys(args).filter((key) => !allowed.includes(key));
+	return extra.length > 0 ? `Unexpected argument${extra.length === 1 ? "" : "s"}: ${extra.join(", ")}.` : null;
+}
+
 function textResult(value: unknown): ToolCallResult {
 	const serialized = JSON.stringify(value, null, 2);
 	const text = typeof value === "string" ? value : (serialized ?? String(value));
@@ -188,7 +197,10 @@ export class TaloxMcpSession {
 	async handle(input: unknown): Promise<JsonRpcResponse | null> {
 		if (!isRecord(input)) return rpcError(null, -32600, "Invalid Request");
 
-		const id = Object.hasOwn(input, "id") ? (input["id"] as JsonRpcId) : undefined;
+		const hasId = Object.hasOwn(input, "id");
+		const rawId = hasId ? input["id"] : undefined;
+		if (hasId && !isJsonRpcId(rawId)) return rpcError(null, -32600, "Invalid Request");
+		const id = rawId as JsonRpcId | undefined;
 		const method = input["method"];
 		if (input["jsonrpc"] !== "2.0" || typeof method !== "string") {
 			return rpcError(id ?? null, -32600, "Invalid Request");
@@ -222,6 +234,13 @@ export class TaloxMcpSession {
 			case "tools/list":
 				return rpcResult(request.id, this.completeResult(this.handleToolsList(request.params), request.params));
 			case "tools/call":
+				if (!isRecord(request.params) || typeof request.params["name"] !== "string") {
+					return rpcError(request.id, -32602, "Invalid tools/call parameters: missing tool name.");
+				}
+				const toolName = request.params["name"];
+				if (!TALOX_MCP_TOOLS.some((tool) => tool.name === toolName)) {
+					return rpcError(request.id, -32602, `Unknown Talox tool: ${toolName}`);
+				}
 				return rpcResult(request.id, this.completeResult(await this.handleToolCall(request.params), request.params));
 			default:
 				return rpcError(request.id, -32601, `Method not found: ${request.method}`);
@@ -339,6 +358,8 @@ export class TaloxMcpSession {
 	}
 
 	private async launch(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["profileId", "profileClass", "browser"]);
+		if (extra) return toolError(extra);
 		if (this.controller) return toolError("A Talox MCP browser session is already active. Stop it before relaunching.");
 
 		const profileId = args["profileId"] ?? "mcp";
@@ -364,6 +385,8 @@ export class TaloxMcpSession {
 	}
 
 	private async navigate(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["url"]);
+		if (extra) return toolError(extra);
 		const controller = this.requireController();
 		const url = args["url"];
 		if (typeof url !== "string" || url.length === 0) return toolError("url must be a non-empty string.");
@@ -371,6 +394,8 @@ export class TaloxMcpSession {
 	}
 
 	private async click(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["selector"]);
+		if (extra) return toolError(extra);
 		const controller = this.requireController();
 		const selector = args["selector"];
 		if (typeof selector !== "string" || selector.length === 0) return toolError("selector must be a non-empty string.");
@@ -378,6 +403,8 @@ export class TaloxMcpSession {
 	}
 
 	private async type(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["selector", "text"]);
+		if (extra) return toolError(extra);
 		const controller = this.requireController();
 		const selector = args["selector"];
 		const text = args["text"];
@@ -387,6 +414,8 @@ export class TaloxMcpSession {
 	}
 
 	private async state(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["variant"]);
+		if (extra) return toolError(extra);
 		const variant = args["variant"] ?? "agent";
 		if (variant !== "agent" && variant !== "debug" && variant !== "full") {
 			return toolError("variant must be one of: agent, debug, full.");
@@ -395,6 +424,8 @@ export class TaloxMcpSession {
 	}
 
 	private async screenshot(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const extra = unexpectedArgument(args, ["selector"]);
+		if (extra) return toolError(extra);
 		const controller = this.requireController();
 		const selector = args["selector"];
 		if (selector !== undefined && (typeof selector !== "string" || selector.length === 0)) {

--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -207,7 +207,7 @@ export class TaloxMcpSession {
 			case "ping":
 				return rpcResult(request.id, this.completeResult({}, request.params));
 			case "tools/list":
-				return rpcResult(request.id, this.handleToolsList(request.params));
+				return rpcResult(request.id, this.completeResult(this.handleToolsList(request.params), request.params));
 			case "tools/call":
 				return rpcResult(request.id, this.completeResult(await this.handleToolCall(request.params), request.params));
 			default:
@@ -233,16 +233,19 @@ export class TaloxMcpSession {
 
 	private handleDiscover(id: JsonRpcId): JsonRpcResponse {
 		this.era = "modern";
-		return rpcResult(id, {
-			resultType: "complete",
-			supportedVersions: [MODERN_PROTOCOL_VERSION],
-			capabilities: { tools: { listChanged: false } },
-			serverInfo: SERVER_INFO,
-			instructions: SERVER_INSTRUCTIONS,
-			ttlMs: 60_000,
-			cacheScope: "public",
-			_meta: { "io.modelcontextprotocol/serverInfo": SERVER_INFO },
-		});
+		return rpcResult(
+			id,
+			this.completeResult(
+				{
+					supportedVersions: [MODERN_PROTOCOL_VERSION],
+					capabilities: { tools: { listChanged: false } },
+					instructions: SERVER_INSTRUCTIONS,
+					ttlMs: 60_000,
+					cacheScope: "public",
+				},
+				undefined,
+			),
+		);
 	}
 
 	private handleInitialize(id: JsonRpcId, params: unknown): JsonRpcResponse {
@@ -271,8 +274,17 @@ export class TaloxMcpSession {
 	}
 
 	private completeResult(result: object, params: unknown): object {
-		if (!this.isModern(params) || Object.hasOwn(result, "resultType")) return result;
-		return { ...result, resultType: "complete" };
+		if (!this.isModern(params)) return result;
+		const record = result as Record<string, unknown>;
+		const existingMeta = isRecord(record["_meta"]) ? record["_meta"] : {};
+		return {
+			...result,
+			resultType: record["resultType"] ?? "complete",
+			_meta: {
+				...existingMeta,
+				"io.modelcontextprotocol/serverInfo": existingMeta["io.modelcontextprotocol/serverInfo"] ?? SERVER_INFO,
+			},
+		};
 	}
 
 	private isModern(params: unknown): boolean {

--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -38,7 +38,7 @@ interface McpController {
 	navigate(url: string): Promise<{ url: string; title?: string }>;
 	click(selector: string): Promise<{ url: string; title?: string }>;
 	type(selector: string, text: string): Promise<{ url: string; title?: string }>;
-	getState(): Promise<unknown>;
+	getState(variant?: "full" | "agent" | "debug"): Promise<unknown>;
 	screenshot(options?: { selector?: string; path?: string }): Promise<Buffer | string>;
 }
 
@@ -112,8 +112,18 @@ export const TALOX_MCP_TOOLS = [
 	},
 	{
 		name: "talox_state",
-		description: "Return Talox's current structured page state for the active session.",
-		inputSchema: { type: "object", properties: {}, additionalProperties: false },
+		description: "Return Talox's structured page state. Defaults to compact agent state to minimize context usage.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				variant: {
+					type: "string",
+					enum: ["agent", "debug", "full"],
+					description: "State detail level. Defaults to agent.",
+				},
+			},
+			additionalProperties: false,
+		},
 	},
 	{
 		name: "talox_screenshot",
@@ -205,7 +215,10 @@ export class TaloxMcpSession {
 			case "initialize":
 				return this.handleInitialize(request.id, request.params);
 			case "ping":
-				return rpcResult(request.id, this.completeResult({}, request.params));
+				if (this.isModern(request.params)) {
+					return rpcError(request.id, -32601, "Method not supported by MCP 2026-07-28: ping");
+				}
+				return rpcResult(request.id, {});
 			case "tools/list":
 				return rpcResult(request.id, this.completeResult(this.handleToolsList(request.params), request.params));
 			case "tools/call":
@@ -312,7 +325,7 @@ export class TaloxMcpSession {
 				case "talox_type":
 					return await this.type(input);
 				case "talox_state":
-					return await this.state();
+					return await this.state(input);
 				case "talox_screenshot":
 					return await this.screenshot(input);
 				case "talox_stop":
@@ -373,8 +386,12 @@ export class TaloxMcpSession {
 		return textResult(await controller.type(selector, text));
 	}
 
-	private async state(): Promise<ToolCallResult> {
-		return textResult(await this.requireController().getState());
+	private async state(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const variant = args["variant"] ?? "agent";
+		if (variant !== "agent" && variant !== "debug" && variant !== "full") {
+			return toolError("variant must be one of: agent, debug, full.");
+		}
+		return textResult(await this.requireController().getState(variant));
 	}
 
 	private async screenshot(args: Record<string, unknown>): Promise<ToolCallResult> {

--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -1,0 +1,442 @@
+/**
+ * MCP stdio bridge for Talox.
+ *
+ * This intentionally has no dependency on the MCP SDK so Talox keeps its
+ * dependency graph stable. It supports both the handshake-era protocol used by
+ * 2025 clients and the stateless 2026-07-28 discovery flow over stdio.
+ */
+
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+import type { ProfileClass } from "../../types/index.js";
+import type { BrowserType } from "../BrowserManager.js";
+import { TaloxController } from "../controller/TaloxController.js";
+
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+const LEGACY_PROTOCOL_VERSION = "2025-11-25";
+const LEGACY_PROTOCOL_VERSIONS = new Set(["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]);
+const SERVER_INFO = { name: "talox", version: "8.1.0" } as const;
+const SERVER_INSTRUCTIONS =
+	"Use Talox tools to launch and control one persistent browser session. Launch before navigation or interaction, then stop when finished.";
+
+export type JsonRpcId = string | number | null;
+
+type JsonRpcResponse =
+	| { jsonrpc: "2.0"; id: JsonRpcId; result: unknown }
+	| { jsonrpc: "2.0"; id: JsonRpcId; error: { code: number; message: string; data?: unknown } };
+
+interface JsonRpcRequest {
+	jsonrpc: "2.0";
+	id?: JsonRpcId;
+	method: string;
+	params?: unknown;
+}
+
+interface McpController {
+	launch(profileId: string, profileClass: ProfileClass, browserType?: BrowserType): Promise<void>;
+	stop(): Promise<void>;
+	navigate(url: string): Promise<{ url: string; title?: string }>;
+	click(selector: string): Promise<{ url: string; title?: string }>;
+	type(selector: string, text: string): Promise<{ url: string; title?: string }>;
+	getState(): Promise<unknown>;
+	screenshot(options?: { selector?: string; path?: string }): Promise<Buffer | string>;
+}
+
+export type McpControllerFactory = () => McpController;
+
+type ProtocolEra = "unknown" | "legacy" | "modern";
+
+type ToolContent =
+	| { type: "text"; text: string }
+	| { type: "image"; data: string; mimeType: string };
+
+interface ToolCallResult {
+	content: ToolContent[];
+	isError?: boolean;
+}
+
+export const TALOX_MCP_TOOLS = [
+	{
+		name: "talox_launch",
+		description: "Launch a persistent Talox browser session.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				profileId: { type: "string", description: "Persistent profile ID. Defaults to mcp." },
+				profileClass: {
+					type: "string",
+					enum: ["ops", "qa", "sandbox"],
+					description: "Talox profile class. Defaults to ops.",
+				},
+				browser: {
+					type: "string",
+					enum: ["chromium", "firefox", "webkit"],
+					description: "Browser engine. Defaults to chromium.",
+				},
+			},
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "talox_navigate",
+		description: "Navigate the active Talox browser session to a URL.",
+		inputSchema: {
+			type: "object",
+			properties: { url: { type: "string", minLength: 1 } },
+			required: ["url"],
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "talox_click",
+		description: "Click an element in the active Talox browser session.",
+		inputSchema: {
+			type: "object",
+			properties: { selector: { type: "string", minLength: 1 } },
+			required: ["selector"],
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "talox_type",
+		description: "Type text into an element in the active Talox browser session.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				selector: { type: "string", minLength: 1 },
+				text: { type: "string" },
+			},
+			required: ["selector", "text"],
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "talox_state",
+		description: "Return Talox's current structured page state for the active session.",
+		inputSchema: { type: "object", properties: {}, additionalProperties: false },
+	},
+	{
+		name: "talox_screenshot",
+		description: "Capture a PNG screenshot of the full page or one selector.",
+		inputSchema: {
+			type: "object",
+			properties: { selector: { type: "string", minLength: 1 } },
+			additionalProperties: false,
+		},
+	},
+	{
+		name: "talox_stop",
+		description: "Stop the active Talox browser session and release its resources.",
+		inputSchema: { type: "object", properties: {}, additionalProperties: false },
+	},
+] as const;
+
+function defaultControllerFactory(): McpController {
+	return new TaloxController(process.cwd());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function textResult(value: unknown): ToolCallResult {
+	const serialized = JSON.stringify(value, null, 2);
+	const text = typeof value === "string" ? value : (serialized ?? String(value));
+	return { content: [{ type: "text", text }] };
+}
+
+function toolError(message: string): ToolCallResult {
+	return { content: [{ type: "text", text: message }], isError: true };
+}
+
+function rpcResult(id: JsonRpcId, result: unknown): JsonRpcResponse {
+	return { jsonrpc: "2.0", id, result };
+}
+
+function rpcError(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcResponse {
+	const error: { code: number; message: string; data?: unknown } = { code, message };
+	if (data !== undefined) error.data = data;
+	return { jsonrpc: "2.0", id, error };
+}
+
+function requestedModernProtocol(params: unknown): boolean {
+	if (!isRecord(params)) return false;
+	const meta = params["_meta"];
+	if (!isRecord(meta)) return false;
+	return meta["io.modelcontextprotocol/protocolVersion"] === MODERN_PROTOCOL_VERSION;
+}
+
+export class TaloxMcpSession {
+	private readonly controllerFactory: McpControllerFactory;
+	private controller: McpController | null = null;
+	private era: ProtocolEra = "unknown";
+
+	constructor(controllerFactory: McpControllerFactory = defaultControllerFactory) {
+		this.controllerFactory = controllerFactory;
+	}
+
+	async handle(input: unknown): Promise<JsonRpcResponse | null> {
+		if (!isRecord(input)) return rpcError(null, -32600, "Invalid Request");
+
+		const id = Object.hasOwn(input, "id") ? (input["id"] as JsonRpcId) : undefined;
+		const method = input["method"];
+		if (input["jsonrpc"] !== "2.0" || typeof method !== "string") {
+			return rpcError(id ?? null, -32600, "Invalid Request");
+		}
+
+		const request: JsonRpcRequest = {
+			jsonrpc: "2.0",
+			method,
+		};
+		if (id !== undefined) request.id = id;
+		if (Object.hasOwn(input, "params")) request.params = input["params"];
+
+		if (request.id === undefined) {
+			return this.handleNotification(request);
+		}
+
+		if (requestedModernProtocol(request.params) && this.era === "unknown") {
+			this.era = "modern";
+		}
+
+		switch (request.method) {
+			case "server/discover":
+				return this.handleDiscover(request.id);
+			case "initialize":
+				return this.handleInitialize(request.id, request.params);
+			case "ping":
+				return rpcResult(request.id, this.completeResult({}, request.params));
+			case "tools/list":
+				return rpcResult(request.id, this.handleToolsList(request.params));
+			case "tools/call":
+				return rpcResult(request.id, this.completeResult(await this.handleToolCall(request.params), request.params));
+			default:
+				return rpcError(request.id, -32601, `Method not found: ${request.method}`);
+		}
+	}
+
+	async close(): Promise<void> {
+		if (!this.controller) return;
+		const controller = this.controller;
+		this.controller = null;
+		await controller.stop();
+	}
+
+	private handleNotification(request: JsonRpcRequest): null {
+		// MCP lifecycle/cancellation notifications require no response. Unknown
+		// notifications are also ignored per JSON-RPC notification semantics.
+		if (request.method === "notifications/initialized" && this.era === "unknown") {
+			this.era = "legacy";
+		}
+		return null;
+	}
+
+	private handleDiscover(id: JsonRpcId): JsonRpcResponse {
+		this.era = "modern";
+		return rpcResult(id, {
+			resultType: "complete",
+			supportedVersions: [MODERN_PROTOCOL_VERSION],
+			capabilities: { tools: { listChanged: false } },
+			serverInfo: SERVER_INFO,
+			instructions: SERVER_INSTRUCTIONS,
+			ttlMs: 60_000,
+			cacheScope: "public",
+			_meta: { "io.modelcontextprotocol/serverInfo": SERVER_INFO },
+		});
+	}
+
+	private handleInitialize(id: JsonRpcId, params: unknown): JsonRpcResponse {
+		this.era = "legacy";
+		const requested = isRecord(params) ? params["protocolVersion"] : undefined;
+		const protocolVersion =
+			typeof requested === "string" && LEGACY_PROTOCOL_VERSIONS.has(requested)
+				? requested
+				: LEGACY_PROTOCOL_VERSION;
+		return rpcResult(id, {
+			protocolVersion,
+			capabilities: { tools: { listChanged: false } },
+			serverInfo: SERVER_INFO,
+			instructions: SERVER_INSTRUCTIONS,
+		});
+	}
+
+	private handleToolsList(params: unknown): Record<string, unknown> {
+		const result: Record<string, unknown> = { tools: TALOX_MCP_TOOLS };
+		if (this.isModern(params)) {
+			result["resultType"] = "complete";
+			result["ttlMs"] = 60_000;
+			result["cacheScope"] = "public";
+		}
+		return result;
+	}
+
+	private completeResult(result: object, params: unknown): object {
+		if (!this.isModern(params) || Object.hasOwn(result, "resultType")) return result;
+		return { ...result, resultType: "complete" };
+	}
+
+	private isModern(params: unknown): boolean {
+		return this.era === "modern" || requestedModernProtocol(params);
+	}
+
+	private async handleToolCall(params: unknown): Promise<ToolCallResult> {
+		if (!isRecord(params) || typeof params["name"] !== "string") {
+			return toolError("Invalid tools/call parameters: missing tool name.");
+		}
+		const args = params["arguments"];
+		if (args !== undefined && !isRecord(args)) {
+			return toolError("Invalid tools/call parameters: arguments must be an object.");
+		}
+		const input = isRecord(args) ? args : {};
+
+		try {
+			switch (params["name"]) {
+				case "talox_launch":
+					return await this.launch(input);
+				case "talox_navigate":
+					return await this.navigate(input);
+				case "talox_click":
+					return await this.click(input);
+				case "talox_type":
+					return await this.type(input);
+				case "talox_state":
+					return await this.state();
+				case "talox_screenshot":
+					return await this.screenshot(input);
+				case "talox_stop":
+					return await this.stop();
+				default:
+					return toolError(`Unknown Talox tool: ${params["name"]}`);
+			}
+		} catch (error: unknown) {
+			return toolError(error instanceof Error ? error.message : String(error));
+		}
+	}
+
+	private async launch(args: Record<string, unknown>): Promise<ToolCallResult> {
+		if (this.controller) return toolError("A Talox MCP browser session is already active. Stop it before relaunching.");
+
+		const profileId = args["profileId"] ?? "mcp";
+		const profileClass = args["profileClass"] ?? "ops";
+		const browser = args["browser"] ?? "chromium";
+		if (typeof profileId !== "string" || profileId.length === 0) return toolError("profileId must be a non-empty string.");
+		if (profileClass !== "ops" && profileClass !== "qa" && profileClass !== "sandbox") {
+			return toolError("profileClass must be one of: ops, qa, sandbox.");
+		}
+		if (browser !== "chromium" && browser !== "firefox" && browser !== "webkit") {
+			return toolError("browser must be one of: chromium, firefox, webkit.");
+		}
+
+		const controller = this.controllerFactory();
+		try {
+			await controller.launch(profileId, profileClass, browser);
+			this.controller = controller;
+			return textResult({ launched: true, profileId, profileClass, browser });
+		} catch (error: unknown) {
+			await controller.stop().catch(() => undefined);
+			throw error;
+		}
+	}
+
+	private async navigate(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const controller = this.requireController();
+		const url = args["url"];
+		if (typeof url !== "string" || url.length === 0) return toolError("url must be a non-empty string.");
+		return textResult(await controller.navigate(url));
+	}
+
+	private async click(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const controller = this.requireController();
+		const selector = args["selector"];
+		if (typeof selector !== "string" || selector.length === 0) return toolError("selector must be a non-empty string.");
+		return textResult(await controller.click(selector));
+	}
+
+	private async type(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const controller = this.requireController();
+		const selector = args["selector"];
+		const text = args["text"];
+		if (typeof selector !== "string" || selector.length === 0) return toolError("selector must be a non-empty string.");
+		if (typeof text !== "string") return toolError("text must be a string.");
+		return textResult(await controller.type(selector, text));
+	}
+
+	private async state(): Promise<ToolCallResult> {
+		return textResult(await this.requireController().getState());
+	}
+
+	private async screenshot(args: Record<string, unknown>): Promise<ToolCallResult> {
+		const controller = this.requireController();
+		const selector = args["selector"];
+		if (selector !== undefined && (typeof selector !== "string" || selector.length === 0)) {
+			return toolError("selector must be a non-empty string when provided.");
+		}
+		const result = await controller.screenshot(typeof selector === "string" ? { selector } : undefined);
+		if (Buffer.isBuffer(result)) {
+			return { content: [{ type: "image", data: result.toString("base64"), mimeType: "image/png" }] };
+		}
+		return textResult({ path: result });
+	}
+
+	private async stop(): Promise<ToolCallResult> {
+		if (!this.controller) return textResult({ stopped: false, reason: "no active session" });
+		const controller = this.controller;
+		this.controller = null;
+		await controller.stop();
+		return textResult({ stopped: true });
+	}
+
+	private requireController(): McpController {
+		if (!this.controller) throw new Error("No active Talox MCP browser session. Call talox_launch first.");
+		return this.controller;
+	}
+}
+
+export class TaloxMcpStdioServer {
+	private readonly session: TaloxMcpSession;
+	private readonly input: Readable;
+	private readonly output: Writable;
+
+	constructor(
+		session: TaloxMcpSession = new TaloxMcpSession(),
+		input: Readable = process.stdin,
+		output: Writable = process.stdout,
+	) {
+		this.session = session;
+		this.input = input;
+		this.output = output;
+	}
+
+	async run(): Promise<void> {
+		const lines = createInterface({ input: this.input, crlfDelay: Number.POSITIVE_INFINITY });
+		try {
+			for await (const line of lines) {
+				const trimmed = line.trim();
+				if (trimmed.length === 0) continue;
+				await this.processLine(trimmed);
+			}
+		} finally {
+			await this.session.close();
+		}
+	}
+
+	async close(): Promise<void> {
+		await this.session.close();
+	}
+
+	private async processLine(line: string): Promise<void> {
+		let payload: unknown;
+		try {
+			payload = JSON.parse(line);
+		} catch {
+			this.write(rpcError(null, -32700, "Parse error"));
+			return;
+		}
+		const response = await this.session.handle(payload);
+		if (response) this.write(response);
+	}
+
+	private write(response: JsonRpcResponse): void {
+		this.output.write(`${JSON.stringify(response)}\n`);
+	}
+}

--- a/src/core/plugins/PluginRegistry.ts
+++ b/src/core/plugins/PluginRegistry.ts
@@ -1,0 +1,244 @@
+import { createLogger } from "../Logger.js";
+import type { TaloxBug, TaloxPageState } from "../../types/index.js";
+
+const logger = createLogger("Plugins");
+const IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+/** Context supplied to opt-in plugin vision detectors. */
+export interface TaloxVisionContext {
+	url?: string;
+	title?: string;
+	metadata?: Readonly<Record<string, unknown>>;
+}
+
+/** A structured finding returned by a plugin vision detector. */
+export interface TaloxVisualDetection {
+	type: string;
+	description: string;
+	confidence?: number;
+	evidence?: Readonly<Record<string, unknown>>;
+}
+
+/** A synchronous rule that participates in the normal RulesEngine QA pass. */
+export interface TaloxRule {
+	id: string;
+	analyze(state: Readonly<TaloxPageState>): readonly TaloxBug[] | null | undefined;
+}
+
+/** An opt-in visual detector. It is never run implicitly by getState(). */
+export interface TaloxVisionDetector {
+	id: string;
+	detect(
+		screenshot: Readonly<Buffer>,
+		context: Readonly<TaloxVisionContext>,
+	): Promise<readonly TaloxVisualDetection[]> | readonly TaloxVisualDetection[];
+}
+
+/** Community extension package registered with Talox. */
+export interface TaloxPlugin {
+	name: string;
+	version: string;
+	rules?: readonly TaloxRule[];
+	visionDetectors?: readonly TaloxVisionDetector[];
+}
+
+/** Stable public metadata for an installed process-wide plugin. */
+export interface TaloxPluginInfo {
+	name: string;
+	version: string;
+	ruleIds: readonly string[];
+	visionDetectorIds: readonly string[];
+}
+
+/** Result for one detector invocation. Plugin failures are isolated here. */
+export interface TaloxVisionDetectorResult {
+	pluginName: string;
+	pluginVersion: string;
+	detectorId: string;
+	detections: readonly TaloxVisualDetection[];
+	error?: string;
+}
+
+/** Internal rule registration consumed by RulesEngine. */
+export interface RegisteredTaloxRule {
+	pluginName: string;
+	pluginVersion: string;
+	rule: TaloxRule;
+}
+
+interface RegisteredPlugin {
+	name: string;
+	version: string;
+	rules: TaloxRule[];
+	visionDetectors: TaloxVisionDetector[];
+}
+
+const plugins = new Map<string, RegisteredPlugin>();
+
+function requireText(value: unknown, label: string): string {
+	if (typeof value !== "string" || value.trim().length === 0) {
+		throw new TypeError(`${label} must be a non-empty string.`);
+	}
+	return value.trim();
+}
+
+function requireIdentifier(value: unknown, label: string): string {
+	const identifier = requireText(value, label);
+	if (!IDENTIFIER_PATTERN.test(identifier)) {
+		throw new TypeError(
+			`${label} must start with an alphanumeric character and contain only letters, numbers, '.', '_', ':', '/', or '-'.`,
+		);
+	}
+	return identifier;
+}
+
+function assertCallable(value: unknown, label: string): asserts value is (...args: never[]) => unknown {
+	if (typeof value !== "function") throw new TypeError(`${label} must be a function.`);
+}
+
+function validateRuleIds(rules: readonly TaloxRule[], occupied: Set<string>): TaloxRule[] {
+	const local = new Set<string>();
+	return rules.map((rule, index) => {
+		if (!rule || typeof rule !== "object") throw new TypeError(`rules[${index}] must be an object.`);
+		const id = requireIdentifier(rule.id, `rules[${index}].id`);
+		assertCallable(rule.analyze, `rules[${index}].analyze`);
+		if (local.has(id)) throw new Error(`Duplicate rule id '${id}' in plugin.`);
+		if (occupied.has(id)) throw new Error(`Rule id '${id}' is already registered by another plugin.`);
+		local.add(id);
+		return { id, analyze: rule.analyze };
+	});
+}
+
+function validateDetectorIds(detectors: readonly TaloxVisionDetector[], occupied: Set<string>): TaloxVisionDetector[] {
+	const local = new Set<string>();
+	return detectors.map((detector, index) => {
+		if (!detector || typeof detector !== "object") throw new TypeError(`visionDetectors[${index}] must be an object.`);
+		const id = requireIdentifier(detector.id, `visionDetectors[${index}].id`);
+		assertCallable(detector.detect, `visionDetectors[${index}].detect`);
+		if (local.has(id)) throw new Error(`Duplicate vision detector id '${id}' in plugin.`);
+		if (occupied.has(id)) throw new Error(`Vision detector id '${id}' is already registered by another plugin.`);
+		local.add(id);
+		return { id, detect: detector.detect };
+	});
+}
+
+function getOccupiedRuleIds(): Set<string> {
+	return new Set([...plugins.values()].flatMap((plugin) => plugin.rules.map((rule) => rule.id)));
+}
+
+function getOccupiedDetectorIds(): Set<string> {
+	return new Set([...plugins.values()].flatMap((plugin) => plugin.visionDetectors.map((detector) => detector.id)));
+}
+
+function isVisualDetection(value: unknown): value is TaloxVisualDetection {
+	if (!value || typeof value !== "object") return false;
+	const candidate = value as Record<string, unknown>;
+	if (typeof candidate.type !== "string" || candidate.type.trim().length === 0) return false;
+	if (typeof candidate.description !== "string" || candidate.description.trim().length === 0) return false;
+	if (
+		candidate.confidence !== undefined &&
+		(typeof candidate.confidence !== "number" || !Number.isFinite(candidate.confidence) || candidate.confidence < 0 || candidate.confidence > 1)
+	) {
+		return false;
+	}
+	return candidate.evidence === undefined || (candidate.evidence !== null && typeof candidate.evidence === "object");
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Register a plugin for the current Node.js process.
+ *
+ * Registration is transactional: duplicate names/IDs or invalid hooks reject
+ * the whole plugin without changing the registry.
+ */
+export function registerTaloxPlugin(plugin: TaloxPlugin): TaloxPluginInfo {
+	if (!plugin || typeof plugin !== "object") throw new TypeError("plugin must be an object.");
+
+	const name = requireText(plugin.name, "plugin.name");
+	const version = requireText(plugin.version, "plugin.version");
+	if (plugins.has(name)) throw new Error(`Talox plugin '${name}' is already registered.`);
+
+	const rules = validateRuleIds(plugin.rules ?? [], getOccupiedRuleIds());
+	const visionDetectors = validateDetectorIds(plugin.visionDetectors ?? [], getOccupiedDetectorIds());
+	const registered: RegisteredPlugin = { name, version, rules, visionDetectors };
+	plugins.set(name, registered);
+	logger.debug(`Registered ${name}@${version} (${rules.length} rules, ${visionDetectors.length} vision detectors).`);
+	return toPluginInfo(registered);
+}
+
+/** Remove one process-wide plugin. Returns true when it existed. */
+export function unregisterTaloxPlugin(name: string): boolean {
+	return plugins.delete(name);
+}
+
+/** Clear all process-wide plugins. Primarily useful for tests and isolated hosts. */
+export function clearTaloxPlugins(): void {
+	plugins.clear();
+}
+
+/** List registered plugins in deterministic registration order. */
+export function listTaloxPlugins(): TaloxPluginInfo[] {
+	return [...plugins.values()].map(toPluginInfo);
+}
+
+function toPluginInfo(plugin: RegisteredPlugin): TaloxPluginInfo {
+	return {
+		name: plugin.name,
+		version: plugin.version,
+		ruleIds: plugin.rules.map((rule) => rule.id),
+		visionDetectorIds: plugin.visionDetectors.map((detector) => detector.id),
+	};
+}
+
+/** Return registered community rules in deterministic plugin/rule order. */
+export function getTaloxPluginRules(): RegisteredTaloxRule[] {
+	return [...plugins.values()].flatMap((plugin) =>
+		plugin.rules.map((rule) => ({ pluginName: plugin.name, pluginVersion: plugin.version, rule })),
+	);
+}
+
+/**
+ * Run every registered visual detector explicitly against a screenshot.
+ *
+ * Each detector receives its own Buffer copy so an unsafe community detector
+ * cannot mutate the bytes observed by later detectors. A detector exception or
+ * malformed result becomes an error result and never aborts the remaining run.
+ */
+export async function runTaloxVisionDetectors(
+	screenshot: Buffer,
+	context: TaloxVisionContext = {},
+): Promise<TaloxVisionDetectorResult[]> {
+	if (!Buffer.isBuffer(screenshot)) throw new TypeError("screenshot must be a Buffer.");
+
+	const results: TaloxVisionDetectorResult[] = [];
+	for (const plugin of plugins.values()) {
+		for (const detector of plugin.visionDetectors) {
+			try {
+				const raw = await detector.detect(Buffer.from(screenshot), { ...context });
+				if (!Array.isArray(raw) || !raw.every(isVisualDetection)) {
+					throw new TypeError(`Vision detector '${detector.id}' returned an invalid detection list.`);
+				}
+				results.push({
+					pluginName: plugin.name,
+					pluginVersion: plugin.version,
+					detectorId: detector.id,
+					detections: [...raw],
+				});
+			} catch (error) {
+				const message = errorMessage(error);
+				logger.warn(`Vision detector ${plugin.name}/${detector.id} failed: ${message}`);
+				results.push({
+					pluginName: plugin.name,
+					pluginVersion: plugin.version,
+					detectorId: detector.id,
+					detections: [],
+					error: message,
+				});
+			}
+		}
+	}
+	return results;
+}

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,0 +1,18 @@
+export {
+	clearTaloxPlugins,
+	getTaloxPluginRules,
+	listTaloxPlugins,
+	registerTaloxPlugin,
+	runTaloxVisionDetectors,
+	unregisterTaloxPlugin,
+} from "./core/plugins/PluginRegistry.js";
+export type {
+	RegisteredTaloxRule,
+	TaloxPlugin,
+	TaloxPluginInfo,
+	TaloxRule,
+	TaloxVisualDetection,
+	TaloxVisionContext,
+	TaloxVisionDetector,
+	TaloxVisionDetectorResult,
+} from "./core/plugins/PluginRegistry.js";

--- a/tests/unit/McpCli.test.ts
+++ b/tests/unit/McpCli.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseMcpCommand } from "../../src/cli/mcp.js";
+
+describe("shouldUseMcpCommand", () => {
+	it("routes the mcp command through the dedicated stdio entrypoint", () => {
+		expect(shouldUseMcpCommand(["mcp"])).toBe(true);
+		expect(shouldUseMcpCommand(["mcp", "--help"])).toBe(true);
+	});
+
+	it("does not intercept existing Talox commands", () => {
+		expect(shouldUseMcpCommand(["run", "Inspect the page"])).toBe(false);
+		expect(shouldUseMcpCommand(["daemon"])).toBe(false);
+	});
+});

--- a/tests/unit/PluginRegistry.test.ts
+++ b/tests/unit/PluginRegistry.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RulesEngine } from "../../src/core/RulesEngine";
+import {
+	clearTaloxPlugins,
+	listTaloxPlugins,
+	registerTaloxPlugin,
+	runTaloxVisionDetectors,
+	unregisterTaloxPlugin,
+} from "../../src/plugins";
+import type { TaloxPageState } from "../../src/types/index";
+
+function makeState(overrides: Partial<TaloxPageState> = {}): TaloxPageState {
+	return {
+		url: "https://example.com",
+		title: "Plugin Test",
+		timestamp: new Date().toISOString(),
+		console: { errors: [], warnings: [], logs: [] },
+		network: { failedRequests: [] },
+		nodes: [],
+		interactiveElements: [],
+		bugs: [],
+		...overrides,
+	};
+}
+
+beforeEach(() => clearTaloxPlugins());
+afterEach(() => clearTaloxPlugins());
+
+describe("Talox plugin registry", () => {
+	it("registers, lists, and unregisters plugins in registration order", () => {
+		registerTaloxPlugin({
+			name: "community-a",
+			version: "1.0.0",
+			rules: [{ id: "missing-alt", analyze: () => [] }],
+		});
+		registerTaloxPlugin({
+			name: "community-b",
+			version: "2.1.0",
+			visionDetectors: [{ id: "banner-detector", detect: () => [] }],
+		});
+
+		expect(listTaloxPlugins()).toEqual([
+			{
+				name: "community-a",
+				version: "1.0.0",
+				ruleIds: ["missing-alt"],
+				visionDetectorIds: [],
+			},
+			{
+				name: "community-b",
+				version: "2.1.0",
+				ruleIds: [],
+				visionDetectorIds: ["banner-detector"],
+			},
+		]);
+		expect(unregisterTaloxPlugin("community-a")).toBe(true);
+		expect(unregisterTaloxPlugin("community-a")).toBe(false);
+		expect(listTaloxPlugins().map((plugin) => plugin.name)).toEqual(["community-b"]);
+	});
+
+	it("rejects duplicate plugin names without replacing the original", () => {
+		registerTaloxPlugin({ name: "same-name", version: "1.0.0" });
+		expect(() => registerTaloxPlugin({ name: "same-name", version: "2.0.0" })).toThrow("already registered");
+		expect(listTaloxPlugins()).toHaveLength(1);
+		expect(listTaloxPlugins()[0].version).toBe("1.0.0");
+	});
+
+	it("rejects duplicate hook ids transactionally", () => {
+		registerTaloxPlugin({
+			name: "first",
+			version: "1.0.0",
+			rules: [{ id: "shared-rule", analyze: () => [] }],
+			visionDetectors: [{ id: "shared-detector", detect: () => [] }],
+		});
+
+		expect(() =>
+			registerTaloxPlugin({
+				name: "second",
+				version: "1.0.0",
+				rules: [{ id: "unique-rule", analyze: () => [] }],
+				visionDetectors: [{ id: "shared-detector", detect: () => [] }],
+			}),
+		).toThrow("already registered by another plugin");
+
+		expect(listTaloxPlugins().map((plugin) => plugin.name)).toEqual(["first"]);
+	});
+
+	it("validates plugin and hook identifiers", () => {
+		expect(() => registerTaloxPlugin({ name: "", version: "1.0.0" })).toThrow("non-empty string");
+		expect(() =>
+			registerTaloxPlugin({
+				name: "bad-rule",
+				version: "1.0.0",
+				rules: [{ id: "has spaces", analyze: () => [] }],
+			}),
+		).toThrow("must start with an alphanumeric character");
+	});
+});
+
+describe("community rules", () => {
+	it("adds plugin findings to the normal RulesEngine pass with collision-safe ids", () => {
+		registerTaloxPlugin({
+			name: "a11y-pack",
+			version: "3.2.1",
+			rules: [
+				{
+					id: "button-label",
+					analyze: (state) =>
+						state.title === "Plugin Test"
+							? [
+								{
+									id: "submit",
+									type: "MISSING_ACCESSIBLE_LABEL",
+									severity: "MAJOR",
+									description: "Submit button has no accessible label.",
+									evidence: { selector: "#submit" },
+								},
+							]
+							: [],
+				},
+			],
+		});
+
+		const bugs = new RulesEngine().analyze(makeState());
+		expect(bugs).toHaveLength(1);
+		expect(bugs[0].id).toBe("plugin:a11y-pack:button-label:submit");
+		expect(bugs[0].type).toBe("MISSING_ACCESSIBLE_LABEL");
+		expect(bugs[0].metadata?.taloxPlugin).toEqual({ name: "a11y-pack", version: "3.2.1", ruleId: "button-label" });
+	});
+
+	it("isolates throwing and malformed plugin rules without suppressing built-in bugs", () => {
+		registerTaloxPlugin({
+			name: "broken-pack",
+			version: "1.0.0",
+			rules: [
+				{ id: "throws", analyze: () => {
+					throw new Error("plugin exploded");
+				} },
+			],
+		});
+		registerTaloxPlugin({
+			name: "malformed-pack",
+			version: "1.0.0",
+			rules: [{ id: "bad-bug", analyze: () => [{ nope: true } as never] }],
+		});
+
+		const bugs = new RulesEngine().analyze(makeState({ console: { errors: ["native failure"] } }));
+		expect(bugs.filter((bug) => bug.type === "JS_ERROR")).toHaveLength(1);
+		expect(bugs.some((bug) => bug.id.startsWith("plugin:"))).toBe(false);
+	});
+});
+
+describe("community vision detectors", () => {
+	it("runs detectors explicitly in deterministic order and isolates screenshot mutation", async () => {
+		registerTaloxPlugin({
+			name: "vision-a",
+			version: "1.0.0",
+			visionDetectors: [
+				{
+					id: "mutating-detector",
+					detect: (screenshot) => {
+						(screenshot as Buffer)[0] = 99;
+						return [{ type: "A", description: "first" }];
+					},
+				},
+			],
+		});
+		registerTaloxPlugin({
+			name: "vision-b",
+			version: "1.0.0",
+			visionDetectors: [
+				{
+					id: "reader",
+					detect: (screenshot, context) => [
+						{
+							type: "B",
+							description: `${screenshot[0]}:${context.url}`,
+							confidence: 0.9,
+						},
+					],
+				},
+			],
+		});
+
+		const source = Buffer.from([7, 8, 9]);
+		const results = await runTaloxVisionDetectors(source, { url: "https://example.com" });
+		expect(results.map((result) => `${result.pluginName}/${result.detectorId}`)).toEqual([
+			"vision-a/mutating-detector",
+			"vision-b/reader",
+		]);
+		expect(results[1].detections[0].description).toBe("7:https://example.com");
+		expect(source[0]).toBe(7);
+	});
+
+	it("returns per-detector errors and continues after failures", async () => {
+		registerTaloxPlugin({
+			name: "vision-errors",
+			version: "1.0.0",
+			visionDetectors: [
+				{
+					id: "throws",
+					detect: async () => {
+						throw new Error("model unavailable");
+					},
+				},
+				{ id: "survives", detect: () => [{ type: "CTA", description: "CTA obscured" }] },
+			],
+		});
+
+		const results = await runTaloxVisionDetectors(Buffer.from("png"));
+		expect(results).toHaveLength(2);
+		expect(results[0].error).toBe("model unavailable");
+		expect(results[0].detections).toEqual([]);
+		expect(results[1].detections[0].type).toBe("CTA");
+	});
+
+	it("converts malformed detector output into an isolated error result", async () => {
+		registerTaloxPlugin({
+			name: "malformed-vision",
+			version: "1.0.0",
+			visionDetectors: [{ id: "bad-output", detect: () => [{ type: "", description: "missing type" }] }],
+		});
+
+		const [result] = await runTaloxVisionDetectors(Buffer.from("png"));
+		expect(result.error).toContain("invalid detection list");
+		expect(result.detections).toEqual([]);
+	});
+});

--- a/tests/unit/TaloxMcpServer.test.ts
+++ b/tests/unit/TaloxMcpServer.test.ts
@@ -129,6 +129,28 @@ describe("TaloxMcpSession", () => {
 		expect(response).toMatchObject({ error: { code: -32601 } });
 	});
 
+	it("rejects unknown tools as protocol InvalidParams", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(toolCall(1, "talox_definitely_missing"));
+
+		expect(response).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			error: { code: -32602, message: expect.stringContaining("Unknown Talox tool") },
+		});
+	});
+
+	it("rejects invalid JSON-RPC ids", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle({ jsonrpc: "2.0", id: { nope: true }, method: "tools/list" });
+
+		expect(response).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32600, message: "Invalid Request" },
+		});
+	});
+
 	it("requires launch before browser-scoped tool calls", async () => {
 		const session = new TaloxMcpSession(() => new FakeController());
 		const response = await session.handle(toolCall(1, "talox_navigate", { url: "https://example.com" }));
@@ -149,6 +171,21 @@ describe("TaloxMcpSession", () => {
 
 		expect(fake.stateVariants).toEqual(["agent"]);
 		expect(response).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"variant": "agent"') }] } });
+	});
+
+	it("rejects extra tool arguments declared outside the schema", async () => {
+		const fake = new FakeController();
+		const session = new TaloxMcpSession(() => fake);
+		await session.handle(toolCall(1, "talox_launch"));
+		const response = await session.handle(toolCall(2, "talox_state", { surprise: true }));
+
+		expect(response).toMatchObject({
+			result: {
+				isError: true,
+				content: [{ type: "text", text: expect.stringContaining("Unexpected argument") }],
+			},
+		});
+		expect(fake.stateVariants).toEqual([]);
 	});
 
 	it("runs a persistent browser session across MCP tool calls", async () => {

--- a/tests/unit/TaloxMcpServer.test.ts
+++ b/tests/unit/TaloxMcpServer.test.ts
@@ -62,6 +62,7 @@ describe("TaloxMcpSession", () => {
 				capabilities: { tools: { listChanged: false } },
 				ttlMs: 60_000,
 				cacheScope: "public",
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
 			},
 		});
 	});
@@ -93,6 +94,23 @@ describe("TaloxMcpSession", () => {
 				resultType: "complete",
 				ttlMs: 60_000,
 				cacheScope: "public",
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
+			},
+		});
+	});
+
+	it("stamps modern results when the request carries the protocol envelope directly", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(
+			request(1, "ping", {
+				_meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+			}),
+		);
+
+		expect(response).toMatchObject({
+			result: {
+				resultType: "complete",
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
 			},
 		});
 	});

--- a/tests/unit/TaloxMcpServer.test.ts
+++ b/tests/unit/TaloxMcpServer.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { TaloxMcpSession, TALOX_MCP_TOOLS } from "../../src/core/mcp/TaloxMcpServer.js";
+
+class FakeController {
+	launchCalls: Array<[string, string, string | undefined]> = [];
+	stopCalls = 0;
+	navigateCalls: string[] = [];
+	clickCalls: string[] = [];
+	typeCalls: Array<[string, string]> = [];
+
+	async launch(profileId: string, profileClass: "ops" | "qa" | "sandbox", browser?: "chromium" | "firefox" | "webkit") {
+		this.launchCalls.push([profileId, profileClass, browser]);
+	}
+
+	async stop() {
+		this.stopCalls += 1;
+	}
+
+	async navigate(url: string) {
+		this.navigateCalls.push(url);
+		return { url, title: "Example" };
+	}
+
+	async click(selector: string) {
+		this.clickCalls.push(selector);
+		return { url: "https://example.com/clicked", title: "Clicked" };
+	}
+
+	async type(selector: string, text: string) {
+		this.typeCalls.push([selector, text]);
+		return { url: "https://example.com/form", title: "Form" };
+	}
+
+	async getState() {
+		return { url: "https://example.com", title: "Example", nodes: [] };
+	}
+
+	async screenshot() {
+		return Buffer.from("fake-png");
+	}
+}
+
+function request(id: number, method: string, params?: Record<string, unknown>) {
+	return { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+}
+
+function toolCall(id: number, name: string, args: Record<string, unknown> = {}) {
+	return request(id, "tools/call", { name, arguments: args });
+}
+
+describe("TaloxMcpSession", () => {
+	it("advertises the modern 2026-07-28 MCP era", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(request(1, "server/discover"));
+
+		expect(response).toMatchObject({
+			jsonrpc: "2.0",
+			id: 1,
+			result: {
+				resultType: "complete",
+				supportedVersions: ["2026-07-28"],
+				capabilities: { tools: { listChanged: false } },
+				ttlMs: 60_000,
+				cacheScope: "public",
+			},
+		});
+	});
+
+	it("keeps handshake-era compatibility for legacy MCP clients", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const initialized = await session.handle(
+			request(1, "initialize", {
+				protocolVersion: "2025-06-18",
+				capabilities: {},
+				clientInfo: { name: "test", version: "1" },
+			}),
+		);
+		const tools = await session.handle(request(2, "tools/list"));
+
+		expect(initialized).toMatchObject({ result: { protocolVersion: "2025-06-18" } });
+		expect(tools).toMatchObject({ result: { tools: TALOX_MCP_TOOLS } });
+		expect(JSON.stringify(tools)).not.toContain("ttlMs");
+	});
+
+	it("adds required cache hints to modern tools/list responses", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		await session.handle(request(1, "server/discover"));
+		const response = await session.handle(request(2, "tools/list"));
+
+		expect(response).toMatchObject({
+			result: {
+				tools: TALOX_MCP_TOOLS,
+				resultType: "complete",
+				ttlMs: 60_000,
+				cacheScope: "public",
+			},
+		});
+	});
+
+	it("requires launch before browser-scoped tool calls", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(toolCall(1, "talox_navigate", { url: "https://example.com" }));
+
+		expect(response).toMatchObject({
+			result: {
+				isError: true,
+				content: [{ type: "text", text: expect.stringContaining("talox_launch") }],
+			},
+		});
+	});
+
+	it("runs a persistent browser session across MCP tool calls", async () => {
+		const fake = new FakeController();
+		const session = new TaloxMcpSession(() => fake);
+
+		const launch = await session.handle(
+			toolCall(1, "talox_launch", { profileId: "agent-a", profileClass: "qa", browser: "chromium" }),
+		);
+		const navigate = await session.handle(toolCall(2, "talox_navigate", { url: "https://example.com" }));
+		const screenshot = await session.handle(toolCall(3, "talox_screenshot"));
+		const stop = await session.handle(toolCall(4, "talox_stop"));
+
+		expect(launch).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"launched": true') }] } });
+		expect(fake.launchCalls).toEqual([["agent-a", "qa", "chromium"]]);
+		expect(fake.navigateCalls).toEqual(["https://example.com"]);
+		expect(navigate).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining("Example") }] } });
+		expect(screenshot).toMatchObject({
+			result: { content: [{ type: "image", data: Buffer.from("fake-png").toString("base64"), mimeType: "image/png" }] },
+		});
+		expect(stop).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"stopped": true') }] } });
+		expect(fake.stopCalls).toBe(1);
+	});
+
+	it("returns JSON-RPC method errors instead of throwing", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(request(7, "made/up"));
+
+		expect(response).toEqual({
+			jsonrpc: "2.0",
+			id: 7,
+			error: { code: -32601, message: "Method not found: made/up" },
+		});
+	});
+});

--- a/tests/unit/TaloxMcpServer.test.ts
+++ b/tests/unit/TaloxMcpServer.test.ts
@@ -1,5 +1,6 @@
+import { Readable, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { TaloxMcpSession, TALOX_MCP_TOOLS } from "../../src/core/mcp/TaloxMcpServer.js";
+import { TaloxMcpSession, TaloxMcpStdioServer, TALOX_MCP_TOOLS } from "../../src/core/mcp/TaloxMcpServer.js";
 
 class FakeController {
 	launchCalls: Array<[string, string, string | undefined]> = [];
@@ -7,6 +8,7 @@ class FakeController {
 	navigateCalls: string[] = [];
 	clickCalls: string[] = [];
 	typeCalls: Array<[string, string]> = [];
+	stateVariants: Array<"full" | "agent" | "debug" | undefined> = [];
 
 	async launch(profileId: string, profileClass: "ops" | "qa" | "sandbox", browser?: "chromium" | "firefox" | "webkit") {
 		this.launchCalls.push([profileId, profileClass, browser]);
@@ -31,8 +33,9 @@ class FakeController {
 		return { url: "https://example.com/form", title: "Form" };
 	}
 
-	async getState() {
-		return { url: "https://example.com", title: "Example", nodes: [] };
+	async getState(variant?: "full" | "agent" | "debug") {
+		this.stateVariants.push(variant);
+		return { url: "https://example.com", title: "Example", nodes: [], variant };
 	}
 
 	async screenshot() {
@@ -102,7 +105,7 @@ describe("TaloxMcpSession", () => {
 	it("stamps modern results when the request carries the protocol envelope directly", async () => {
 		const session = new TaloxMcpSession(() => new FakeController());
 		const response = await session.handle(
-			request(1, "ping", {
+			request(1, "tools/list", {
 				_meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
 			}),
 		);
@@ -115,6 +118,17 @@ describe("TaloxMcpSession", () => {
 		});
 	});
 
+	it("rejects legacy ping in the modern protocol era", async () => {
+		const session = new TaloxMcpSession(() => new FakeController());
+		const response = await session.handle(
+			request(1, "ping", {
+				_meta: { "io.modelcontextprotocol/protocolVersion": "2026-07-28" },
+			}),
+		);
+
+		expect(response).toMatchObject({ error: { code: -32601 } });
+	});
+
 	it("requires launch before browser-scoped tool calls", async () => {
 		const session = new TaloxMcpSession(() => new FakeController());
 		const response = await session.handle(toolCall(1, "talox_navigate", { url: "https://example.com" }));
@@ -125,6 +139,16 @@ describe("TaloxMcpSession", () => {
 				content: [{ type: "text", text: expect.stringContaining("talox_launch") }],
 			},
 		});
+	});
+
+	it("defaults talox_state to the compact agent variant", async () => {
+		const fake = new FakeController();
+		const session = new TaloxMcpSession(() => fake);
+		await session.handle(toolCall(1, "talox_launch"));
+		const response = await session.handle(toolCall(2, "talox_state"));
+
+		expect(fake.stateVariants).toEqual(["agent"]);
+		expect(response).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"variant": "agent"') }] } });
 	});
 
 	it("runs a persistent browser session across MCP tool calls", async () => {
@@ -157,6 +181,49 @@ describe("TaloxMcpSession", () => {
 			jsonrpc: "2.0",
 			id: 7,
 			error: { code: -32601, message: "Method not found: made/up" },
+		});
+	});
+});
+
+describe("TaloxMcpStdioServer", () => {
+	it("emits newline-delimited JSON-RPC and stays silent for notifications", async () => {
+		const input = Readable.from([
+			`${JSON.stringify(request(1, "server/discover"))}\n`,
+			`${JSON.stringify({ jsonrpc: "2.0", method: "notifications/cancelled", params: { requestId: 1 } })}\n`,
+		]);
+		let output = "";
+		const sink = new Writable({
+			write(chunk, _encoding, callback) {
+				output += chunk.toString();
+				callback();
+			},
+		});
+		const server = new TaloxMcpStdioServer(new TaloxMcpSession(() => new FakeController()), input, sink);
+
+		await server.run();
+
+		const lines = output.trim().split("\n");
+		expect(lines).toHaveLength(1);
+		expect(JSON.parse(lines[0] ?? "{}")).toMatchObject({ id: 1, result: { supportedVersions: ["2026-07-28"] } });
+	});
+
+	it("returns a JSON-RPC parse error for malformed input", async () => {
+		const input = Readable.from(["{definitely-not-json}\n"]);
+		let output = "";
+		const sink = new Writable({
+			write(chunk, _encoding, callback) {
+				output += chunk.toString();
+				callback();
+			},
+		});
+		const server = new TaloxMcpStdioServer(new TaloxMcpSession(() => new FakeController()), input, sink);
+
+		await server.run();
+
+		expect(JSON.parse(output.trim())).toEqual({
+			jsonrpc: "2.0",
+			id: null,
+			error: { code: -32700, message: "Parse error" },
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds the v8.2 community extension seam for structured QA rules and opt-in vision detectors.

- process-wide deterministic plugin registry
- synchronous community rules integrated into `RulesEngine`
- collision-safe plugin bug IDs + provenance metadata
- explicit async vision detector runner
- per-detector screenshot copies and failure isolation
- transactional registration validation
- public `talox/plugins` package entrypoint
- unit coverage for lifecycle, rule integration, malformed hooks, detector isolation, and deterministic ordering
- `docs/PLUGINS.md`

## Validation

PR #28 (MCP) is merged. This PR now contains only the plugin architecture diff against `main`.

Validated on this head:
- CI: success
- Docker: success
- Production Dependency Audit: success
- all browser integration shards: success

## Scope

No automatic model/image inference is added to normal state collection. Rules remain cheap and synchronous; vision detectors are explicitly invoked by hosts so plugin inference cannot silently inflate every Talox state pass.