### PR TITLE
ci: smoke packed release artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,24 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+  # ─── Packed package smoke — validate the artifact consumers actually install ─
+  package-smoke:
+    name: Packed Package Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Pack, install, import exports, and run CLI
+        run: npm run test:package
+
   # ─── Browser integration tests — runs on every push / PR ──────────────────────
   # Browser tests remain serial inside each shard. The unusually slow error-path
   # suite has its own runner so a transient browser-launch failure does not force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Runtime dependency audit
         run: npm audit --omit=dev --audit-level=high
 
-      - name: Verify package contents
-        run: npm pack --dry-run
+      - name: Smoke packed package in a fresh consumer
+        run: npm run test:package
 
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,7 +10,9 @@ Talox GitHub releases are created through the guarded manual `Release` workflow 
 4. Leave **dry_run** enabled.
 5. Run the workflow.
 
-A dry run creates no tag and no GitHub Release. It verifies the release contract, typechecks and builds the package, runs the full unit suite, audits production dependencies, checks `npm pack --dry-run`, and runs the Chromium browser integration suite.
+A dry run creates no tag and no GitHub Release. It verifies the release contract, typechecks and builds the package, runs the full unit suite, audits production dependencies, packs the actual npm tarball, installs that tarball into a fresh temporary consumer project, imports every public package surface (`talox`, `talox/plugins`, `talox/adapters`, and `talox/local-vision`), runs the installed `talox --help` binary, and then runs the Chromium browser integration suite.
+
+The same packed-package consumer smoke also runs in normal CI so export-map, tarball, dependency, and CLI packaging regressions are caught before release day.
 
 ## Publish
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test:unit": "vitest run --config vitest.config.unit.ts",
     "test:coverage": "vitest --config vitest.config.unit.ts --coverage",
     "test:browser": "vitest run --config vitest.config.browser.ts",
+    "test:package": "npm run build && node scripts/smoke-packed-package.mjs",
     "test:all": "vitest",
     "observe": "node ./dist/cli/entry.js observe",
     "prepublishOnly": "npm run build",

--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
+const workspace = mkdtempSync(join(tmpdir(), "talox-package-smoke-"));
+const packDir = join(workspace, "pack");
+const consumerDir = join(workspace, "consumer");
+
+function run(command, args, options = {}) {
+	return execFileSync(command, args, {
+		cwd: options.cwd ?? repoRoot,
+		encoding: "utf8",
+		stdio: options.capture ? ["ignore", "pipe", "inherit"] : "inherit",
+		env: process.env,
+	});
+}
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+try {
+	mkdirSync(packDir, { recursive: true });
+	mkdirSync(consumerDir, { recursive: true });
+
+	const packOutput = run(npmCommand, ["pack", "--json", "--pack-destination", packDir], { capture: true });
+	const packResult = JSON.parse(packOutput);
+	const artifact = Array.isArray(packResult) ? packResult[0] : undefined;
+	assert(artifact && typeof artifact.filename === "string", "npm pack did not return a package filename");
+
+	const packageJson = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+	assert(artifact.name === packageJson.name, `packed package name mismatch: ${String(artifact.name)}`);
+	assert(artifact.version === packageJson.version, `packed package version mismatch: ${String(artifact.version)}`);
+
+	const tarballPath = join(packDir, artifact.filename);
+	writeFileSync(
+		join(consumerDir, "package.json"),
+		JSON.stringify({ name: "talox-packed-smoke-consumer", private: true, type: "module" }, null, 2),
+		"utf8",
+	);
+
+	run(
+		npmCommand,
+		["install", "--ignore-scripts", "--no-audit", "--no-fund", "--package-lock=false", tarballPath],
+		{ cwd: consumerDir },
+	);
+
+	const importSmoke = `
+import { TaloxController } from "talox";
+import { listTaloxPlugins } from "talox/plugins";
+import { BUILT_IN_PLATFORM_ADAPTERS } from "talox/adapters";
+import { createLocalVisionReasoner } from "talox/local-vision";
+
+const checks = [
+  ["talox:TaloxController", typeof TaloxController === "function"],
+  ["talox/plugins:listTaloxPlugins", typeof listTaloxPlugins === "function"],
+  ["talox/adapters:BUILT_IN_PLATFORM_ADAPTERS", Array.isArray(BUILT_IN_PLATFORM_ADAPTERS)],
+  ["talox/local-vision:createLocalVisionReasoner", typeof createLocalVisionReasoner === "function"],
+];
+
+for (const [name, ok] of checks) {
+  if (!ok) throw new Error("Packed export smoke failed: " + name);
+}
+console.log("Packed imports OK");
+`;
+
+	run(process.execPath, ["--input-type=module", "--eval", importSmoke], { cwd: consumerDir });
+
+	const binPath = join(
+		consumerDir,
+		"node_modules",
+		".bin",
+		process.platform === "win32" ? "talox.cmd" : "talox",
+	);
+	const cliOutput = run(binPath, ["--help"], { cwd: consumerDir, capture: true });
+	assert(/talox/i.test(cliOutput), "Packed CLI smoke produced no Talox help output");
+
+	const size = typeof artifact.size === "number" ? `${(artifact.size / 1024).toFixed(1)} kB` : "unknown";
+	const unpacked = typeof artifact.unpackedSize === "number" ? `${(artifact.unpackedSize / 1024 / 1024).toFixed(2)} MB` : "unknown";
+	const files = Array.isArray(artifact.files) ? artifact.files.length : "unknown";
+	process.stdout.write(
+		`Packed package smoke OK: ${artifact.name}@${artifact.version} (${size} tarball, ${unpacked} unpacked, ${files} files)\n`,
+	);
+} finally {
+	if (process.env.TALOX_KEEP_PACKAGE_SMOKE !== "1") {
+		rmSync(workspace, { recursive: true, force: true });
+	} else {
+		process.stdout.write(`Preserved package smoke workspace: ${workspace}\n`);
+	}
+}

