### PR TITLE
docs: refresh the llm-facing v9 API contract

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -197,7 +197,7 @@ const talox = new TaloxController('./profiles', {
 });
 
 await talox.launch('agent-id', 'ops', 'chromium');
-await talox.requestHumanTakeover('Need 2FA code');
+await talox.requestHumanTakeover('2fa-required');
 // Human completes the step, then:
 talox.resumeAgent();
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -1,50 +1,66 @@
 # Talox
 
-> Stateful browser runtime for AI agents built on Playwright. Adaptive mode provides resilient, human-paced interaction for real-world web UIs. Debug mode gives full observability. Both modes return a single structured JSON contract.
+> Local-first, stateful browser runtime for AI agents built on Playwright. Talox provides persistent browser sessions, human-paced interaction, structured page state, resilient automation, and deep observability.
 
-Talox is designed to be consumed directly by AI agents. Every action returns a `TaloxPageState` — a structured JSON object containing the AX-Tree, interactive elements with bounding boxes, console output, network failures, and detected bugs. Agents do not need to parse HTML or interpret screenshots.
+This file is a compact agent-facing reference for the current v9 public API. Prefer the explicit settings model below. Legacy `mode` values still exist only as constructor compatibility aliases; do not plan new integrations around runtime mode switching.
 
-## Core Concept
-
-Agents interact with Talox through a single controller class (`TaloxController`). The controller manages browser lifecycle, profile persistence, mode switching, and returns structured state after every action.
+## Quick start
 
 ```typescript
 import { TaloxController } from 'talox';
 
-const talox = new TaloxController('./profiles');
-await talox.launch('agent-id', 'ops', 'adaptive');
+const talox = new TaloxController('./profiles', {
+  settings: { verbosity: 0 },
+});
+
+await talox.launch('agent-id', 'ops', 'chromium');
 const state = await talox.navigate('https://example.com');
-// state is a TaloxPageState — ready for agent consumption
+console.log(state.title);
 await talox.stop();
 ```
 
-## Modes
+`launch(profileId, profileClass, browserType?)` accepts profile classes `ops | qa | sandbox` and browser types such as `chromium`, `firefox`, or `webkit`. The third argument is a browser type, not a Talox mode.
 
-- `adaptive` — Biomechanical Ghost Engine: Fitts's Law, Bezier curves, variable typing cadence. Use for resilient interaction on fragile real-world UIs. (`stealth` is a backwards-compatible alias.)
-- `debug` — Full AX-Tree, all console/network data, layout bug detection. Use for diagnosis.
-- `balanced` — General-purpose agent tasks.
-- `speed` — Maximum throughput, no human simulation.
-- `browse` — Human-like browsing sessions.
-- `qa` — Testing and visual regression.
+## Runtime settings
 
-Switch modes at runtime: `await talox.setMode('debug')`
+Talox uses `TaloxSettings` rather than runtime mode switching. Common constructor settings:
 
-## TaloxPageState (the JSON contract)
+```typescript
+const talox = new TaloxController('./profiles', {
+  settings: {
+    headed: false,
+    verbosity: 0,
+    safeMode: false,
+    navigationWaitUntil: 'domcontentloaded',
+    contentSafety: 'warn',
+  },
+});
+```
 
-Every `navigate()` and `getState()` call returns this object. JSON Schema: `src/schema/TaloxPageState.schema.json`
+Useful runtime controls:
+
+```typescript
+talox.setVerbosity(2);
+await talox.setHeaded(true);
+talox.setSafeMode(true);
+```
+
+There is no current `talox.setMode()` API. Legacy constructor `mode` values are retained for backwards compatibility and are mapped to settings by `resolveLegacyMode()`.
+
+## TaloxPageState
+
+Every `navigate()`, `click()`, `type()`, and full `getState()` call returns Talox's structured page-state contract.
 
 ```typescript
 {
-  url: string;               // current page URL
-  title: string;             // page title
-  timestamp: string;         // ISO 8601
-  profileId?: string;        // active profile ID
-  mode: TaloxMode;           // active mode
+  url: string;
+  title: string;
+  timestamp: string;
 
   console: {
-    errors: string[];        // console.error() output
-    warnings?: string[];     // console.warn() output
-    logs?: string[];         // console.log() output
+    errors: string[];
+    warnings?: string[];
+    logs?: string[];
   };
 
   network: {
@@ -52,101 +68,151 @@ Every `navigate()` and `getState()` call returns this object. JSON Schema: `src/
     exceptions?: any[];
   };
 
-  axTree?: TaloxNode;        // full AX-Tree root (perceptionDepth: 'full' only)
-  nodes: TaloxNode[];        // flat list of all AX nodes
-
+  nodes: TaloxNode[];
   interactiveElements: Array<{
     id: string;
-    tagName: string;         // 'button', 'input', 'a', etc.
-    role?: string;           // ARIA role
-    text?: string;           // visible text
+    tagName: string;
+    role?: string;
+    text?: string;
     boundingBox: { x: number; y: number; width: number; height: number };
-    isActionable?: boolean;  // false if disabled/hidden
+    isActionable?: boolean;
+    cursorDetected?: boolean;
+    detectionMethod?: 'cursor-style' | 'onclick-attr' | 'tabindex';
+    trust?: 'first-party' | 'external';
   }>;
 
