### PR TITLE
test: stabilize multi-agent loop integration

### DIFF
--- a/tests/core/loop/PlanDelegateObserveLoop.integration.test.ts
+++ b/tests/core/loop/PlanDelegateObserveLoop.integration.test.ts
@@ -36,7 +36,17 @@ describe("PlanDelegateObserveLoop integration", () => {
 		coordinator = new AgentCoordinator({
 			agents: 2,
 			baseDir: path.join(__dirname, "../../temp-profiles/multi-agent-loop"),
-			settings: { headed: false, verbosity: 0 },
+			// This test exercises coordination and state isolation, not biomechanical
+			// input simulation. Keep browser actions deterministic so interaction
+			// randomness cannot turn an orchestration regression into a CI flake.
+			settings: {
+				headed: false,
+				verbosity: 0,
+				safeMode: true,
+				humanStealth: 0,
+				fidgetEnabled: false,
+				adaptiveStealthEnabled: false,
+			},
 		});
 
 		try {
@@ -94,6 +104,8 @@ describe("PlanDelegateObserveLoop integration", () => {
 				}
 
 				if (plannerCall === 2) {
+					expect(input.multiAgent?.agents[0]?.lastTaskSucceeded).toBe(true);
+					expect(input.multiAgent?.agents[1]?.lastTaskSucceeded).toBe(true);
 					expect(input.multiAgent?.agents[0]?.title).toBe("agent-a");
 					expect(input.multiAgent?.agents[1]?.title).toBe("agent-b");
 					expect(input.multiAgent?.sharedState).toHaveProperty("agentA");
@@ -123,6 +135,8 @@ describe("PlanDelegateObserveLoop integration", () => {
 					};
 				}
 
+				expect(input.multiAgent?.agents[0]?.lastTaskSucceeded).toBe(true);
+				expect(input.multiAgent?.agents[1]?.lastTaskSucceeded).toBe(true);
 				expect(input.multiAgent?.agents[0]?.title).toBe("agent-a-done");
 				expect(input.multiAgent?.agents[1]?.title).toBe("agent-b-done");
 				return {


### PR DESCRIPTION
## Summary

Stabilize the browser-backed `PlanDelegateObserveLoop` integration test after a real CI flake was observed on the v9 release-metadata PR.

The failing run reported the final coordinated result as `failed`, while an immediate rerun of the identical head passed. The test was unintentionally exercising Talox's default biomechanical interaction settings (`humanStealth: 1`, fidgeting, adaptive stealth) even though its purpose is deterministic multi-agent coordination and isolated browser state.

## Changes

- enable explicit `safeMode` for the coordination integration test
- disable human-stealth, fidget, and adaptive-stealth randomness in that test only
- add `lastTaskSucceeded` assertions after navigation and click waves so future failures distinguish action failure from stale/incorrect state
- leave production runtime behavior unchanged

## Validation on head `47d031827a510d1d53a32b7566696b8099bd0ceb`

- Lint & Typecheck: green
- Unit Tests: green
- all six browser integration shards: green
- browser integration aggregate gate: green
- `Browser Integration · loop`: green in the normal matrix
- targeted `loop` rerun #1: green
- targeted `loop` rerun #2: green

Three consecutive green loop executions on the patched head, versus the observed one-off failure under randomized interaction settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for deterministic browser behavior.
  * Added verification that both agents successfully completed their previous tasks before proceeding with subsequent checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->