--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -41,7 +41,16 @@ try {
 	const tarballPath = join(packDir, artifact.filename);
 	writeFileSync(
 		join(consumerDir, "package.json"),
-		JSON.stringify({ name: "talox-packed-smoke-consumer", private: true, type: "module" }, null, 2),
+		JSON.stringify(
+			{
+				name: "talox-packed-smoke-consumer",
+				private: true,
+				type: "module",
+				scripts: { "smoke:cli": "talox --help" },
+			},
+			null,
+			2,
+		),
 		"utf8",
 	);
 
@@ -72,13 +81,10 @@ console.log("Packed imports OK");
 
 	run(process.execPath, ["--input-type=module", "--eval", importSmoke], { cwd: consumerDir });
 
-	const binPath = join(
-		consumerDir,
-		"node_modules",
-		".bin",
-		process.platform === "win32" ? "talox.cmd" : "talox",
-	);
-	const cliOutput = run(binPath, ["--help"], { cwd: consumerDir, capture: true });
+	// npm scripts prepend the consumer's local node_modules/.bin to PATH on every
+	// supported platform, avoiding direct .cmd execution quirks on Windows while
+	// still proving that the installed package generated a working `talox` bin.
+	const cliOutput = run(npmCommand, ["run", "--silent", "smoke:cli"], { cwd: consumerDir, capture: true });
 	assert(/talox/i.test(cliOutput), "Packed CLI smoke produced no Talox help output");
 
 	const size = typeof artifact.size === "number" ? `${(artifact.size / 1024).toFixed(1)} kB` : "unknown";


### PR DESCRIPTION
## Summary

Make Talox packaging itself a tested contract instead of assuming source-tree tests imply a usable published artifact.

## Changes

- add `npm run test:package`
- build the real `talox` tarball via `npm pack --json`
- install that tarball into a fresh temporary consumer project with install scripts disabled
- import `talox`, `talox/plugins`, `talox/adapters`, and `talox/local-vision` from the installed artifact
- invoke the installed local `talox --help` binary through the consumer's npm-script PATH, which is cross-platform and does not depend on direct `.cmd` execution
- verify packed package name/version metadata
- clean temporary artifacts automatically
- add `Packed Package Smoke` as a permanent normal-CI job
- require the same packed-artifact smoke in the guarded manual Release workflow
- document the stronger release validation in `docs/RELEASING.md`

No runtime behavior, dependencies, package version, or lockfile content changes.

## Validation on head `00257beb1c4f770a296bd603b92afae7b9c546a8`

- Lint & Typecheck: green
- Unit Tests: green
- Packed Package Smoke: green
  - fresh consumer installed 26 packages from the packed artifact
  - all four public import surfaces loaded successfully
  - installed CLI help executed successfully
  - `talox@9.0.0`: 509.8 KiB tarball, 2.20 MiB unpacked, 437 files
- all six browser integration shards: green
- browser aggregate gate: green
- Production Dependency Audit: green
- Docker build/runtime/sandbox smoke: green, including Talox-driven Chromium launch
- no review threads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated smoke testing for packed packages, including public imports and CLI behavior.
  * Release validation now tests the actual package tarball in a fresh consumer environment.

* **Documentation**
  * Updated release guidance to describe packed-package consumer testing and browser integration checks.

* **Chores**
  * Added a package smoke-test command to the project workflow and CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->