### PR TITLE
fix: make smart navigation resilient to continuously busy SPAs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export * from "./types/index.js";
  * These exports provide backwards compatibility for code using the old mode system.
  *
  * Migration guide:
- * - `mode: 'smart'` → Use `DEFAULT_SETTINGS` (smart is now the default)
+ * - `mode: 'smart'` → Use `DEFAULT_SETTINGS` plus `navigationWaitUntil: 'domcontentloaded'`
  * - `mode: 'debug'` → `{ verbosity: 3, headed: true, humanTakeoverEnabled: true }`
  * - `mode: 'speed'` → `{ mouseSpeed: 2.0, fidgetEnabled: false, stealthLevel: 'low' }`
  * - `mode: 'observe'` → `{ headed: true, verbosity: 2 }`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -44,14 +44,17 @@ export interface TaloxConfig {
 	};
 	/**
 	 * @deprecated Use `settings` instead. Legacy modes map to the new agent-first control model.
-	 * - 'smart' | 'adaptive' | 'stealth' | 'balanced' | 'qa' → DEFAULT_SETTINGS (high stealth, adaptive behavior)
+	 * - 'smart' | 'adaptive' | 'stealth' | 'balanced' | 'qa' → high-stealth adaptive settings
+	 *   with `navigationWaitUntil: 'domcontentloaded'` so continuously-busy SPAs do not stall.
 	 *   Note: 'stealth', 'balanced', 'qa' are deprecated aliases for 'smart'/'adaptive'.
 	 * - 'debug' → headed, verbosity 3, human takeover enabled
 	 * - 'speed' → fast mouse, low stealth, no fidget
 	 * - 'browse' → headed with human takeover for interactive browsing
 	 * - 'observe' → headed with full perception for observation
 	 *
-	 * Use `resolveLegacyMode()` to see the exact mapping.
+	 * Use `resolveLegacyMode()` to see the exact mapping. When migrating away from
+	 * `mode: 'smart'`, preserve `navigationWaitUntil: 'domcontentloaded'` unless you
+	 * intentionally want the stricter `networkidle` readiness contract.
 	 */
 	mode?: LegacyTaloxMode; // NOSONAR
 }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -112,9 +112,11 @@ export function resolveLegacyMode(mode: LegacyTaloxMode): Partial<TaloxSettings>
 		case "stealth":
 		case "balanced":
 		case "qa":
-			// High stealth, adaptive behavior, full perception - the "works everywhere" default
-			// Tradeoff: Uses bot-detection warmup delays and stealth randomness that may distort results.
-			// For testing your own app, prefer explicit settings with debug mode.
+			// High stealth, adaptive behavior, full perception - the "works everywhere" default.
+			// Modern SPAs frequently keep analytics/WebSocket/long-poll requests alive,
+			// so waiting for networkidle can turn a usable page into a navigation stall.
+			// Smart mode proceeds once the DOM is ready; callers can still explicitly
+			// request networkidle when their target genuinely has a stable idle state.
 			return {
 				mouseSpeed: 0.7,
 				stealthLevel: "high",
@@ -122,6 +124,7 @@ export function resolveLegacyMode(mode: LegacyTaloxMode): Partial<TaloxSettings>
 				humanStealth: 1,
 				fidgetEnabled: true,
 				verbosity: 0,
+				navigationWaitUntil: "domcontentloaded",
 			};
 
 		case "debug":

