### PR TITLE
feat: add local VLM vision fallback

### DIFF
--- a/docs/LOCAL-VISION.md
+++ b/docs/LOCAL-VISION.md
@@ -1,0 +1,108 @@
+# Local VLM Integration
+
+Talox already exposes a `VisualReasoner` fallback interface. `createLocalVisionReasoner()` plugs local multimodal models into that existing path without adding a second vision architecture or requiring a cloud API.
+
+The provider is available from `talox/local-vision` and has no additional runtime dependencies.
+
+## Ollama
+
+Ollama is the default provider:
+
+```ts
+import { TaloxController } from "talox";
+import { createLocalVisionReasoner } from "talox/local-vision";
+
+const talox = new TaloxController();
+
+talox.useVision(
+  createLocalVisionReasoner({
+    model: "gemma4",
+  }),
+);
+```
+
+The default endpoint is:
+
+```text
+http://127.0.0.1:11434
+```
+
+Talox sends screenshots to Ollama's native `POST /api/chat` vision endpoint as base64 image data with `stream: false`.
+
+Optional generation controls:
+
+```ts
+createLocalVisionReasoner({
+  model: "gemma4",
+  maxTokens: 300,
+  keepAlive: "10m",
+  timeoutMs: 60_000,
+});
+```
+
+## OpenAI-compatible local servers
+
+Local inference servers that expose an OpenAI-compatible multimodal chat API can use the second provider mode:
+
+```ts
+createLocalVisionReasoner({
+  provider: "openai-compatible",
+  model: "local-vision-model",
+  baseUrl: "http://127.0.0.1:1234/v1",
+  maxTokens: 300,
+});
+```
+
+An API key is optional because many loopback inference servers do not require one:
+
+```ts
+createLocalVisionReasoner({
+  provider: "openai-compatible",
+  model: "local-vision-model",
+  baseUrl: "http://localhost:8000/v1",
+  apiKey: "local-key",
+});
+```
+
+Compatibility depends on the local server and selected model actually supporting image input through chat completions.
+
+## Screenshot privacy boundary
+
+A feature called "local vision" should not silently upload screenshots somewhere else because a hostname was mistyped. Talox therefore rejects non-loopback endpoints by default.
+
+Accepted without extra configuration:
+
+- `localhost` and `*.localhost`
+- IPv4 loopback addresses in `127.0.0.0/8`
+- IPv6 loopback `::1`
+
+A LAN or remote inference host requires explicit opt-in:
+
+```ts
+createLocalVisionReasoner({
+  model: "vision-model",
+  baseUrl: "http://192.168.1.25:11434",
+  allowRemote: true,
+});
+```
+
+`allowRemote: true` means screenshot bytes may be transferred to that host. Talox does not reinterpret a LAN endpoint as private merely because it happens to be nearby.
+
+## Runtime behavior
+
+The factory snapshots its configuration when the reasoner is created. Mutating the original config object later cannot swap the model, token limit, keep-alive value, or API credential used by an existing reasoner.
+
+Requests use a bounded timeout. Non-2xx responses and malformed JSON are surfaced as errors to the existing `VisualReasoner` fallback boundary, where Talox already logs and isolates reasoner failures.
+
+An empty or structurally incomplete successful response returns `null` rather than manufacturing an answer.
+
+## Existing Talox flow
+
+This provider does not change Talox's agent-first vision behavior:
+
+1. Talox emits a `visualQuestion` to the hosting agent.
+2. If the agent answers in time, that answer wins.
+3. If it does not, the registered `VisualReasoner` is used as fallback.
+4. A local reasoner can therefore provide private standalone fallback while preserving agent-native vision when available.
+
+The same reasoner can also be consumed by existing Talox visual/captcha hooks that already use `VisualReasoner`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "./plugins": {
       "import": "./dist/plugins.js",
       "types": "./dist/plugins.d.ts"
+    },
+    "./local-vision": {
+      "import": "./dist/local-vision.js",
+      "types": "./dist/local-vision.d.ts"
     }
   },
   "files": [

--- a/src/core/LocalVisionReasoner.ts
+++ b/src/core/LocalVisionReasoner.ts
@@ -84,6 +84,9 @@ function validatePositiveInteger(value: number | undefined, label: string): void
 
 function validateConfig(config: LocalVisionConfig): void {
 	if (!config || typeof config !== "object") throw new TypeError("Local vision config is required.");
+	if (config.provider !== undefined && config.provider !== "ollama" && config.provider !== "openai-compatible") {
+		throw new TypeError("Local vision provider must be 'ollama' or 'openai-compatible'.");
+	}
 	if (typeof config.model !== "string" || config.model.trim().length === 0) {
 		throw new TypeError("Local vision model must be a non-empty string.");
 	}
@@ -92,8 +95,13 @@ function validateConfig(config: LocalVisionConfig): void {
 	}
 	validatePositiveInteger(config.timeoutMs, "timeoutMs");
 	validatePositiveInteger(config.maxTokens, "maxTokens");
-	if (config.provider === "openai-compatible" && (!config.baseUrl || typeof config.baseUrl !== "string")) {
-		throw new TypeError("OpenAI-compatible local vision requires baseUrl.");
+	if (config.provider === "openai-compatible") {
+		if (!config.baseUrl || typeof config.baseUrl !== "string") {
+			throw new TypeError("OpenAI-compatible local vision requires baseUrl.");
+		}
+		if (config.apiKey !== undefined && typeof config.apiKey !== "string") {
+			throw new TypeError("apiKey must be a string when provided.");
+		}
 	}
 	if (config.provider !== "openai-compatible" && config.keepAlive !== undefined) {
 		const validNumber = typeof config.keepAlive === "number" && Number.isFinite(config.keepAlive);

--- a/src/core/LocalVisionReasoner.ts
+++ b/src/core/LocalVisionReasoner.ts
@@ -117,7 +117,11 @@ function endpoint(baseUrl: URL, path: string): string {
 async function requestJson(url: string, init: RequestInit, timeoutMs: number): Promise<unknown> {
 	let response: Response;
 	try {
-		response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+		response = await fetch(url, {
+			...init,
+			redirect: "manual",
+			signal: AbortSignal.timeout(timeoutMs),
+		});
 	} catch (error) {
 		if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
 			throw new Error(`Local vision request timed out after ${timeoutMs}ms.`);

--- a/src/core/LocalVisionReasoner.ts
+++ b/src/core/LocalVisionReasoner.ts
@@ -1,0 +1,212 @@
+import type { Buffer } from "node:buffer";
+import type { VisualReasoner } from "./VisualReasoner.js";
+
+export type LocalVisionProvider = "ollama" | "openai-compatible";
+
+interface LocalVisionBaseConfig {
+	/** Model identifier exposed by the local inference server. */
+	model: string;
+	/** Request timeout in milliseconds. Defaults to 60 seconds for local inference. */
+	timeoutMs?: number;
+	/**
+	 * Allow a non-loopback endpoint. Defaults to false so screenshots cannot
+	 * accidentally leave the machine under a configuration described as local.
+	 */
+	allowRemote?: boolean;
+}
+
+export interface OllamaVisionConfig extends LocalVisionBaseConfig {
+	provider?: "ollama";
+	/** Ollama base URL. Defaults to http://127.0.0.1:11434. */
+	baseUrl?: string;
+	/** Maximum generated tokens, forwarded as Ollama `num_predict`. */
+	maxTokens?: number;
+	/** Ollama model keep-alive value such as `5m` or `0`. */
+	keepAlive?: string | number;
+}
+
+export interface OpenAICompatibleLocalVisionConfig extends LocalVisionBaseConfig {
+	provider: "openai-compatible";
+	/** OpenAI-compatible API base URL, usually ending in `/v1`. */
+	baseUrl: string;
+	/** Optional local-server API key. */
+	apiKey?: string;
+	/** Maximum generated tokens. Defaults to 300. */
+	maxTokens?: number;
+}
+
+export type LocalVisionConfig = OllamaVisionConfig | OpenAICompatibleLocalVisionConfig;
+
+const DEFAULT_OLLAMA_URL = "http://127.0.0.1:11434";
+const DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MAX_TOKENS = 300;
+
+function normalizeBaseUrl(value: string): URL {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new TypeError(`Invalid local vision base URL: ${value}`);
+	}
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new TypeError("Local vision base URL must use http or https.");
+	}
+	url.pathname = url.pathname.replace(/\/+$/, "");
+	url.search = "";
+	url.hash = "";
+	return url;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+	if (host === "localhost" || host.endsWith(".localhost") || host === "::1") return true;
+	const octets = host.split(".");
+	return octets.length === 4 && octets[0] === "127" && octets.every((part) => /^\d{1,3}$/.test(part));
+}
+
+function assertLocalEndpoint(url: URL, allowRemote: boolean): void {
+	if (!allowRemote && !isLoopbackHostname(url.hostname)) {
+		throw new Error(
+			`Refusing non-loopback local vision endpoint '${url.origin}'. Set allowRemote: true only when screenshot transfer to that host is intentional.`,
+		);
+	}
+}
+
+function validatePositiveInteger(value: number | undefined, label: string): void {
+	if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+		throw new TypeError(`${label} must be a positive integer.`);
+	}
+}
+
+function validateConfig(config: LocalVisionConfig): void {
+	if (!config || typeof config !== "object") throw new TypeError("Local vision config is required.");
+	if (typeof config.model !== "string" || config.model.trim().length === 0) {
+		throw new TypeError("Local vision model must be a non-empty string.");
+	}
+	validatePositiveInteger(config.timeoutMs, "timeoutMs");
+	validatePositiveInteger(config.maxTokens, "maxTokens");
+	if (config.provider === "openai-compatible" && (!config.baseUrl || typeof config.baseUrl !== "string")) {
+		throw new TypeError("OpenAI-compatible local vision requires baseUrl.");
+	}
+}
+
+function endpoint(baseUrl: URL, path: string): string {
+	return `${baseUrl.toString().replace(/\/$/, "")}${path}`;
+}
+
+async function requestJson(url: string, init: RequestInit, timeoutMs: number): Promise<unknown> {
+	let response: Response;
+	try {
+		response = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+	} catch (error) {
+		if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+			throw new Error(`Local vision request timed out after ${timeoutMs}ms.`);
+		}
+		throw error;
+	}
+	if (!response.ok) {
+		const body = await response.text();
+		throw new Error(`Local vision server returned HTTP ${response.status}: ${body.slice(0, 200)}`);
+	}
+	return response.json();
+}
+
+function createOllamaReasoner(config: OllamaVisionConfig): VisualReasoner {
+	const baseUrl = normalizeBaseUrl(config.baseUrl ?? DEFAULT_OLLAMA_URL);
+	assertLocalEndpoint(baseUrl, config.allowRemote === true);
+	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const model = config.model.trim();
+
+	return {
+		name: `Local VLM · Ollama (${model})`,
+		async analyze(screenshot: Buffer, question: string): Promise<string | null> {
+			const body: {
+				model: string;
+				messages: Array<{ role: "user"; content: string; images: string[] }>;
+				stream: false;
+				options?: { num_predict: number };
+				keep_alive?: string | number;
+			} = {
+				model,
+				messages: [
+					{
+						role: "user",
+						content: question,
+						images: [screenshot.toString("base64")],
+					},
+				],
+				stream: false,
+			};
+			if (config.maxTokens !== undefined) body.options = { num_predict: config.maxTokens };
+			if (config.keepAlive !== undefined) body.keep_alive = config.keepAlive;
+
+			const data = (await requestJson(
+				endpoint(baseUrl, "/api/chat"),
+				{
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify(body),
+				},
+				timeoutMs,
+			)) as { message?: { content?: unknown } };
+			const content = data.message?.content;
+			return typeof content === "string" && content.trim() ? content.trim() : null;
+		},
+	};
+}
+
+function createOpenAICompatibleReasoner(config: OpenAICompatibleLocalVisionConfig): VisualReasoner {
+	const baseUrl = normalizeBaseUrl(config.baseUrl);
+	assertLocalEndpoint(baseUrl, config.allowRemote === true);
+	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const model = config.model.trim();
+	const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+	return {
+		name: `Local VLM · OpenAI-compatible (${model})`,
+		async analyze(screenshot: Buffer, question: string): Promise<string | null> {
+			const headers: Record<string, string> = { "Content-Type": "application/json" };
+			if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
+			const data = (await requestJson(
+				endpoint(baseUrl, "/chat/completions"),
+				{
+					method: "POST",
+					headers,
+					body: JSON.stringify({
+						model,
+						max_tokens: maxTokens,
+						messages: [
+							{
+								role: "user",
+								content: [
+									{ type: "text", text: question },
+									{
+										type: "image_url",
+										image_url: { url: `data:image/png;base64,${screenshot.toString("base64")}` },
+									},
+								],
+							},
+						],
+					}),
+				},
+				timeoutMs,
+			)) as { choices?: Array<{ message?: { content?: unknown } }> };
+			const content = data.choices?.[0]?.message?.content;
+			return typeof content === "string" && content.trim() ? content.trim() : null;
+		},
+	};
+}
+
+/**
+ * Create a VisualReasoner backed by a local vision-language model server.
+ *
+ * Ollama is the default provider. OpenAI-compatible mode covers local servers
+ * such as LM Studio, llama.cpp, or vLLM when they expose multimodal chat.
+ * Non-loopback endpoints are rejected unless `allowRemote` is explicitly true.
+ */
+export function createLocalVisionReasoner(config: LocalVisionConfig): VisualReasoner {
+	validateConfig(config);
+	return config.provider === "openai-compatible"
+		? createOpenAICompatibleReasoner(config)
+		: createOllamaReasoner(config);
+}

--- a/src/core/LocalVisionReasoner.ts
+++ b/src/core/LocalVisionReasoner.ts
@@ -61,7 +61,11 @@ function isLoopbackHostname(hostname: string): boolean {
 	const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
 	if (host === "localhost" || host.endsWith(".localhost") || host === "::1") return true;
 	const octets = host.split(".");
-	return octets.length === 4 && octets[0] === "127" && octets.every((part) => /^\d{1,3}$/.test(part));
+	return (
+		octets.length === 4 &&
+		octets[0] === "127" &&
+		octets.every((part) => /^\d{1,3}$/.test(part) && Number(part) >= 0 && Number(part) <= 255)
+	);
 }
 
 function assertLocalEndpoint(url: URL, allowRemote: boolean): void {
@@ -83,10 +87,18 @@ function validateConfig(config: LocalVisionConfig): void {
 	if (typeof config.model !== "string" || config.model.trim().length === 0) {
 		throw new TypeError("Local vision model must be a non-empty string.");
 	}
+	if (config.allowRemote !== undefined && typeof config.allowRemote !== "boolean") {
+		throw new TypeError("allowRemote must be a boolean when provided.");
+	}
 	validatePositiveInteger(config.timeoutMs, "timeoutMs");
 	validatePositiveInteger(config.maxTokens, "maxTokens");
 	if (config.provider === "openai-compatible" && (!config.baseUrl || typeof config.baseUrl !== "string")) {
 		throw new TypeError("OpenAI-compatible local vision requires baseUrl.");
+	}
+	if (config.provider !== "openai-compatible" && config.keepAlive !== undefined) {
+		const validNumber = typeof config.keepAlive === "number" && Number.isFinite(config.keepAlive);
+		const validString = typeof config.keepAlive === "string" && config.keepAlive.trim().length > 0;
+		if (!validNumber && !validString) throw new TypeError("keepAlive must be a finite number or non-empty string.");
 	}
 }
 
@@ -104,18 +116,26 @@ async function requestJson(url: string, init: RequestInit, timeoutMs: number): P
 		}
 		throw error;
 	}
+
+	const body = await response.text();
 	if (!response.ok) {
-		const body = await response.text();
 		throw new Error(`Local vision server returned HTTP ${response.status}: ${body.slice(0, 200)}`);
 	}
-	return response.json();
+	try {
+		return body ? JSON.parse(body) : {};
+	} catch {
+		throw new Error(`Local vision server returned invalid JSON: ${body.slice(0, 200)}`);
+	}
 }
 
 function createOllamaReasoner(config: OllamaVisionConfig): VisualReasoner {
 	const baseUrl = normalizeBaseUrl(config.baseUrl ?? DEFAULT_OLLAMA_URL);
-	assertLocalEndpoint(baseUrl, config.allowRemote === true);
+	const allowRemote = config.allowRemote === true;
+	assertLocalEndpoint(baseUrl, allowRemote);
 	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const model = config.model.trim();
+	const maxTokens = config.maxTokens;
+	const keepAlive = config.keepAlive;
 
 	return {
 		name: `Local VLM · Ollama (${model})`,
@@ -137,8 +157,8 @@ function createOllamaReasoner(config: OllamaVisionConfig): VisualReasoner {
 				],
 				stream: false,
 			};
-			if (config.maxTokens !== undefined) body.options = { num_predict: config.maxTokens };
-			if (config.keepAlive !== undefined) body.keep_alive = config.keepAlive;
+			if (maxTokens !== undefined) body.options = { num_predict: maxTokens };
+			if (keepAlive !== undefined) body.keep_alive = keepAlive;
 
 			const data = (await requestJson(
 				endpoint(baseUrl, "/api/chat"),
@@ -157,16 +177,18 @@ function createOllamaReasoner(config: OllamaVisionConfig): VisualReasoner {
 
 function createOpenAICompatibleReasoner(config: OpenAICompatibleLocalVisionConfig): VisualReasoner {
 	const baseUrl = normalizeBaseUrl(config.baseUrl);
-	assertLocalEndpoint(baseUrl, config.allowRemote === true);
+	const allowRemote = config.allowRemote === true;
+	assertLocalEndpoint(baseUrl, allowRemote);
 	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	const model = config.model.trim();
 	const maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+	const apiKey = config.apiKey;
 
 	return {
 		name: `Local VLM · OpenAI-compatible (${model})`,
 		async analyze(screenshot: Buffer, question: string): Promise<string | null> {
 			const headers: Record<string, string> = { "Content-Type": "application/json" };
-			if (config.apiKey) headers.Authorization = `Bearer ${config.apiKey}`;
+			if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
 			const data = (await requestJson(
 				endpoint(baseUrl, "/chat/completions"),
 				{

--- a/src/local-vision.ts
+++ b/src/local-vision.ts
@@ -1,0 +1,7 @@
+export { createLocalVisionReasoner } from "./core/LocalVisionReasoner.js";
+export type {
+	LocalVisionConfig,
+	LocalVisionProvider,
+	OllamaVisionConfig,
+	OpenAICompatibleLocalVisionConfig,
+} from "./core/LocalVisionReasoner.js";

--- a/tests/unit/LocalVisionReasoner.test.ts
+++ b/tests/unit/LocalVisionReasoner.test.ts
@@ -152,23 +152,50 @@ describe("createLocalVisionReasoner", () => {
 		await expect(reasoner.analyze(Buffer.from("x"), "q")).resolves.toBe("lan result");
 	});
 
+	it("never follows redirects that could replay screenshot data", async () => {
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(null, {
+					status: 307,
+					headers: { Location: "https://remote.example.com/collect" },
+				}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({ model: "vision" });
+
+		await expect(reasoner.analyze(Buffer.from("secret-image"), "inspect")).rejects.toThrow(/HTTP 307/);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe("manual");
+	});
+
 	it("accepts standard IPv4 and IPv6 loopback URLs", () => {
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://127.7.8.9:11434" })).not.toThrow();
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://[::1]:11434" })).not.toThrow();
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://vision.localhost:11434" })).not.toThrow();
 	});
 
-	it("validates model, timeout, token limit, flags, keep-alive, and URL protocol", () => {
+	it("validates model, provider, timeout, token limit, flags, keep-alive, API key, and URL protocol", () => {
 		expect(() => createLocalVisionReasoner({ model: "" })).toThrow(/model/);
 		expect(() => createLocalVisionReasoner({ model: "vision", timeoutMs: 0 })).toThrow(/timeoutMs/);
 		expect(() => createLocalVisionReasoner({ model: "vision", maxTokens: Number.NaN })).toThrow(/maxTokens/);
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "file:///tmp/model" })).toThrow(/http or https/);
+		expect(() =>
+			createLocalVisionReasoner({ model: "vision", provider: "mystery" } as unknown as LocalVisionConfig),
+		).toThrow(/provider/);
 		expect(() =>
 			createLocalVisionReasoner({ model: "vision", allowRemote: "yes" } as unknown as LocalVisionConfig),
 		).toThrow(/allowRemote/);
 		expect(() =>
 			createLocalVisionReasoner({ model: "vision", keepAlive: {} } as unknown as LocalVisionConfig),
 		).toThrow(/keepAlive/);
+		expect(() =>
+			createLocalVisionReasoner({
+				provider: "openai-compatible",
+				model: "vision",
+				baseUrl: "http://127.0.0.1:1234/v1",
+				apiKey: 42,
+			} as unknown as LocalVisionConfig),
+		).toThrow(/apiKey/);
 	});
 
 	it("reports local server HTTP failures without swallowing them", async () => {

--- a/tests/unit/LocalVisionReasoner.test.ts
+++ b/tests/unit/LocalVisionReasoner.test.ts
@@ -1,0 +1,142 @@
+import { Buffer } from "node:buffer";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLocalVisionReasoner } from "../../src/core/LocalVisionReasoner.js";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+function jsonResponse(value: unknown, status = 200): Response {
+	return new Response(JSON.stringify(value), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("createLocalVisionReasoner", () => {
+	it("uses Ollama vision on loopback by default", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ message: { content: "  submit button  " } }));
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({ model: "gemma4" });
+
+		await expect(reasoner.analyze(Buffer.from("png-bytes"), "What is visible?")).resolves.toBe("submit button");
+		expect(reasoner.name).toBe("Local VLM · Ollama (gemma4)");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(url).toBe("http://127.0.0.1:11434/api/chat");
+		const body = JSON.parse(String(init?.body));
+		expect(body).toEqual({
+			model: "gemma4",
+			messages: [
+				{
+					role: "user",
+					content: "What is visible?",
+					images: [Buffer.from("png-bytes").toString("base64")],
+				},
+			],
+			stream: false,
+		});
+	});
+
+	it("forwards Ollama token and keep-alive options", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ message: { content: "ok" } }));
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({ model: "vision", maxTokens: 128, keepAlive: "10m" });
+		await reasoner.analyze(Buffer.from("x"), "inspect");
+		const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(body.options).toEqual({ num_predict: 128 });
+		expect(body.keep_alive).toBe("10m");
+	});
+
+	it("supports an OpenAI-compatible local multimodal server", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ choices: [{ message: { content: " found it " } }] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({
+			provider: "openai-compatible",
+			model: "local-vlm",
+			baseUrl: "http://localhost:1234/v1/",
+			apiKey: "local-key",
+			maxTokens: 222,
+		});
+
+		await expect(reasoner.analyze(Buffer.from("image"), "Find target")).resolves.toBe("found it");
+		const [url, init] = fetchMock.mock.calls[0]!;
+		expect(url).toBe("http://localhost:1234/v1/chat/completions");
+		expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer local-key");
+		const body = JSON.parse(String(init?.body));
+		expect(body.model).toBe("local-vlm");
+		expect(body.max_tokens).toBe(222);
+		expect(body.messages[0].content[0]).toEqual({ type: "text", text: "Find target" });
+		expect(body.messages[0].content[1].image_url.url).toBe(
+			`data:image/png;base64,${Buffer.from("image").toString("base64")}`,
+		);
+	});
+
+	it("omits Authorization when no local API key is configured", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ choices: [] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({
+			provider: "openai-compatible",
+			model: "local-vlm",
+			baseUrl: "http://127.0.0.1:8080/v1",
+		});
+		await expect(reasoner.analyze(Buffer.from("x"), "q")).resolves.toBeNull();
+		expect((fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>).Authorization).toBeUndefined();
+	});
+
+	it("refuses non-loopback endpoints by default", () => {
+		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "https://vlm.example.com" })).toThrow(
+			/non-loopback/,
+		);
+		expect(() =>
+			createLocalVisionReasoner({
+				provider: "openai-compatible",
+				model: "vision",
+				baseUrl: "http://192.168.1.25:8000/v1",
+			}),
+		).toThrow(/allowRemote/);
+	});
+
+	it("allows an intentional remote endpoint only with explicit opt-in", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ message: { content: "lan result" } }));
+		vi.stubGlobal("fetch", fetchMock);
+		const reasoner = createLocalVisionReasoner({
+			model: "vision",
+			baseUrl: "http://192.168.1.25:11434",
+			allowRemote: true,
+		});
+		await expect(reasoner.analyze(Buffer.from("x"), "q")).resolves.toBe("lan result");
+	});
+
+	it("accepts standard IPv4 and IPv6 loopback URLs", () => {
+		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://127.7.8.9:11434" })).not.toThrow();
+		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://[::1]:11434" })).not.toThrow();
+		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://vision.localhost:11434" })).not.toThrow();
+	});
+
+	it("validates model, timeout, token limit, and URL protocol", () => {
+		expect(() => createLocalVisionReasoner({ model: "" })).toThrow(/model/);
+		expect(() => createLocalVisionReasoner({ model: "vision", timeoutMs: 0 })).toThrow(/timeoutMs/);
+		expect(() => createLocalVisionReasoner({ model: "vision", maxTokens: Number.NaN })).toThrow(/maxTokens/);
+		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "file:///tmp/model" })).toThrow(/http or https/);
+	});
+
+	it("reports local server HTTP failures without swallowing them", async () => {
+		vi.stubGlobal("fetch", vi.fn(async () => new Response("model missing", { status: 404 })));
+		const reasoner = createLocalVisionReasoner({ model: "missing" });
+		await expect(reasoner.analyze(Buffer.from("x"), "q")).rejects.toThrow(/HTTP 404: model missing/);
+	});
+
+	it("normalizes timeout errors", async () => {
+		const timeout = new Error("timed out");
+		timeout.name = "TimeoutError";
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw timeout;
+			}),
+		);
+		const reasoner = createLocalVisionReasoner({ model: "vision", timeoutMs: 25 });
+		await expect(reasoner.analyze(Buffer.from("x"), "q")).rejects.toThrow(/timed out after 25ms/);
+	});
+});