-  bugs: TaloxBug[];          // detected issues, empty = no bugs
-  screenshots?: { fullPage?: string; crops?: Array<...> };
+  bugs: TaloxBug[];
+
+  axTree?: TaloxNode;
+  timing?: TaloxStateTiming;
+  diff?: TaloxStateDiff;
+  profileId?: string;
+  domainHints?: string[];
+  screenshots?: {
+    fullPage?: string;
+    crops?: Array<{ id: string; path: string; reason: string }>;
+  };
 }
 ```
 
-## Key Actions
+The frozen v1 core fields are `url`, `title`, `timestamp`, `console`, `network`, `nodes`, `interactiveElements`, and `bugs`. Do not expect a `mode` field in `TaloxPageState`.
+
+For lower token usage, request compact state variants:
 
 ```typescript
-// Navigation
-const state = await talox.navigate(url);
-
-// Interaction — HumanMouse handles trajectory in adaptive/browse modes
-await talox.click({ selector: 'button#submit' });
-await talox.click({ x: 400, y: 300 });
-await talox.type({ text: 'hello', selector: 'input[name="q"]' });
-await talox.press({ key: 'Enter' });
-
-// State
-const state = await talox.getState();
-
-// Visual regression
-const diff = await talox.verifyVisual({ baselinePath: './baseline.png', threshold: 0.01 });
-
-// Mode switching
-await talox.setMode('debug');
-
-// Granular setting override
-talox.override('mouseSpeed', 0.5);
-
-// Multi-page
-await talox.openPage('https://other.com');
-await talox.switchPage(pageId);
+const agentState = await talox.getState('agent');
+const debugState = await talox.getState('debug');
+const fullState = await talox.getState('full');
 ```
 
-## Profile Classes
+## Core actions
 
-- `ops` — Persistent authenticated sessions, domain-restricted via policy YAML
-- `qa` — Full perception, visual regression, debugging
-- `sandbox` — Ephemeral, low-risk experimentation
+```typescript
+await talox.navigate('https://example.com');
+await talox.click('button#submit');
+await talox.type('input[name="q"]', 'hello');
 
-## perceptionDepth
+const state = await talox.getState('agent');
+const description = await talox.describePage();
+const intent = await talox.getIntentState();
 
-- `shallow` — Returns only `interactiveElements` (buttons, inputs, links). Minimal tokens.
-- `full` — Returns complete `nodes` array and `axTree` root. Use for deep analysis.
+await talox.scrollTo('#footer', 'center');
+const rows = await talox.extractTable('table.results');
+await talox.waitForLoadState('domcontentloaded', 30_000);
 
-Set via: `talox.override('perceptionDepth', 'shallow')`
+const element = await talox.findElement('Submit', 'button');
+const title = await talox.evaluate<string>('document.title');
 
-## Bug Types
-
-The Rules Engine automatically detects and returns these in `state.bugs`:
-
-- `JS_ERROR` — JavaScript exception thrown on page
-- `NETWORK_FAILURE` — 4xx/5xx HTTP response
-- `LAYOUT_OVERLAP` — Two elements with overlapping bounding boxes
-- `CLIPPED_ELEMENT` — Element overflows its container
-- `INVISIBLE_CTA` — Button/link that is not visible or pointer-events: none
-- `VISUAL_REGRESSION` — Pixel diff exceeds threshold vs baseline
-
-## Self-Healing Selectors
-
-If a selector fails (DOM changed), Talox automatically retries using a fallback chain: ID → text content → ARIA role → position. No agent intervention needed.
-
-## Policy-as-Code
-
-Restrict agent actions per profile using YAML:
-
-```yaml
-allowedDomains:
-  - example.com
-blockedActions:
-  - navigate:https://competitor.com
+await talox.screenshot();
+await talox.screenshot({ selector: '#hero', path: 'hero.png' });
 ```
 
-Load with: `await talox.loadPolicy('./policies/ops.yaml')`
+Selectors passed to `click()` and `type()` are strings. Do not pass object-shaped `{ selector: ... }` interaction arguments.
 
-## Files
+## Function-calling tools
 
