### PR TITLE
fix: align function-calling tools with the v9 controller API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Talox is a **local browser runtime** — agents work inside a real browser with 
 ```typescript
 import { TaloxController } from 'talox';
 
-const talox = new TaloxController({ settings: { verbosity: 0 } });  // v4 shorthand
+const talox = new TaloxController({ settings: { verbosity: 0 } });  // config-object shorthand
 
 // Agent does everything with full stealth — always on
 await talox.launch('my-agent', 'ops');
@@ -97,8 +97,9 @@ await talox.stop();
 ```
 
 ```typescript
-// Headed mode — shows browser with glow frame + fake cursor overlay
-const talox = new TaloxController({ headed: true });  // v4 shorthand
+// Headed mode — shows browser with glow frame + cursor overlay
+const talox = new TaloxController({ settings: { headed: true } });
+await talox.launch('my-agent', 'ops');
 
 // Human Takeover — agent pauses, human does a step (e.g., login, 2FA)
 await talox.requestHumanTakeover('Need 2FA code');
@@ -172,8 +173,8 @@ Talox keeps `playwright` and `playwright-core` on the same version. System Chrom
 ```typescript
 import { TaloxController } from 'talox';
 
-// v4: config object as first arg
-const talox = new TaloxController({ headless: true });
+// Config object as first arg. Headless is the default because settings.headed is false.
+const talox = new TaloxController();
 
 await talox.launch('my-agent', 'ops');
 
@@ -254,7 +255,11 @@ mcp2cli run talox-mcp -- talox_navigate --url https://example.com
 
 ### OpenAI function calling
 
-Talox can act as the backend for an OpenAI function-calling loop: the model decides when to ask Talox to navigate, click, or read state, and you just forward the structured result back into the prompt.
+Talox can act as the backend for an OpenAI function-calling loop. `getTaloxTools()` returns schemas that map directly to public `TaloxController` methods, so the model only sees arguments Talox can actually execute.
+
+The current function-tool surface is:
+
+`talox_navigate`, `talox_click`, `talox_type`, `talox_get_state`, `talox_describe_page`, `talox_get_intent_state`, `talox_screenshot`, `talox_scroll_to`, `talox_extract_table`, `talox_wait_for_load_state`, `talox_set_verbosity`, `talox_set_headed`, `talox_set_safe_mode`, `talox_verify_visual`, `talox_find_element`, and `talox_evaluate`.
 
 ```typescript
 import OpenAI from 'openai';
@@ -341,7 +346,7 @@ exporter.stdin.end();
 await talox.stop();
 ```
 
-Any local script that reads from stdin or a temporary file can pick apart `state.interactiveElements`, `state.bugs`, or `state.timings` before feeding the result back to another automation layer.
+Any local script that reads from stdin or a temporary file can pick apart `state.interactiveElements`, `state.bugs`, or `state.timing` before feeding the result back to another automation layer.
 
 ---
 
@@ -351,12 +356,12 @@ Any local script that reads from stdin or a temporary file can pick apart `state
 - **Everything always on** — HumanMouse, BotDetector, AdaptationEngine, browser-computed ARIA perception with geometry active by default, no mode required
 - **Agent overlay with human takeover** — visual layer shows agent working (cyan glow), human can pause and take control anytime
 - **Human-paced mouse movement** — HumanMouse generates Bezier curves with Fitts's Law timing, jitter, and biomechanical easing for realistic interaction
-- **Structured state contract** — every action returns a single JSON object: AX-Tree, interactive elements, console, network, bugs, screenshots
-- **Deep observability** — full AX-Tree snapshots, console capture, network failure tracking, layout bug detection, visual regression
+- **Structured state contract** — every action returns a single JSON object: ARIA nodes, interactive elements, console, network, bugs, screenshots
+- **Deep observability** — browser-computed ARIA snapshots, console capture, network failure tracking, layout bug detection, visual regression
 - **Resilient interaction** — self-healing selectors, semantic element resolution, challenge detection and adaptation
 - **Session artifacts** — interaction timeline, screenshots, event log, annotations, and bug summaries for debugging
 - **Policy-as-code** — YAML-based action restrictions per profile
-- **LLM-native API** — 14 function-calling tools compatible with OpenAI, Claude, and other LLM APIs
+- **LLM-native API** — 16 controller-aligned function-calling tools compatible with OpenAI, Claude, and other LLM APIs
 
 ---
 
@@ -367,7 +372,7 @@ v6.0.0 introduces a self-driving execution engine. `AutonomousLoop` runs a plan-
 ```typescript
 import { TaloxController, AutonomousLoop, LLMPlanner } from 'talox';
 
