### PR TITLE
ci: use runner Chrome for real-world jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,9 @@ jobs:
   # ─── Real-world tests — nightly full suite in isolated serial shards ──────────
   # Real sites are allowed to be slow or hostile, but one scenario must not consume
   # the entire nightly budget. Shards stay serial to avoid rate-limit/shared-IP
-  # pressure while each gets its own runner timeout and diagnostics.
+  # pressure while each gets its own runner timeout and diagnostics. Talox itself
+  # uses the system Chrome channel, so these jobs verify the runner browser instead
+  # of downloading an unused Playwright Chromium bundle for every serial shard.
   real-world-shard:
     name: Real-World · ${{ matrix.group }}
     if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.grep == '')
@@ -219,8 +221,12 @@ jobs:
 
       - run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - name: Verify runner Chrome prerequisites
+        shell: bash
+        run: |
+          command -v google-chrome
+          google-chrome --version
+          command -v Xvfb
 
       - name: Run real-world shard
         run: npx playwright test ${{ matrix.target }}
@@ -290,8 +296,12 @@ jobs:
 
       - run: npm run build
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+      - name: Verify runner Chrome prerequisites
+        shell: bash
+        run: |
+          command -v google-chrome
+          google-chrome --version
+          command -v Xvfb
 
       - name: Run filtered real-world tests
         run: npx playwright test --grep "${{ github.event.inputs.grep }}"


### PR DESCRIPTION
## Summary

Extend the proven runner-Chrome CI path to Talox's scheduled and manually filtered real-world jobs instead of downloading Playwright Chromium for each run.

## Changes

- replace `npx playwright install --with-deps chromium` in the 5 serial nightly real-world shards with an explicit system Chrome/Xvfb prerequisite check
- do the same for the filtered manual real-world job
- keep the actual Playwright/Talox test commands unchanged

## Evidence

PR #55 proved all normal browser integration shards pass using GitHub runner Chrome and Xvfb without the Playwright Chromium bundle. A repository search shows `tests/real/*` do not directly call unchanneled `chromium.launch()`; browser startup goes through Talox's BrowserManager, which already prefers the system Chrome channel.

The previous install step cost roughly ~35 seconds per job and downloaded ~300 MiB. Because the five nightly shards are deliberately serial, removing that redundant setup should save roughly ~3 minutes from a full nightly run while preserving the browser path Talox actually uses.