### PR TITLE
ci: isolate VisionGate in parallel browser shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,10 @@ jobs:
   # runtime. GitHub's Ubuntu runner already ships Chrome + Xvfb, so downloading a
   # separate ~300 MiB Playwright Chromium bundle in every shard only adds setup
   # latency for a fallback that normal CI does not use.
+  #
+  # VisionGate is intentionally isolated because OCR/visual comparison dominates
+  # the former root shard (~42.6s of ~55.3s test time). Running it in parallel keeps
+  # full coverage while removing that serial tax from the rest of the root tests.
   browser-shard:
     name: Browser Integration · ${{ matrix.group }}
     runs-on: ubuntu-latest
@@ -115,21 +119,31 @@ jobs:
           - group: root
             target: 'tests/core/*.test.ts'
             exclude: 'tests/core/error-paths.test.ts'
+            exclude2: 'tests/core/VisionGate.test.ts'
+          - group: vision
+            target: 'tests/core/VisionGate.test.ts'
+            exclude: ''
+            exclude2: ''
           - group: error-paths
             target: 'tests/core/error-paths.test.ts'
             exclude: ''
+            exclude2: ''
           - group: loop
             target: 'tests/core/loop/*.test.ts'
             exclude: ''
+            exclude2: ''
           - group: controller
             target: 'tests/core/controller/*.test.ts'
             exclude: ''
+            exclude2: ''
           - group: observe
             target: 'tests/core/observe/*.test.ts'
             exclude: ''
+            exclude2: ''
           - group: smart
             target: 'tests/core/smart/*.test.ts'
             exclude: ''
+            exclude2: ''
     steps:
       - uses: actions/checkout@v7
 
@@ -152,7 +166,9 @@ jobs:
       - name: Run browser integration shard
         shell: bash
         run: |
-          if [ -n "${{ matrix.exclude }}" ]; then
+          if [ -n "${{ matrix.exclude2 }}" ]; then
+            npx vitest run --config vitest.config.browser.ts ${{ matrix.target }} --exclude ${{ matrix.exclude }} --exclude ${{ matrix.exclude2 }}
+          elif [ -n "${{ matrix.exclude }}" ]; then
             npx vitest run --config vitest.config.browser.ts ${{ matrix.target }} --exclude ${{ matrix.exclude }}
           else
             npx vitest run --config vitest.config.browser.ts ${{ matrix.target }}


### PR DESCRIPTION
## Summary

Move `VisionGate.test.ts` out of the general root browser shard and run it as its own parallel matrix shard. No tests are removed or weakened.

## Why

CI #616 measured:
- root browser test phase: **55.30s**
- `VisionGate.test.ts`: **42.61s** (~77% of root)
- all remaining root tests together: roughly **8s** of test work plus runner/import overhead

Previous PR #54 already tested an attempt to speed up VisionGate itself and was correctly closed because the measured suite got slightly slower. Parallel isolation is therefore the lower-risk lever.

## Changes

- add a dedicated `vision` browser shard targeting `tests/core/VisionGate.test.ts`
- exclude VisionGate and error-paths from the remaining root glob
- support a second explicit exclusion in the shared shard command
- preserve the aggregate browser gate so every shard must still pass

Expected result: roughly 10–15 seconds lower browser-CI wall-clock time while retaining identical VisionGate coverage.