### PR TITLE
chore: validate release dry run

### DIFF
--- a/.github/workflows/release-dry-run-validation.yml
+++ b/.github/workflows/release-dry-run-validation.yml
@@ -1,0 +1,49 @@
+name: Release Dry Run Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Mirror release dry run
+    if: github.head_ref == 'validate/release-dry-run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare release notes and verify version contract
+        run: node scripts/prepare-release.mjs v9.0.0 release-notes.md
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Runtime dependency audit
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Verify package contents
+        run: npm pack --dry-run
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Browser integration tests
+        run: npm run test:browser


### PR DESCRIPTION
Temporary non-merge validation PR for the Talox v9 release gate.

## Result

Read-only release dry run passed completely on the current main baseline (`30e092338c662292d29e389c023415909e544e3c`).

- release contract: `v9.0.0` OK
- typecheck: passed
- build: passed
- units: **128/128 files, 1,983/1,983 tests**
- production dependency audit: **0 vulnerabilities**
- `npm pack --dry-run`: passed
  - package: `talox@9.0.0`
  - tarball size: **522.0 kB**
  - unpacked size: **2.3 MB**
  - files: **437**
- full unsharded browser integration: **21/21 files, 125/125 tests**, 147.46s
- validation token permissions: repository contents read-only

This PR is intentionally closed without merge. Its temporary workflow commit will be removed by resetting the validation branch to main.