### PR TITLE
test: validate packed TypeScript declarations

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,9 +10,9 @@ Talox GitHub releases are created through the guarded manual `Release` workflow 
 4. Leave **dry_run** enabled.
 5. Run the workflow.
 
-A dry run creates no tag and no GitHub Release. It verifies the release contract, typechecks and builds the package, runs the full unit suite, audits production dependencies, packs the actual npm tarball, installs that tarball into a fresh temporary consumer project, imports every public package surface (`talox`, `talox/plugins`, `talox/adapters`, and `talox/local-vision`), runs the installed `talox --help` binary, and then runs the Chromium browser integration suite.
+A dry run creates no tag and no GitHub Release. It verifies the release contract, typechecks and builds the package, runs the full unit suite, audits production dependencies, packs the actual npm tarball, installs that tarball into a fresh temporary consumer project, imports every public package surface (`talox`, `talox/plugins`, `talox/adapters`, and `talox/local-vision`), compiles a fresh TypeScript consumer against the packed declarations, runs the installed `talox --help` binary, and then runs the Chromium browser integration suite.
 
-The same packed-package consumer smoke also runs in normal CI so export-map, tarball, dependency, and CLI packaging regressions are caught before release day.
+The same packed-package consumer smoke also runs in normal CI so export-map, declaration, tarball, dependency, and CLI packaging regressions are caught before release day.
 
 ## Publish
 

--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -46,7 +46,14 @@ try {
 				name: "talox-packed-smoke-consumer",
 				private: true,
 				type: "module",
-				scripts: { "smoke:cli": "talox --help" },
+				scripts: {
+					"smoke:cli": "talox --help",
+					"smoke:types": "tsc --noEmit --strict --target ESNext --module NodeNext --moduleResolution NodeNext type-smoke.ts",
+				},
+				devDependencies: {
+					"@types/node": packageJson.devDependencies?.["@types/node"],
+					typescript: packageJson.devDependencies?.typescript,
+				},
 			},
 			null,
 			2,
@@ -81,9 +88,8 @@ console.log("Packed imports OK");
 
 	run(process.execPath, ["--input-type=module", "--eval", importSmoke], { cwd: consumerDir });
 
-	const typeSmokePath = join(consumerDir, "type-smoke.ts");
 	writeFileSync(
-		typeSmokePath,
+		join(consumerDir, "type-smoke.ts"),
 		`import { TaloxController } from "talox";
 import { listTaloxPlugins } from "talox/plugins";
 import { BUILT_IN_PLATFORM_ADAPTERS } from "talox/adapters";
@@ -101,23 +107,7 @@ void publicSurface;
 		"utf8",
 	);
 
-	const tscPath = join(repoRoot, "node_modules", "typescript", "bin", "tsc");
-	run(
-		process.execPath,
-		[
-			tscPath,
-			typeSmokePath,
-			"--noEmit",
-			"--strict",
-			"--target",
-			"ES2022",
-			"--module",
-			"NodeNext",
-			"--moduleResolution",
-			"NodeNext",
-		],
-		{ cwd: consumerDir },
-	);
+	run(npmCommand, ["run", "--silent", "smoke:types"], { cwd: consumerDir });
 	process.stdout.write("Packed TypeScript declarations OK\n");
 
 	// npm scripts prepend the consumer's local node_modules/.bin to PATH on every

--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -81,6 +81,45 @@ console.log("Packed imports OK");
 
 	run(process.execPath, ["--input-type=module", "--eval", importSmoke], { cwd: consumerDir });
 
+	const typeSmokePath = join(consumerDir, "type-smoke.ts");
+	writeFileSync(
+		typeSmokePath,
+		`import { TaloxController } from "talox";
+import { listTaloxPlugins } from "talox/plugins";
+import { BUILT_IN_PLATFORM_ADAPTERS } from "talox/adapters";
+import { createLocalVisionReasoner } from "talox/local-vision";
+
+const publicSurface = {
+  TaloxController,
+  listTaloxPlugins,
+  BUILT_IN_PLATFORM_ADAPTERS,
+  createLocalVisionReasoner,
+};
+
+void publicSurface;
+`,
+		"utf8",
+	);
+
+	const tscPath = join(repoRoot, "node_modules", "typescript", "bin", "tsc");
+	run(
+		process.execPath,
+		[
+			tscPath,
+			typeSmokePath,
+			"--noEmit",
+			"--strict",
+			"--target",
+			"ES2022",
+			"--module",
+			"NodeNext",
+			"--moduleResolution",
+			"NodeNext",
+		],
+		{ cwd: consumerDir },
+	);
+	process.stdout.write("Packed TypeScript declarations OK\n");
+
 	// npm scripts prepend the consumer's local node_modules/.bin to PATH on every
 	// supported platform, avoiding direct .cmd execution quirks on Windows while
 	// still proving that the installed package generated a working `talox` bin.


### PR DESCRIPTION
## Summary

Extend the packed-package release smoke so Talox proves its shipped TypeScript declarations from the same fresh consumer that already validates runtime imports and the installed CLI.

## Changes

- write a minimal TypeScript consumer after installing the real `npm pack` artifact
- import all four public package surfaces: `talox`, `talox/plugins`, `talox/adapters`, and `talox/local-vision`
- compile that consumer with the repository's pinned TypeScript compiler using strict NodeNext resolution
- keep the test consumer isolated from the source tree for package resolution
- document declaration validation in the release procedure

## Why

The current packed-artifact smoke catches missing runtime exports and broken CLI packaging, but a publish could still ship missing or unresolvable `.d.ts` files. This turns the published declaration graph into part of the release contract without changing runtime behavior or dependencies.