### PR TITLE
ci: isolate nightly real-world failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ on:
         required: false
         default: ''
 
-# Cancel superseded runs on the same branch/ref when a newer commit arrives.
-# This keeps PR feedback focused on the current head instead of stale intermediates.
+# Cancel superseded runs only when they are the same event on the same ref.
+# A push to main must not cancel the nightly real-world run halfway through.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -146,10 +146,73 @@ jobs:
           fi
           echo "All browser integration shards passed."
 
-  # ─── Real-world tests — nightly + manual only ────────────────────────────────
-  real-world:
-    name: Real-World Tests
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  # ─── Real-world tests — nightly full suite in isolated serial shards ──────────
+  # Real sites are allowed to be slow or hostile, but one scenario must not consume
+  # the entire nightly budget. Shards stay serial to avoid rate-limit/shared-IP
+  # pressure while each gets its own runner timeout and diagnostics.
+  real-world-shard:
+    name: Real-World · ${{ matrix.group }}
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.grep == '')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        include:
+          - group: detection
+            target: 'tests/real/00-detection-suite.spec.ts'
+          - group: disposable-mail
+            target: 'tests/real/01-guerrillamail.spec.ts'
+          - group: reddit-signup
+            target: 'tests/real/02-reddit-signup.spec.ts'
+          - group: platforms
+            target: 'tests/real/03-reddit-login.spec.ts tests/real/04-x-bot-detection.spec.ts tests/real/05-stackoverflow.spec.ts'
+          - group: agents-observe
+            target: 'tests/real/06-chatgpt-agent-to-agent.spec.ts tests/real/06b-grok-agent-to-agent.spec.ts tests/real/07-observe-driven-ai.spec.ts'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run real-world shard
+        run: npx playwright test ${{ matrix.target }}
+        env:
+          REDDIT_USER: ${{ secrets.REDDIT_USER }}
+          REDDIT_PASS: ${{ secrets.REDDIT_PASS }}
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report-${{ matrix.group }}-${{ github.run_number }}
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Upload test videos (failures only)
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-videos-${{ matrix.group }}-${{ github.run_number }}
+          path: test-results/
+          retention-days: 3
+
+  # ─── Filtered real-world run — manual targeted diagnostics only ──────────────
+  real-world-filtered:
+    name: Real-World · filtered
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.grep != ''
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -168,13 +231,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run real-world tests
-        run: |
-          if [ -n "${{ github.event.inputs.grep }}" ]; then
-            npx playwright test --grep "${{ github.event.inputs.grep }}"
-          else
-            npx playwright test
-          fi
+      - name: Run filtered real-world tests
+        run: npx playwright test --grep "${{ github.event.inputs.grep }}"
         env:
           REDDIT_USER: ${{ secrets.REDDIT_USER }}
           REDDIT_PASS: ${{ secrets.REDDIT_PASS }}
@@ -184,7 +242,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-report-${{ github.run_number }}
+          name: playwright-report-filtered-${{ github.run_number }}
           path: playwright-report/
           retention-days: 7
 
@@ -192,6 +250,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: test-videos-${{ github.run_number }}
+          name: test-videos-filtered-${{ github.run_number }}
           path: test-results/
           retention-days: 3

--- a/tests/real/02-reddit-signup.spec.ts
+++ b/tests/real/02-reddit-signup.spec.ts
@@ -27,6 +27,7 @@ const adaptedEvents: any[] = [];
 let disposableEmail = "";
 const testUsername = `talox_test_${Date.now().toString(36)}`;
 const testPassword = `T@lox_${Date.now()}!`;
+const REDDIT_REGISTRATION_STEP_TIMEOUT_MS = 90_000;
 
 test.describe("Scenario 2 — Reddit signup via Gorilla Mail", () => {
 	test.setTimeout(180_000);
@@ -93,12 +94,14 @@ test.describe("Scenario 2 — Reddit signup via Gorilla Mail", () => {
 	});
 
 	test("Step 2b — navigates to registration page", async () => {
+		test.setTimeout(REDDIT_REGISTRATION_STEP_TIMEOUT_MS);
 		const state = await talox.navigate("https://www.reddit.com/register");
 		expect(state.url).toContain("reddit.com");
 		console.log("[test] Registration URL:", state.url);
 	});
 
 	test("Step 2c — AX-Tree has email or username input", async () => {
+		test.setTimeout(REDDIT_REGISTRATION_STEP_TIMEOUT_MS);
 		// Reddit register may be a SPA modal — give it a moment
 		// Re-navigate to ensure we're on the registration page even if worker restarted
 		await talox.waitForTimeout(2000);


### PR DESCRIPTION
## Summary

Stop one slow or hostile real-world scenario from starving the rest of Talox's nightly compatibility evidence.

## Changes

- keep scheduled full-suite real-world coverage, but split it into five serial shards
- use `max-parallel: 1` so live-site tests still avoid concurrent shared-IP/rate-limit pressure
- give every shard its own 20-minute job budget and uniquely named diagnostics artifacts
- keep targeted manual `--grep` diagnostics as a separate workflow-dispatch job
- separate schedule concurrency from pushes so maintenance commits cannot cancel the nightly run
- cap the two historically pathological Reddit registration checks at 90 seconds each

## Evidence

A recent nightly run spent roughly 12 minutes on two Reddit registration checks alone because each stalled for three minutes and then retried. The overall real-world job subsequently hit its 30-minute ceiling before later StackOverflow and agent scenarios could run. The new structure preserves failure visibility while allowing later shards to execute independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved nightly real-world test reliability by splitting runs into serial shards with dedicated timeouts.
  * Added clearer diagnostics, including Playwright failure videos and targeted test groups.
  * Increased timeout coverage for Reddit registration steps.

* **Chores**
  * Updated CI scheduling to prevent unrelated runs from cancelling each other.
  * Manual filtered test runs now require a filter and produce clearly identified artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->