-- `src/types/index.ts` — All TypeScript types
-- `src/schema/TaloxPageState.schema.json` — JSON Schema for TaloxPageState
-- `src/core/TaloxController.ts` — Main API
-- `docs/TALOX-CONTRACTS.md` — Full data model documentation
-- `docs/TALOX-SPEC.md` — Technical specification
-- `docs/TALOX-ARCHITECTURE.md` — System design with Mermaid diagrams
-- `examples/adaptive-controller.ts` — Adaptive session example
-- `examples/debug-controller.ts` — Debug/observability example
-- `examples/qa-flow.test.ts` — QA bug detection example
+`getTaloxTools()` returns 16 schemas aligned to public `TaloxController` methods:
+
+- `talox_navigate`
+- `talox_click`
+- `talox_type`
+- `talox_get_state`
+- `talox_describe_page`
+- `talox_get_intent_state`
+- `talox_screenshot`
+- `talox_scroll_to`
+- `talox_extract_table`
+- `talox_wait_for_load_state`
+- `talox_set_verbosity`
+- `talox_set_headed`
+- `talox_set_safe_mode`
+- `talox_verify_visual`
+- `talox_find_element`
+- `talox_evaluate`
+
+These schemas intentionally do not expose removed `set_mode` behavior or phantom per-call navigation/click/type options.
+
+## MCP
+
+Talox also provides a separate MCP stdio bridge. Its tool surface is intentionally smaller than `getTaloxTools()` and manages one persistent browser session through launch, navigate, click, type, state, screenshot, and stop operations. Do not assume the function-calling and MCP tool lists are identical.
+
+## Events
+
+Event handlers receive the typed payload directly, not an `{ data: ... }` wrapper.
+
+```typescript
+talox.on('navigation', (event) => console.log(event.url));
+talox.on('consoleError', (event) => console.log(event.error));
+talox.on('bugDetected', (bug) => console.log(bug.description));
+```
+
+## Profile classes
+
+- `ops` — persistent authenticated sessions and policy-controlled operations
+- `qa` — testing, visual verification, and debugging workflows
+- `sandbox` — low-risk experimentation
+
+## Navigation readiness
+
+The v9 default `navigationWaitUntil` is `domcontentloaded`. This is deliberate: modern SPAs may keep analytics, WebSocket, long-poll, or background fetch traffic alive indefinitely, making `networkidle` unreachable even when the UI is usable.
+
+Override it explicitly only when a target needs a stricter readiness contract:
+
+```typescript
+const talox = new TaloxController('./profiles', {
+  settings: { navigationWaitUntil: 'networkidle' },
+});
+```
+
+## Safety and takeover
+
+Content safety defaults to `warn`. Talox also supports human takeover and headed escalation for steps such as login, 2FA, CAPTCHA, policy blocks, or agent uncertainty.
+
+```typescript
+const talox = new TaloxController('./profiles', {
+  settings: {
+    headed: true,
+    humanTakeoverEnabled: true,
+  },
+});
+
+await talox.launch('agent-id', 'ops', 'chromium');
+await talox.requestHumanTakeover('Need 2FA code');
+// Human completes the step, then:
+talox.resumeAgent();
+```
+
+## Source of truth
+
+- `src/types/config.ts` — constructor configuration
+- `src/types/settings.ts` — runtime settings and defaults
+- `src/types/index.ts` — `TaloxPageState` and public data contracts
+- `src/types/events.ts` — typed event payloads
+- `src/core/controller/TaloxController.ts` — public controller API
+- `src/core/TaloxTools.ts` — function-calling schemas
+- `src/core/mcp/TaloxMcpServer.ts` — MCP tool surface
+- `src/schema/TaloxPageState.schema.json` — JSON Schema
+- `docs/TALOX-CONTRACTS.md` — contract documentation
+- `docs/TALOX-ARCHITECTURE.md` — architecture documentation
+
+Talox v9 requires Node.js 20+.


### PR DESCRIPTION
## Summary

Replace the stale `llms.txt` reference with a compact v9 agent-facing contract that matches the current public API.

## Why

`llms.txt` is explicitly meant to guide AI agents, but it still described an older Talox architecture. It told agents to:

- pass `adaptive` as the third `launch()` argument even though that position is `browserType`
- switch runtime modes with a nonexistent `setMode()` method
- expect a `mode` field in `TaloxPageState`
- call `click()` / `type()` with object-shaped arguments that current controller methods do not accept
- use obsolete `perceptionDepth: shallow`
- plan around old mode-specific interaction behavior

That makes the agent reference actively worse than having no reference, because models plan against capabilities and signatures that do not exist.

## Changes

- document the current `TaloxController` constructor and `launch(profileId, profileClass, browserType?)` contract
- describe explicit `TaloxSettings` as the modern configuration model and legacy modes only as compatibility aliases
- document current runtime controls: `setVerbosity`, `setHeaded`, and `setSafeMode`
- replace the stale state shape with the frozen `TaloxPageState` v1 contract plus current optional fields
- document compact `getState('agent' | 'debug' | 'full')` variants
- use current string-selector signatures for navigation and interaction
- list the 16 controller-aligned function-calling tools from PR #62
- distinguish the smaller MCP tool surface from `getTaloxTools()`
- fix typed event payload examples
- document the v9 `domcontentloaded` navigation default and why it is SPA-safe
- use the typed `2fa-required` takeover reason
- point agents at the actual source-of-truth files
- record the Node.js 20+ runtime baseline

## Scope

This PR intentionally updates only the LLM-facing reference. It does not add new runtime APIs or revive runtime mode switching.