--- a/tests/unit/LocalVisionReasoner.test.ts
+++ b/tests/unit/LocalVisionReasoner.test.ts
@@ -1,6 +1,11 @@
 import { Buffer } from "node:buffer";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createLocalVisionReasoner } from "../../src/core/LocalVisionReasoner.js";
+import {
+	createLocalVisionReasoner,
+	type LocalVisionConfig,
+	type OllamaVisionConfig,
+	type OpenAICompatibleLocalVisionConfig,
+} from "../../src/core/LocalVisionReasoner.js";
 
 afterEach(() => {
 	vi.unstubAllGlobals();
@@ -48,6 +53,22 @@ describe("createLocalVisionReasoner", () => {
 		expect(body.keep_alive).toBe("10m");
 	});
 
+	it("snapshots Ollama config so caller mutation cannot change requests", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ message: { content: "ok" } }));
+		vi.stubGlobal("fetch", fetchMock);
+		const config: OllamaVisionConfig = { model: "stable-model", maxTokens: 64, keepAlive: "5m" };
+		const reasoner = createLocalVisionReasoner(config);
+		config.model = "mutated-model";
+		config.maxTokens = 999;
+		config.keepAlive = "0";
+
+		await reasoner.analyze(Buffer.from("x"), "inspect");
+		const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(body.model).toBe("stable-model");
+		expect(body.options).toEqual({ num_predict: 64 });
+		expect(body.keep_alive).toBe("5m");
+	});
+
 	it("supports an OpenAI-compatible local multimodal server", async () => {
 		const fetchMock = vi.fn(async () => jsonResponse({ choices: [{ message: { content: " found it " } }] }));
 		vi.stubGlobal("fetch", fetchMock);
@@ -70,6 +91,29 @@ describe("createLocalVisionReasoner", () => {
 		expect(body.messages[0].content[1].image_url.url).toBe(
 			`data:image/png;base64,${Buffer.from("image").toString("base64")}`,
 		);
+	});
+
+	it("snapshots OpenAI-compatible credentials and generation config", async () => {
+		const fetchMock = vi.fn(async () => jsonResponse({ choices: [{ message: { content: "ok" } }] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const config: OpenAICompatibleLocalVisionConfig = {
+			provider: "openai-compatible",
+			model: "stable-vlm",
+			baseUrl: "http://127.0.0.1:1234/v1",
+			apiKey: "stable-key",
+			maxTokens: 111,
+		};
+		const reasoner = createLocalVisionReasoner(config);
+		config.model = "mutated-vlm";
+		config.apiKey = "mutated-key";
+		config.maxTokens = 999;
+
+		await reasoner.analyze(Buffer.from("image"), "Find target");
+		const [, init] = fetchMock.mock.calls[0]!;
+		expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer stable-key");
+		const body = JSON.parse(String(init?.body));
+		expect(body.model).toBe("stable-vlm");
+		expect(body.max_tokens).toBe(111);
 	});
 
 	it("omits Authorization when no local API key is configured", async () => {
@@ -114,17 +158,29 @@ describe("createLocalVisionReasoner", () => {
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "http://vision.localhost:11434" })).not.toThrow();
 	});
 
-	it("validates model, timeout, token limit, and URL protocol", () => {
+	it("validates model, timeout, token limit, flags, keep-alive, and URL protocol", () => {
 		expect(() => createLocalVisionReasoner({ model: "" })).toThrow(/model/);
 		expect(() => createLocalVisionReasoner({ model: "vision", timeoutMs: 0 })).toThrow(/timeoutMs/);
 		expect(() => createLocalVisionReasoner({ model: "vision", maxTokens: Number.NaN })).toThrow(/maxTokens/);
 		expect(() => createLocalVisionReasoner({ model: "vision", baseUrl: "file:///tmp/model" })).toThrow(/http or https/);
+		expect(() =>
+			createLocalVisionReasoner({ model: "vision", allowRemote: "yes" } as unknown as LocalVisionConfig),
+		).toThrow(/allowRemote/);
+		expect(() =>
+			createLocalVisionReasoner({ model: "vision", keepAlive: {} } as unknown as LocalVisionConfig),
+		).toThrow(/keepAlive/);
 	});
 
 	it("reports local server HTTP failures without swallowing them", async () => {
 		vi.stubGlobal("fetch", vi.fn(async () => new Response("model missing", { status: 404 })));
 		const reasoner = createLocalVisionReasoner({ model: "missing" });
 		await expect(reasoner.analyze(Buffer.from("x"), "q")).rejects.toThrow(/HTTP 404: model missing/);
+	});
+
+	it("reports malformed local server JSON clearly", async () => {
+		vi.stubGlobal("fetch", vi.fn(async () => new Response("definitely-not-json", { status: 200 })));
+		const reasoner = createLocalVisionReasoner({ model: "vision" });
+		await expect(reasoner.analyze(Buffer.from("x"), "q")).rejects.toThrow(/invalid JSON/);
 	});
 
 	it("normalizes timeout errors", async () => {


### PR DESCRIPTION
## Summary

Adds a zero-dependency local vision provider behind Talox's existing `VisualReasoner` interface.

### Providers

- Ollama native vision API via `POST /api/chat`
- OpenAI-compatible local multimodal chat servers

### Privacy and safety

- non-loopback endpoints are rejected by default
- `allowRemote: true` is required before screenshot bytes can leave loopback
- supports `localhost`, `*.localhost`, `127.0.0.0/8`, and `::1`
- automatic redirects are disabled so a loopback 307/308 cannot replay screenshot bytes to a remote host
- config is snapshotted at reasoner creation so later caller mutation cannot swap model, token settings, keep-alive, or API credentials
- request timeouts, HTTP failures, redirects, and malformed JSON are surfaced cleanly through the existing reasoner failure boundary
- runtime config validates provider names, remote opt-in, generation limits, keep-alive values, and OpenAI-compatible API keys

### API

- `createLocalVisionReasoner(config)`
- public `talox/local-vision` subpath
- no new runtime dependencies
- reuses the current agent-first visualQuestion → VisualReasoner fallback flow
- supports locally hosted/quantized models through external inference servers; Talox does not bundle model weights or its own inference runtime

### Reconciliation

- rebased logically onto Platform Adapters #32 through a two-parent merge commit
- package exports preserve `talox/plugins`, `talox/adapters`, and `talox/local-vision`
- final diff against `main` is exactly five Local VLM files

### Validation

- 127 unit test files / 1,949 tests passed
- LocalVisionReasoner: 14 tests passed, including redirect-replay blocking and runtime config validation
- lint & typecheck passed
- all six browser integration shards passed: root, loop, controller, observe, smart, error-paths
- aggregate Browser Integration Tests gate passed
- Docker build/smoke passed
- Production Dependency Audit passed
- reviewer P1 redirect finding fixed on `0d124dc040bff5462717e8ba7365964403e5d42b` and review thread resolved

All validation above is from the final security-fixed head.