### PR TITLE
ci: persist detection baselines across runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,15 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Restore previous detection baseline
+        if: matrix.group == 'detection'
+        uses: actions/cache/restore@v5
+        with:
+          path: tests/real/detection-results.json
+          key: talox-detection-results-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            talox-detection-results-${{ runner.os }}-
+
       - run: npm ci
 
       - run: npm run build
@@ -192,6 +201,32 @@ jobs:
           REDDIT_USER: ${{ secrets.REDDIT_USER }}
           REDDIT_PASS: ${{ secrets.REDDIT_PASS }}
           CI: true
+
+      - name: Check detection baseline output
+        id: detection-baseline
+        if: always() && matrix.group == 'detection'
+        shell: bash
+        run: |
+          if [ -f tests/real/detection-results.json ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Save detection baseline
+        if: always() && matrix.group == 'detection' && steps.detection-baseline.outputs.exists == 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: tests/real/detection-results.json
+          key: talox-detection-results-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Upload detection baseline
+        if: always() && matrix.group == 'detection' && steps.detection-baseline.outputs.exists == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: detection-results-${{ github.run_number }}-${{ github.run_attempt }}
+          path: tests/real/detection-results.json
+          retention-days: 30
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           fi
 
       - name: Save detection baseline
-        if: always() && matrix.group == 'detection' && steps.detection-baseline.outputs.exists == 'true'
+        if: success() && matrix.group == 'detection' && steps.detection-baseline.outputs.exists == 'true'
         uses: actions/cache/save@v5
         with:
           path: tests/real/detection-results.json

--- a/tests/real/00-detection-suite.spec.ts
+++ b/tests/real/00-detection-suite.spec.ts
@@ -63,6 +63,14 @@ function saveResults(results: DetectionResults): void {
 	fs.writeFileSync(RESULTS_PATH, JSON.stringify(results, null, 2));
 }
 
+function logLowerIsBetterDelta(label: string, current: number | null, previous: number | null): void {
+	if (current === null || previous === null || current === previous) return;
+	const delta = current - previous;
+	const direction = delta > 0 ? "REGRESSION" : "IMPROVEMENT";
+	const log = delta > 0 ? console.warn : console.log;
+	log(`[CreepJS] ${direction}: ${label} ${previous} → ${current} (${delta > 0 ? "+" : ""}${delta})`);
+}
+
 test.describe("Detection Score Suite", () => {
 	test.setTimeout(300_000);
 
@@ -164,18 +172,28 @@ test.describe("Detection Score Suite", () => {
 			console.warn(`[Sannysoft] Unclassified checks: ${result.unclassifiedChecks.join(", ")}`);
 		}
 
-		// Document current score — do NOT fail on low scores. Only parser/page
-		// failures are errors; actual failed checks are compatibility evidence.
+		// Compare pass rates rather than raw counts because Sannysoft can add or
+		// remove checks over time. A changed denominator should not manufacture a
+		// regression or improvement by itself.
 		const previous = loadPreviousResults();
-		if (previous?.sannysoft) {
-			const prevScore = previous.sannysoft.passed;
-			if (result.passed < prevScore) {
+		if (previous?.sannysoft?.total > 0 && result.total > 0) {
+			const previousRate = previous.sannysoft.passed / previous.sannysoft.total;
+			const currentRate = result.passed / result.total;
+			const deltaPoints = (currentRate - previousRate) * 100;
+			if (deltaPoints < -0.01) {
 				console.warn(
-					`[Sannysoft] REGRESSION: ${result.passed} < previous ${prevScore}. ` +
-						`New failures: ${result.failedChecks.join(", ")}`,
+					`[Sannysoft] REGRESSION: ${(previousRate * 100).toFixed(1)}% → ` +
+						`${(currentRate * 100).toFixed(1)}% (${deltaPoints.toFixed(1)} pp). ` +
+						`Failures: ${result.failedChecks.join(", ")}`,
 				);
-			} else if (result.passed > prevScore) {
-				console.log(`[Sannysoft] IMPROVEMENT: ${result.passed} > previous ${prevScore}`);
+			} else if (deltaPoints > 0.01) {
+				console.log(
+					`[Sannysoft] IMPROVEMENT: ${(previousRate * 100).toFixed(1)}% → ` +
+						`${(currentRate * 100).toFixed(1)}% (+${deltaPoints.toFixed(1)} pp)`,
+				);
+			}
+			if (previous.sannysoft.total !== result.total) {
+				console.log(`[Sannysoft] Check count changed: ${previous.sannysoft.total} → ${result.total}`);
 			}
 		}
 
@@ -262,7 +280,15 @@ test.describe("Detection Score Suite", () => {
 		expect(result.stealthPct).not.toBeNull();
 		expect(result.totalLies).not.toBeNull();
 
-		const current = loadPreviousResults() || ({} as DetectionResults);
+		const previous = loadPreviousResults();
+		if (previous?.creepjs) {
+			logLowerIsBetterDelta("like-headless", result.likeHeadlessPct, previous.creepjs.likeHeadlessPct ?? null);
+			logLowerIsBetterDelta("headless", result.headlessPct, previous.creepjs.headlessPct ?? null);
+			logLowerIsBetterDelta("stealth", result.stealthPct, previous.creepjs.stealthPct ?? null);
+			logLowerIsBetterDelta("lies", result.totalLies, previous.creepjs.totalLies ?? null);
+		}
+
+		const current = previous || ({} as DetectionResults);
 		current.timestamp = new Date().toISOString();
 		current.creepjs = result;
 		saveResults(current as DetectionResults);


### PR DESCRIPTION
## Summary

Make Talox's real-world detection regression tracking actually compare against previous runs instead of only reading JSON created earlier in the same clean checkout.

## Changes

- restore the most recent detection baseline before the scheduled/manual full detection shard
- promote a newly generated baseline only after a successful detection shard
- retain failed/partial detection output as a diagnostic artifact without poisoning the next baseline
- use immutable per-run/per-attempt cache keys with a stable restore prefix
- upload each detection JSON as a 30-day artifact for human inspection and auditability
- compare Sannysoft by pass **rate**, not raw pass count, so site check-count changes do not create fake regressions
- compare CreepJS like-headless/headless/stealth/lie metrics against the restored baseline, where lower is better

## Why

`tests/real/detection-results.json` is generated at runtime and is not committed. On a clean GitHub-hosted runner, `loadPreviousResults()` therefore had no previous-night data at the start of the detection suite. The code called this regression tracking, but it only remembered earlier tests from the current process. This gives the nightly suite actual historical memory and normalized comparisons while ensuring failed measurement runs cannot become the trusted baseline.