### PR TITLE
test: remove human-simulation delays from loop integrations

### DIFF
--- a/tests/core/loop/AutonomousLoop.integration.test.ts
+++ b/tests/core/loop/AutonomousLoop.integration.test.ts
@@ -76,7 +76,18 @@ describe("AutonomousLoop integration", () => {
 	let browserAvailable = true;
 
 	beforeAll(async () => {
-		controller = new TaloxController(path.join(__dirname, "../../temp-profiles"));
+		controller = new TaloxController(path.join(__dirname, "../../temp-profiles"), {
+			settings: {
+				safeMode: true,
+				automaticThinkingEnabled: false,
+				humanStealth: 0,
+				fidgetEnabled: false,
+				adaptiveStealthEnabled: false,
+				typoProbability: 0,
+				typingDelayMin: 0,
+				typingDelayMax: 0,
+			},
+		});
 		try {
 			await controller.launch(`loop-integration-${Date.now()}`, "sandbox");
 		} catch (error) {

--- a/tests/core/loop/PlanDelegateObserveLoop.integration.test.ts
+++ b/tests/core/loop/PlanDelegateObserveLoop.integration.test.ts
@@ -43,6 +43,7 @@ describe("PlanDelegateObserveLoop integration", () => {
 				headed: false,
 				verbosity: 0,
 				safeMode: true,
+				automaticThinkingEnabled: false,
 				humanStealth: 0,
 				fidgetEnabled: false,
 				adaptiveStealthEnabled: false,


### PR DESCRIPTION
## Summary

Run browser-backed loop integration coverage with deterministic Talox settings so CI measures orchestration/controller behavior instead of intentional human-simulation delays.

## Changes

- enable `safeMode` and disable automatic thinking/human simulation in `AutonomousLoop.integration.test.ts`
- disable the remaining automatic-thinking delay in the already-safe `PlanDelegateObserveLoop.integration.test.ts`
- keep real browser launches, real TaloxController/AgentCoordinator paths, real page-state collection, click/type/navigation behavior, and loop assertions unchanged

## Baseline

Latest clean CI run #611:
- `AutonomousLoop.integration.test.ts`: **60.87s**
- `PlanDelegateObserveLoop.integration.test.ts`: **11.65s**
- full loop shard: **74.30s**
- autonomous `click and type` case alone: **18.53s**

These suites test autonomous/coordinated loop mechanics on controlled local pages, not biomechanical stealth. Talox already exposes `safeMode` specifically for fast deterministic testing, while `automaticThinkingEnabled` remains a separate delay and must be disabled explicitly.