--- a/tests/core/controller/smart-navigation-readiness.test.ts
+++ b/tests/core/controller/smart-navigation-readiness.test.ts
@@ -26,6 +26,8 @@ describe("smart-mode navigation readiness", () => {
 <head><title>spa-ready</title></head>
 <body>
 	<h1>Ready while background network stays busy</h1>
+	<label for="email">Email</label>
+	<input id="email" name="email" type="email" />
 	<script>fetch('/hang').catch(() => {});</script>
 </body>
 </html>`);
@@ -59,7 +61,7 @@ describe("smart-mode navigation readiness", () => {
 		if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true });
 	});
 
-	it("returns usable page state without waiting for background network to become idle", async () => {
+	it("returns actionable page state without waiting for background network to become idle", async () => {
 		expect(talox.settings.navigationWaitUntil).toBe("domcontentloaded");
 
 		const startedAt = Date.now();
@@ -68,7 +70,7 @@ describe("smart-mode navigation readiness", () => {
 
 		expect(state.url).toContain(origin);
 		expect(state.title).toBe("spa-ready");
-		expect(state.nodes.length).toBeGreaterThan(0);
+		expect(state.nodes.some((node) => node.role === "textbox" || node.id === "#email")).toBe(true);
 		expect(elapsedMs).toBeLessThan(5_000);
 	});
 });

--- a/tests/core/controller/smart-navigation-readiness.test.ts
+++ b/tests/core/controller/smart-navigation-readiness.test.ts
@@ -68,7 +68,7 @@ describe("smart-mode navigation readiness", () => {
 
 		expect(state.url).toContain(origin);
 		expect(state.title).toBe("spa-ready");
-		expect(state.nodes.some((node) => node.name.includes("Ready while background network stays busy"))).toBe(true);
+		expect(state.nodes.length).toBeGreaterThan(0);
 		expect(elapsedMs).toBeLessThan(5_000);
 	});
 });

--- a/tests/core/controller/smart-navigation-readiness.test.ts
+++ b/tests/core/controller/smart-navigation-readiness.test.ts
@@ -1,0 +1,74 @@
+import http from "node:http";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { TaloxController } from "../../../src/core/controller/TaloxController.js";
+
+describe("smart-mode navigation readiness", () => {
+	let talox: TaloxController;
+	let profileDir: string;
+	let server: http.Server;
+	let origin: string;
+
+	beforeAll(async () => {
+		server = http.createServer((req, res) => {
+			if (req.url === "/hang") {
+				res.writeHead(200, { "content-type": "text/plain" });
+				res.write("connection intentionally left open");
+				return;
+			}
+
+			res.writeHead(200, { "content-type": "text/html" });
+			res.end(`<!doctype html>
+<html>
+<head><title>spa-ready</title></head>
+<body>
+	<h1>Ready while background network stays busy</h1>
+	<script>fetch('/hang').catch(() => {});</script>
+</body>
+</html>`);
+		});
+
+		await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+		const address = server.address() as AddressInfo;
+		origin = `http://127.0.0.1:${address.port}`;
+
+		profileDir = fs.mkdtempSync(path.join(os.tmpdir(), "talox-smart-navigation-"));
+		talox = new TaloxController(profileDir, {
+			mode: "smart",
+			settings: {
+				automaticThinkingEnabled: false,
+				humanStealth: 0,
+				fidgetEnabled: false,
+				safeMode: true,
+			},
+		});
+		await talox.launch("smart-navigation-readiness", "sandbox", "chromium");
+
+		// Consume first-navigation warmup outside the timed assertion. This test is
+		// specifically about completion semantics once a modern SPA starts loading.
+		await talox.navigate("about:blank");
+	});
+
+	afterAll(async () => {
+		await talox?.stop().catch(() => {});
+		server?.closeAllConnections();
+		await new Promise<void>((resolve) => server?.close(() => resolve()));
+		if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true });
+	});
+
+	it("returns usable page state without waiting for background network to become idle", async () => {
+		expect(talox.settings.navigationWaitUntil).toBe("domcontentloaded");
+
+		const startedAt = Date.now();
+		const state = await talox.navigate(origin);
+		const elapsedMs = Date.now() - startedAt;
+
+		expect(state.url).toContain(origin);
+		expect(state.title).toBe("spa-ready");
+		expect(state.nodes.some((node) => node.name.includes("Ready while background network stays busy"))).toBe(true);
+		expect(elapsedMs).toBeLessThan(5_000);
+	});
+});


### PR DESCRIPTION
## Summary

Make Talox's legacy `smart`/`adaptive` mode family proceed at `domcontentloaded` instead of waiting for `networkidle`, which can be unreachable on modern SPAs with analytics, WebSockets, long polling, or persistent background fetches.

## Why

The latest scheduled real-world run exposed the concrete failure mode on Reddit signup: homepage navigation succeeded, but `https://www.reddit.com/register` repeatedly stalled until the test timeout while later direct form interactions could still succeed. The runtime default remains `networkidle`; this PR narrows the behavior change to the legacy smart/adaptive aliases used for hostile real-world automation. Explicit `settings.navigationWaitUntil` still overrides the mode mapping.

## Changes

- map `smart`, `adaptive`, `stealth`, `balanced`, and `qa` to `navigationWaitUntil: "domcontentloaded"`
- leave `DEFAULT_SETTINGS.navigationWaitUntil` at `networkidle` for callers that do not use a legacy mode
- add a real-browser regression test with a local SPA that opens a fetch request which intentionally never completes
- require that fixture to return actionable textbox state within 5 seconds
- update the public migration guidance in `src/index.ts` and `src/types/config.ts` so removing the deprecated smart mode does not accidentally restore `networkidle`

## Evidence

The regression fixture is deliberately impossible to satisfy with `networkidle`: it opens a fetch response that never completes while the page already exposes a usable email input. The controller regression passes on CI with navigation plus actionable state returned in 1.857 seconds, validating the readiness contract without depending on Reddit being stable during PR CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smart and adaptive navigation so pages become ready after DOM content loads, without waiting for background network activity to finish.
  * Legacy modes now use more responsive navigation behavior, including when pages maintain ongoing connections.

* **Documentation**
  * Updated migration guidance and configuration documentation to explain the navigation behavior for legacy modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->