### PR TITLE
ci: use runner Chrome for browser integration shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,9 +100,10 @@ jobs:
         run: npx playwright test --list
 
   # ─── Browser integration tests — runs on every push / PR ──────────────────────
-  # Browser tests remain serial inside each shard. The unusually slow error-path
-  # suite has its own runner so a transient browser-launch failure does not force
-  # the rest of the root suite to be repeated after ~18 minutes of work.
+  # Talox deliberately prefers the real system Chrome channel for its adaptive
+  # runtime. GitHub's Ubuntu runner already ships Chrome + Xvfb, so downloading a
+  # separate ~300 MiB Playwright Chromium bundle in every shard only adds setup
+  # latency for a fallback that normal CI does not use.
   browser-shard:
     name: Browser Integration · ${{ matrix.group }}
     runs-on: ubuntu-latest
@@ -141,8 +142,12 @@ jobs:
 
       - run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - name: Verify runner Chrome prerequisites
+        shell: bash
+        run: |
+          command -v google-chrome
+          google-chrome --version
+          command -v Xvfb
 
       - name: Run browser integration shard
         shell: bash

--- a/tests/core/page-state-accessibility-compat.test.ts
+++ b/tests/core/page-state-accessibility-compat.test.ts
@@ -7,7 +7,7 @@ describe("PageStateCollector · modern Playwright accessibility compatibility", 
 	let page: Page;
 
 	beforeAll(async () => {
-		browser = await chromium.launch({ headless: true });
+		browser = await chromium.launch({ headless: true, ...(process.env.CI ? { channel: "chrome" } : {}) });
 		page = await browser.newPage();
 		await page.setContent(`<main><h1>Compatibility</h1>${Array.from({ length: 12 }, (_, i) => `<button>Action ${i}</button>`).join("")}</main>`);
 	});

--- a/tests/core/page-state-modern-aria.test.ts
+++ b/tests/core/page-state-modern-aria.test.ts
@@ -7,7 +7,7 @@ describe("PageStateCollector · modern ARIA state", () => {
 	let page: Page;
 
 	beforeAll(async () => {
-		browser = await chromium.launch({ headless: true });
+		browser = await chromium.launch({ headless: true, ...(process.env.CI ? { channel: "chrome" } : {}) });
 		page = await browser.newPage({ viewport: { width: 900, height: 700 } });
 		await page.setContent(`
 			<main>


### PR DESCRIPTION
## Summary

Stop downloading Playwright's Chromium bundle in every normal browser-integration shard when Talox already prefers the system Chrome channel and GitHub's Ubuntu runner ships Chrome + Xvfb.

## Changes

- remove `npx playwright install --with-deps chromium` from the six push/PR browser shards
- explicitly verify `google-chrome` and `Xvfb` are present before running the shard
- route the two page-state tests that directly call `playwright-core` to the `chrome` channel in CI while preserving their bundled-browser behavior locally
- leave scheduled/manual real-world jobs unchanged until this path is proven independently

## Evidence

A representative browser shard currently spends about 35 seconds provisioning Playwright Chromium before tests begin:

- dependency/font installation: ~23s
- downloads: Chrome 184.3 MiB + FFmpeg 2.3 MiB + headless shell 114.7 MiB, ~11s

The first experiment showed 5/6 browser shards already pass with runner Chrome. The root shard exposed exactly two tests that bypass Talox and call `chromium.launch()` directly; those are now explicitly routed to the runner's Chrome channel in CI. This preserves local Playwright-managed-browser coverage while removing the redundant bundle from GitHub browser integration jobs.