-const talox = new TaloxController({ headless: true });
+const talox = new TaloxController(); // headless by default
 await talox.launch('auto-agent', 'ops');
 
 const planner = new LLMPlanner({ apiKey: process.env.OPENAI_API_KEY });
@@ -421,7 +426,7 @@ When `settings.headed === true`, Talox automatically injects a visual overlay in
 
 ### Technical Details
 
-- All overlay elements carry `aria-hidden="true"` — invisible to agent's AX-tree
+- All overlay elements carry `aria-hidden="true"` — invisible to agent's ARIA state
 - Overlay is pure JavaScript, injected via `page.addInitScript()` (persists across navigations)
 - Node.js ↔ browser communication via `page.exposeFunction('__taloxBridge__', handler)` and `__taloxCmd__` dispatcher
 
@@ -429,7 +434,7 @@ When `settings.headed === true`, Talox automatically injects a visual overlay in
 
 ## The Smart Interaction Engine
 
-Smart mode runs the **Biomechanical Ghost Engine** — a mouse and keyboard system that produces human-paced, low-noise interaction patterns suited for fragile or complex real-world interfaces.
+Talox's interaction engine produces human-paced, low-noise interaction patterns suited for fragile or complex real-world interfaces.
 
 - **Fitts's Law** — movement speed scales naturally with target size and distance
 - **Quintic Easing** — natural burst-and-settle acceleration curves
@@ -447,14 +452,14 @@ This makes Talox significantly more reliable on real-world UIs that are sensitiv
 
 Talox provides maximum observability into what the agent sees, without interfering with it:
 
-- Full AX-Tree snapshot as agent-readable JSON
+- Browser-computed ARIA snapshot as agent-readable JSON
 - All interactive elements with bounding boxes
 - Console errors, warnings, and logs
 - Network failures and 4xx/5xx responses
 - Layout bug detection: overlaps, clipped elements, invisible CTAs
 - Visual regression via Pixelmatch + SSIM
 - OCR text extraction from screenshots (Tesseract.js)
-- AX-Tree structural diffing between states
+- Structural diffing between states
 - GhostVisualizer: overlays interaction paths on screenshots for replay
 - Runtime verbosity control via `setVerbosity(0-3)` for pulling debug data on demand
 - `getDebugSnapshot()` returns current state + recent events at any time
@@ -468,14 +473,14 @@ Talox provides maximum observability into what the agent sees, without interferi
 │                      TaloxController                         │
 │  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐ │
 │  │ BrowserManager│  │  HumanMouse  │  │ PageStateCollector │ │
-│  │  (Playwright) │  │  Interaction │  │  AX-Tree + DOM     │ │
+│  │  (Playwright) │  │  Interaction │  │  ARIA + DOM        │ │
 │  └──────────────┘  └──────────────┘  └────────────────────┘ │
 │  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐ │
 │  │  VisionGate  │  │  RulesEngine │  │   PolicyEngine     │ │
 │  │  SSIM + OCR  │  │  Bug detect  │  │   YAML policies    │ │
 │  └──────────────┘  └──────────────┘  └────────────────────┘ │
 │  ┌──────────────┐  ┌──────────────────────────────────────┐  │
-│  │  TaloxTools  │  │         EventEmitter                │  │
+│  │  TaloxTools  │  │            EventBus                 │  │
 │  │  LLM Schema  │  │   (navigation, errors, bugs)        │  │
 │  └──────────────┘  └──────────────────────────────────────┘  │
 └──────────────────────────────────────────────────────────────┘
@@ -487,24 +492,24 @@ Talox provides maximum observability into what the agent sees, without interferi
        Selector
 ```
 
-As of v1.2.0, `TaloxController` is a thin orchestrator delegating to `EventBus`, `ModeManager`, `ActionExecutor`, and `SessionManager`. See `docs/TALOX-ARCHITECTURE.md` for the full module map.
+`TaloxController` is a thin orchestrator delegating browser lifecycle to `SessionManager`, interactions to `ActionExecutor`, events to `EventBus`, and adaptive behavior to `AdaptationEngine`. See `docs/TALOX-ARCHITECTURE.md` for the full module map.
 
 | Module | Role |
 | :--- | :--- |
-| `TaloxController` | Main orchestration API, mode/preset manager |
+| `TaloxController` | Public orchestration API and runtime settings coordinator |
 | `BrowserManager` | Playwright/Chromium lifecycle, persistent profiles |
-| `HumanMouse` | Biomechanical Ghost Engine |
-| `PageStateCollector` | AX-Tree + DOM harvester → agent-ready JSON |
+| `HumanMouse` | Biomechanical interaction engine |
+| `PageStateCollector` | ARIA + DOM harvester → agent-ready JSON |
 | `VisionGate` | Visual verification: SSIM, Pixelmatch, OCR, baseline vault |
 | `RulesEngine` | Layout bug detection via bounding box analysis |
-| `SemanticMapper` | Maps AX-Tree to semantic entities for intent-based interaction |
+| `SemanticMapper` | Maps page state to semantic entities for intent-based interaction |
 | `SelfHealingSelector` | Auto-rebuilds selectors when DOM changes |
 | `NetworkMocker` | Record / replay / mock network traffic |
-| `AXTreeDiffer` | Structural diff between AX-Tree snapshots |
+| `AXTreeDiffer` | Structural diff between page-state snapshots |
 | `GhostVisualizer` | Interaction path overlay for session replay and debugging |
 | `PolicyEngine` | YAML-based action restrictions per profile |
-| `TaloxTools` | LLM function calling schema for AI agents |
-| `EventEmitter` | Real-time notifications for navigation, errors, bugs |
+| `TaloxTools` | LLM function-calling schema aligned with controller methods |
+| `EventBus` | Typed runtime notifications for navigation, errors, bugs, and adaptation |
 
 ---
 
@@ -517,7 +522,6 @@ Every `navigate()` and `getState()` call returns a `TaloxPageState` — a single
   url: string;
   title: string;
   timestamp: string;
-  mode: TaloxMode;
 
   console: {
     errors: string[];
@@ -526,22 +530,34 @@ Every `navigate()` and `getState()` call returns a `TaloxPageState` — a single
   };
 
   network: {
-    failedRequests: Array<{ url: string; status: number }>;
+    failedRequests: Array<{ url: string; status: number; type?: string }>;
+    exceptions?: any[];
   };
 
-  axTree?: TaloxNode;          // full AX-Tree root
-  nodes: TaloxNode[];          // flat list of all AX nodes
-  interactiveElements: Array<{ // buttons, inputs, links with bounding boxes
+  nodes: TaloxNode[];
+  interactiveElements: Array<{
     id: string;
     tagName: string;
     role?: string;
     text?: string;
     boundingBox: { x: number; y: number; width: number; height: number };
     isActionable?: boolean;
+    cursorDetected?: boolean;
+    detectionMethod?: 'cursor-style' | 'onclick-attr' | 'tabindex';
+    trust?: 'first-party' | 'external';
   }>;
 
-  bugs: TaloxBug[];            // detected layout/JS/network issues
-  screenshots?: { fullPage?: string };
+  bugs: TaloxBug[];
+
+  axTree?: TaloxNode;
+  timing?: TaloxStateTiming;
+  diff?: TaloxStateDiff;
+  profileId?: string;
+  domainHints?: string[];
+  screenshots?: {
+    fullPage?: string;
+    crops?: Array<{ id: string; path: string; reason: string }>;
+  };
 }
 ```
 
@@ -554,13 +570,10 @@ JSON Schema: [`src/schema/TaloxPageState.schema.json`](./src/schema/TaloxPageSta
 ### LLM Function Schema
 
 ```typescript
-import { getTaloxTools, TaloxController } from 'talox';
+import { getTaloxTools } from 'talox';
 
 const tools = getTaloxTools();
-// Returns 14 tool definitions: navigate, click, type, get_state,
-// describe_page, get_intent_state, screenshot, scroll_to,
-// extract_table, wait_for_load_state, set_mode, verify_visual,
-// find_element, evaluate
+// Returns 16 controller-aligned tool definitions.
 ```
 
 ### Semantic Page Understanding
@@ -578,9 +591,9 @@ const intent = await talox.getIntentState();
 ### Event-Driven Workflows
 
 ```typescript
-talox.on('navigation', (event) => console.log('Navigated to:', event.data.url));
-talox.on('consoleError', (event) => console.log('Error:', event.data.error));
-talox.on('bugDetected', (event) => console.log('Bug:', event.data));
+talox.on('navigation', (event) => console.log('Navigated to:', event.url));
+talox.on('consoleError', (event) => console.log('Error:', event.error));
+talox.on('bugDetected', (bug) => console.log('Bug:', bug));
 ```
 
 ### Utility Methods
@@ -590,7 +603,7 @@ await talox.screenshot();
 await talox.screenshot({ selector: '#hero', path: 'hero.png' });
 await talox.scrollTo('#footer', 'center');
 const rows = await talox.extractTable('table.product-list');
-const title = await talox.evaluate(() => document.title);
+const title = await talox.evaluate<string>('document.title');
 const element = await talox.findElement('Submit', 'button');
 ```
 
@@ -614,11 +627,9 @@ Playwright's Chromium requires system dependencies that aren't present on a bare
 npx playwright install chromium --with-deps
 ```
 
-Talox defaults to `headless: true`, so no display server is needed. The required Chromium flags (`--no-sandbox`, `--disable-dev-shm-usage`) are set automatically.
+Talox defaults to `settings.headed: false`, so no display server is needed for ordinary headless use. On Linux without a display, Talox can also use Xvfb when `virtualDisplay` is enabled for a headed browser fingerprint. The required Chromium flags are managed by the runtime.
 
-All features work fully headless — including screenshots, visual diff (Pixelmatch/SSIM), OCR (Tesseract.js), and GhostVisualizer. None of these require a display; they operate on pixel buffers and pure JS.
-
-If you're on a low-memory VPS (< 1GB), set `PLAYWRIGHT_CHROMIUM_SANDBOX=0` as an environment variable as well.
+Screenshots, visual diff (Pixelmatch/SSIM), OCR (Tesseract.js), and GhostVisualizer operate on browser output and do not require a physical display.
 
 ---
 
@@ -638,7 +649,7 @@ talox.on('sessionEnd', ({ reportPath, interactionCount, annotationCount }) => {
   console.log(`${interactionCount} steps · ${annotationCount} issues found`);
 });
 
-// Headless session with overlay-driven annotations and session report
+// Headed observe session with overlay-driven annotations and session report
 await talox.launch('ai-test-run', 'qa', 'chromium', {
   output: 'both',
   outputDir: './test-sessions',
@@ -653,7 +664,7 @@ for (const bug of state.bugs) {
     window.__taloxEmit__('annotation:add', {
       interactionIndex: 1,
       labels: ['bug'],
-      comment: ${JSON.stringify(bug.message)},
+      comment: ${JSON.stringify(bug.description)},
       element: { tag: 'body', text: '' },
     });
   `);
@@ -704,15 +715,15 @@ This produces a Markdown report with every issue attached to the specific elemen
 
 | Feature | Detail |
 | :--- | :--- |
-| Engine | Playwright (Chromium, Firefox, WebKit) |
-| Interaction | Fitts's Law + Quintic easing + Bezier curves, synthetic mouse events (OS cursor stays still) |
-| Perception | AX-Tree + DOM + Console + Network → single JSON contract, always on |
-| Overlay | Agent glow frame, fake cursor trail, human takeover layer (when headed: true) |
-| Visual Diff | Pixelmatch (1px), SSIM, OCR (Tesseract.js) |
-| Verbosity | Runtime control via `setVerbosity(0-3)`, no modes |
-| LLM Tools | 14 function-calling tools for AI agents |
-| Events | navigation, stateChanged, consoleError, bugDetected, agentThinking, agentActing, cursorClicked |
-| Node.js | ≥ 18 |
+| Engine | Playwright / playwright-core (Chromium, Firefox, WebKit) |
+| Interaction | Fitts's Law + quintic easing + Bezier curves, synthetic mouse events |
+| Perception | Browser-computed ARIA + DOM + Console + Network → single JSON contract |
+| Overlay | Agent glow frame, cursor trail, human takeover layer when headed |
+| Visual Diff | Pixelmatch, SSIM, OCR (Tesseract.js) |
+| Verbosity | Runtime control via `setVerbosity(0-3)`, no mode switch required |
+| LLM Tools | 16 controller-aligned function-calling tools |
+| Events | Typed `EventBus` payloads for navigation, state, errors, bugs, adaptation, takeover, and loop activity |
+| Node.js | ≥ 20 |
 
 ---
 

--- a/src/core/TaloxTools.ts
+++ b/src/core/TaloxTools.ts
@@ -25,31 +25,27 @@ export interface TaloxToolSet {
 	version: string;
 }
 
+/**
+ * Return function-calling schemas that map directly to the public
+ * {@link TaloxController} API.
+ *
+ * Keep this surface deliberately boring: every advertised argument must be
+ * accepted by the corresponding controller method. Runtime behavior belongs
+ * in controller settings, not in phantom per-call options.
+ */
 export function getTaloxTools(): TaloxTool[] {
 	return [
 		{
 			type: "function",
 			function: {
 				name: "talox_navigate",
-				description:
-					"Navigate to a URL and get structured page state. Use adaptive mode for resilient human-paced interaction, debug mode for full observability.",
+				description: "Navigate to a URL and return Talox's structured page state.",
 				parameters: {
 					type: "object",
 					properties: {
 						url: {
 							type: "string",
 							description: "Target URL to navigate to",
-						},
-						mode: {
-							type: "string",
-							description:
-								"Browser mode: adaptive (resilient human-paced interaction), debug (full observability), speed (maximum throughput), balanced (default), browse (human-like), qa (testing)",
-							enum: ["adaptive", "stealth", "debug", "speed", "balanced", "browse", "qa"],
-						},
-						waitUntil: {
-							type: "string",
-							description: "When to consider navigation complete",
-							enum: ["load", "domcontentloaded", "networkidle", "commit"],
 						},
 					},
 					required: ["url"],
@@ -60,18 +56,13 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_click",
-				description:
-					"Click an element on the page using a CSS selector or accessible name. Uses human-like mouse movement.",
+				description: "Click an element using a CSS selector and return the resulting page state.",
 				parameters: {
 					type: "object",
 					properties: {
 						selector: {
 							type: "string",
-							description: "CSS selector or accessible name of element to click",
-						},
-						waitForNavigation: {
-							type: "boolean",
-							description: "Wait for navigation after click",
+							description: "CSS selector of the element to click",
 						},
 					},
 					required: ["selector"],
@@ -82,21 +73,17 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_type",
-				description: "Type text into an input field with human-like keystroke simulation.",
+				description: "Type text into an element using a CSS selector and return the resulting page state.",
 				parameters: {
 					type: "object",
 					properties: {
 						selector: {
 							type: "string",
-							description: "CSS selector of input field",
+							description: "CSS selector of the input element",
 						},
 						text: {
 							type: "string",
 							description: "Text to type",
-						},
-						clearFirst: {
-							type: "boolean",
-							description: "Clear existing text before typing",
 						},
 					},
 					required: ["selector", "text"],
@@ -107,15 +94,14 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_get_state",
-				description:
-					"Get current page state including AX-Tree, interactive elements, console logs, and network failures.",
+				description: "Get the current Talox page state at the requested detail level.",
 				parameters: {
 					type: "object",
 					properties: {
-						perceptionDepth: {
+						variant: {
 							type: "string",
-							description: "Depth of AX-Tree perception",
-							enum: ["shallow", "full"],
+							description: "State detail level. Omit for the full state.",
+							enum: ["full", "agent", "debug"],
 						},
 					},
 				},
@@ -125,8 +111,7 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_describe_page",
-				description:
-					"Get a human-readable description of the current page including structure, forms, and interactive elements.",
+				description: "Return a human-readable description of the current page.",
 				parameters: {
 					type: "object",
 					properties: {},
@@ -137,8 +122,7 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_get_intent_state",
-				description:
-					"Get compact intent-focused state: page type, primary action, inputs, and errors. Use for quick decision making.",
+				description: "Return compact intent-focused page state for quick agent decisions.",
 				parameters: {
 					type: "object",
 					properties: {},
@@ -155,11 +139,11 @@ export function getTaloxTools(): TaloxTool[] {
 					properties: {
 						selector: {
 							type: "string",
-							description: "Optional CSS selector to capture specific element",
+							description: "Optional CSS selector to capture a specific element",
 						},
 						path: {
 							type: "string",
-							description: "Optional path to save screenshot",
+							description: "Optional path to save the screenshot",
 						},
 					},
 				},
@@ -169,20 +153,21 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_scroll_to",
-				description: "Scroll an element into view with smooth scrolling.",
+				description: "Scroll an element into view.",
 				parameters: {
 					type: "object",
 					properties: {
 						selector: {
 							type: "string",
-							description: "CSS selector of element to scroll into view",
+							description: "CSS selector of the element to scroll into view",
 						},
 						align: {
 							type: "string",
-							description: "Alignment when scrolling",
+							description: "Alignment when scrolling. Defaults to center.",
 							enum: ["start", "center", "end", "nearest"],
 						},
 					},
+					required: ["selector"],
 				},
 			},
 		},
@@ -190,13 +175,13 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_extract_table",
-				description: "Extract table data as JSON array of objects.",
+				description: "Extract table data as an array of JSON objects.",
 				parameters: {
 					type: "object",
 					properties: {
 						selector: {
 							type: "string",
-							description: "CSS selector of table element",
+							description: "CSS selector of the table element",
 						},
 					},
 					required: ["selector"],
@@ -207,7 +192,7 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_wait_for_load_state",
-				description: "Wait for a specific page load state.",
+				description: "Wait for a specific browser load state.",
 				parameters: {
 					type: "object",
 					properties: {
@@ -218,7 +203,7 @@ export function getTaloxTools(): TaloxTool[] {
 						},
 						timeout: {
 							type: "number",
-							description: "Timeout in milliseconds (default 30000)",
+							description: "Timeout in milliseconds. Defaults to 30000.",
 						},
 					},
 					required: ["state"],
@@ -228,18 +213,51 @@ export function getTaloxTools(): TaloxTool[] {
 		{
 			type: "function",
 			function: {
-				name: "talox_set_mode",
-				description: "Switch between browser modes at runtime.",
+				name: "talox_set_verbosity",
+				description: "Set Talox runtime verbosity from 0 (quiet) to 3 (maximum diagnostics).",
 				parameters: {
 					type: "object",
 					properties: {
-						mode: {
-							type: "string",
-							description: "Target mode",
-							enum: ["adaptive", "stealth", "debug", "speed", "balanced", "browse", "qa"],
+						level: {
+							type: "number",
+							description: "Verbosity level: 0, 1, 2, or 3",
 						},
 					},
-					required: ["mode"],
+					required: ["level"],
+				},
+			},
+		},
+		{
+			type: "function",
+			function: {
+				name: "talox_set_headed",
+				description: "Switch the active Talox session between headed and headless browser mode.",
+				parameters: {
+					type: "object",
+					properties: {
+						headed: {
+							type: "boolean",
+							description: "True for headed mode, false for headless mode",
+						},
+					},
+					required: ["headed"],
+				},
+			},
+		},
+		{
+			type: "function",
+			function: {
+				name: "talox_set_safe_mode",
+				description: "Enable or disable deterministic safe mode for fast interactions without human simulation.",
+				parameters: {
+					type: "object",
+					properties: {
+						enabled: {
+							type: "boolean",
+							description: "Whether deterministic safe mode is enabled",
+						},
+					},
+					required: ["enabled"],
 				},
 			},
 		},
@@ -247,7 +265,7 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_verify_visual",
-				description: "Compare current page screenshot with a baseline for visual regression testing.",
+				description: "Compare the current page screenshot with a stored visual baseline.",
 				parameters: {
 					type: "object",
 					properties: {
@@ -257,7 +275,7 @@ export function getTaloxTools(): TaloxTool[] {
 						},
 						autoSave: {
 							type: "boolean",
-							description: "Auto-save current as baseline if no match found",
+							description: "Save the current screenshot as a baseline when one is missing",
 						},
 					},
 					required: ["baselineKey"],
@@ -268,7 +286,7 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_find_element",
-				description: "Find an element by text content or accessible name within the page.",
+				description: "Find an element by text content or accessible name.",
 				parameters: {
 					type: "object",
 					properties: {
@@ -278,7 +296,7 @@ export function getTaloxTools(): TaloxTool[] {
 						},
 						elementType: {
 							type: "string",
-							description: "Filter by element type",
+							description: "Optional element type filter",
 							enum: ["button", "link", "input", "checkbox", "radio", "menuitem", "any"],
 						},
 					},
@@ -290,13 +308,13 @@ export function getTaloxTools(): TaloxTool[] {
 			type: "function",
 			function: {
 				name: "talox_evaluate",
-				description: "Execute JavaScript code in the browser context and return the result.",
+				description: "Execute JavaScript source in the browser context and return the result.",
 				parameters: {
 					type: "object",
 					properties: {
 						script: {
 							type: "string",
-							description: "JavaScript code to execute",
+							description: "JavaScript source code to execute",
 						},
 					},
 					required: ["script"],
@@ -307,5 +325,5 @@ export function getTaloxTools(): TaloxTool[] {
 }
 
 export function getToolNames(): string[] {
-	return getTaloxTools().map((t) => t.function.name);
+	return getTaloxTools().map((tool) => tool.function.name);
 }

--- a/tests/unit/TaloxTools.test.ts
+++ b/tests/unit/TaloxTools.test.ts
@@ -1,104 +1,144 @@
 import { describe, expect, it } from "vitest";
 import { getTaloxTools, getToolNames } from "../../src/core/TaloxTools";
 
+const EXPECTED_TOOL_NAMES = [
+	"talox_navigate",
+	"talox_click",
+	"talox_type",
+	"talox_get_state",
+	"talox_describe_page",
+	"talox_get_intent_state",
+	"talox_screenshot",
+	"talox_scroll_to",
+	"talox_extract_table",
+	"talox_wait_for_load_state",
+	"talox_set_verbosity",
+	"talox_set_headed",
+	"talox_set_safe_mode",
+	"talox_verify_visual",
+	"talox_find_element",
+	"talox_evaluate",
+] as const;
+
 describe("TaloxTools", () => {
 	describe("getTaloxTools", () => {
-		it("returns a non-empty array of tool definitions", () => {
+		it("returns the v9 controller-aligned tool surface", () => {
 			const tools = getTaloxTools();
-			expect(Array.isArray(tools)).toBe(true);
-			expect(tools.length).toBeGreaterThan(0);
+			expect(tools.map((tool) => tool.function.name)).toEqual(EXPECTED_TOOL_NAMES);
 		});
 
-		it('every tool has type "function"', () => {
-			const tools = getTaloxTools();
-			for (const tool of tools) {
+		it('every tool has type "function" and complete metadata', () => {
+			for (const tool of getTaloxTools()) {
 				expect(tool.type).toBe("function");
-			}
-		});
-
-		it("every tool has required function metadata", () => {
-			const tools = getTaloxTools();
-			for (const tool of tools) {
-				expect(tool.function).toBeDefined();
 				expect(typeof tool.function.name).toBe("string");
 				expect(typeof tool.function.description).toBe("string");
-				expect(tool.function.parameters).toBeDefined();
 				expect(tool.function.parameters.type).toBe("object");
 				expect(tool.function.parameters.properties).toBeDefined();
 			}
 		});
 
-		it("includes all expected tool names", () => {
+		it("does not advertise removed legacy mode controls", () => {
 			const tools = getTaloxTools();
-			const names = tools.map((t) => t.function.name);
-			const expected = [
-				"talox_navigate",
-				"talox_click",
-				"talox_type",
-				"talox_get_state",
-				"talox_describe_page",
-				"talox_get_intent_state",
-				"talox_screenshot",
-				"talox_scroll_to",
-				"talox_extract_table",
-				"talox_wait_for_load_state",
-				"talox_set_mode",
-				"talox_verify_visual",
-				"talox_find_element",
-				"talox_evaluate",
-			];
-			for (const name of expected) {
-				expect(names).toContain(name);
+			const names = tools.map((tool) => tool.function.name);
+			const navigate = tools.find((tool) => tool.function.name === "talox_navigate")!;
+
+			expect(names).not.toContain("talox_set_mode");
+			expect(navigate.function.parameters.properties).toEqual({
+				url: {
+					type: "string",
+					description: "Target URL to navigate to",
+				},
+			});
+		});
+
+		it("does not advertise phantom click/type arguments", () => {
+			const tools = getTaloxTools();
+			const click = tools.find((tool) => tool.function.name === "talox_click")!;
+			const type = tools.find((tool) => tool.function.name === "talox_type")!;
+
+			expect(Object.keys(click.function.parameters.properties)).toEqual(["selector"]);
+			expect(Object.keys(type.function.parameters.properties)).toEqual(["selector", "text"]);
+			expect(click.function.parameters.required).toEqual(["selector"]);
+			expect(type.function.parameters.required).toEqual(["selector", "text"]);
+		});
+
+		it("maps state detail to TaloxController.getState variants", () => {
+			const state = getTaloxTools().find((tool) => tool.function.name === "talox_get_state")!;
+			const variant = state.function.parameters.properties["variant"];
+
+			expect(variant.type).toBe("string");
+			expect(variant.enum).toEqual(["full", "agent", "debug"]);
+			expect(state.function.parameters.properties["perceptionDepth"]).toBeUndefined();
+		});
+
+		it("exposes current runtime controls instead of mode switching", () => {
+			const tools = getTaloxTools();
+			const verbosity = tools.find((tool) => tool.function.name === "talox_set_verbosity")!;
+			const headed = tools.find((tool) => tool.function.name === "talox_set_headed")!;
+			const safeMode = tools.find((tool) => tool.function.name === "talox_set_safe_mode")!;
+
+			expect(verbosity.function.parameters.properties["level"].type).toBe("number");
+			expect(verbosity.function.parameters.required).toEqual(["level"]);
+			expect(headed.function.parameters.properties["headed"].type).toBe("boolean");
+			expect(headed.function.parameters.required).toEqual(["headed"]);
+			expect(safeMode.function.parameters.properties["enabled"].type).toBe("boolean");
+			expect(safeMode.function.parameters.required).toEqual(["enabled"]);
+		});
+
+		it("keeps load-state and element-type enums aligned with controller methods", () => {
+			const tools = getTaloxTools();
+			const wait = tools.find((tool) => tool.function.name === "talox_wait_for_load_state")!;
+			const find = tools.find((tool) => tool.function.name === "talox_find_element")!;
+
+			expect(wait.function.parameters.properties["state"].enum).toEqual([
+				"load",
+				"domcontentloaded",
+				"networkidle",
+			]);
+			expect(find.function.parameters.properties["elementType"].enum).toEqual([
+				"button",
+				"link",
+				"input",
+				"checkbox",
+				"radio",
+				"menuitem",
+				"any",
+			]);
+		});
+
+		it("declares required arguments for direct controller calls", () => {
+			const tools = getTaloxTools();
+			const requiredByTool: Record<string, string[]> = {
+				talox_navigate: ["url"],
+				talox_click: ["selector"],
+				talox_type: ["selector", "text"],
+				talox_scroll_to: ["selector"],
+				talox_extract_table: ["selector"],
+				talox_wait_for_load_state: ["state"],
+				talox_set_verbosity: ["level"],
+				talox_set_headed: ["headed"],
+				talox_set_safe_mode: ["enabled"],
+				talox_verify_visual: ["baselineKey"],
+				talox_find_element: ["text"],
+				talox_evaluate: ["script"],
+			};
+
+			for (const [name, required] of Object.entries(requiredByTool)) {
+				const tool = tools.find((candidate) => candidate.function.name === name);
+				expect(tool?.function.parameters.required).toEqual(required);
 			}
 		});
 
-		it("tools with required fields declare them correctly", () => {
-			const tools = getTaloxTools();
-			const taloxNavigate = tools.find((t) => t.function.name === "talox_navigate");
-			expect(taloxNavigate?.function.parameters.required).toContain("url");
-
-			const taloxClick = tools.find((t) => t.function.name === "talox_click");
-			expect(taloxClick?.function.parameters.required).toContain("selector");
-
-			const taloxType = tools.find((t) => t.function.name === "talox_type");
-			expect(taloxType?.function.parameters.required).toContain("selector");
-			expect(taloxType?.function.parameters.required).toContain("text");
-		});
-
-		it("tools with enum parameters define the enum array", () => {
-			const tools = getTaloxTools();
-			const navigate = tools.find((t) => t.function.name === "talox_navigate")!;
-			const modeParam = navigate.function.parameters.properties["mode"];
-			expect(modeParam.enum).toBeDefined();
-			expect(modeParam.enum).toContain("adaptive");
-
-			const wait = tools.find((t) => t.function.name === "talox_wait_for_load_state")!;
-			const stateParam = wait.function.parameters.properties["state"];
-			expect(stateParam.enum).toBeDefined();
-			expect(stateParam.enum).toContain("networkidle");
-		});
-
-		it("returns new arrays on each call (no shared references)", () => {
-			const a = getTaloxTools();
-			const b = getTaloxTools();
-			expect(a).not.toBe(b);
+		it("returns new arrays on each call", () => {
+			const first = getTaloxTools();
+			const second = getTaloxTools();
+			expect(first).not.toBe(second);
 		});
 	});
 
 	describe("getToolNames", () => {
-		it("returns array of function name strings", () => {
-			const names = getToolNames();
-			expect(Array.isArray(names)).toBe(true);
-			for (const name of names) {
-				expect(typeof name).toBe("string");
-			}
-		});
-
-		it("matches the tools from getTaloxTools", () => {
-			const tools = getTaloxTools();
-			const names = getToolNames();
-			const toolNames = tools.map((t) => t.function.name);
-			expect(names).toEqual(toolNames);
+		it("matches getTaloxTools exactly", () => {
+			expect(getToolNames()).toEqual(EXPECTED_TOOL_NAMES);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Bring `getTaloxTools()` and the public README back into contract with the current v9 `TaloxController` API. The function-calling schema had survived multiple architecture generations and was still advertising removed modes plus arguments that the controller does not accept; the README repeated several of the same stale contracts.

## Broken contract found

The old function schema exposed several phantom controls:

- `talox_navigate.mode` even though `navigate()` accepts only `url`
- `talox_navigate.waitUntil` even though navigation readiness is a controller setting
- `talox_click.waitForNavigation` even though `click()` accepts only `selector`
- `talox_type.clearFirst` even though `type()` accepts only `selector, text`
- `talox_get_state.perceptionDepth` even though `getState()` uses `full | agent | debug` variants
- `talox_set_mode` even though the v2/v9 controller no longer exposes `setMode()`

The existing unit tests were locking those stale fields in place rather than checking them against the current controller surface.

The README also contained stale public examples including top-level `headed`/`headless` constructor options that are not part of `TaloxConfig`, an obsolete `mode` field in `TaloxPageState`, wrapped event payloads that do not match `TaloxEventMap`, a callback form for `evaluate()` despite the string-script API, `state.timings` instead of `state.timing`, and Node.js 18 despite the v9 Node 20+ baseline.

## Changes

- remove legacy mode switching and phantom per-call arguments
- map state detail to `getState('full' | 'agent' | 'debug')`
- expose current runtime controls that actually exist: `setVerbosity`, `setHeaded`, and `setSafeMode`
- keep screenshot, scrolling, visual verification, element lookup, evaluation, and load-state arguments aligned with their controller signatures
- expand the schema from 14 stale tools to 16 controller-aligned tools
- replace legacy-preservation unit tests with contract tests that explicitly reject removed arguments and mode controls
- align README constructor examples with `TaloxConfig.settings`
- update README function-tool list, state contract, event payloads, evaluation syntax, timing field, architecture terminology, and Node.js 20+ requirement

## Validation

CI #630 is green, including unit tests, typecheck, package smoke, every browser integration shard, and the browser aggregate gate. Docker #235 is also green. The README diff was manually checked after the contract update and is limited to the stale API/documentation sections rather than removing unrelated content.

## Why

Function-calling schemas and copy-paste README examples are API. An LLM or user receiving an argument that Talox silently cannot use is worse than a missing feature because they plan against capabilities that do not exist. This PR makes the public surface boring and truthful: every advertised operation maps directly to a public controller method.