### PR TITLE
fix: keep public examples aligned with the v9 API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      - name: Typecheck public examples
+        run: npm run typecheck:examples
+
   # ─── Unit tests — runs on every push / PR ────────────────────────────────────
   unit:
     name: Unit Tests

--- a/examples/adaptive-controller.ts
+++ b/examples/adaptive-controller.ts
@@ -1,10 +1,9 @@
 /**
  * Adaptive Session Example
  *
- * Demonstrates launching Talox in adaptive mode for resilient, human-paced
- * interaction on real-world web UIs. The Biomechanical Interaction Engine
- * handles all mouse/keyboard interactions with variable timing, Bezier curves,
- * and realistic keystroke cadence.
+ * Demonstrates Talox's modern settings-first model for resilient,
+ * human-paced interaction on real-world web UIs. The interaction engine
+ * handles mouse/keyboard timing, curved movement, and adaptive stealth.
  *
  * Use this pattern when:
  * - Interacting with complex or fragile real-world interfaces
@@ -14,12 +13,19 @@
 
 import { TaloxController } from 'talox';
 
-const talox = new TaloxController('./profiles');
+const talox = new TaloxController('./profiles', {
+  settings: {
+    adaptiveStealthEnabled: true,
+    stealthLevel: 'high',
+    humanStealth: 1,
+    navigationWaitUntil: 'domcontentloaded',
+  },
+});
 
-// Launch with an 'ops' profile (persistent, domain-restricted) in adaptive mode
-await talox.launch('my-agent', 'ops', 'adaptive');
+// The third launch argument is the browser engine, not a Talox mode.
+await talox.launch('my-agent', 'ops', 'chromium');
 
-// navigate() returns a TaloxPageState — the full structured JSON contract
+// navigate() returns the full TaloxPageState contract.
 const state = await talox.navigate('https://example.com');
 
 console.log('URL:', state.url);
@@ -27,14 +33,13 @@ console.log('Title:', state.title);
 console.log('Interactive elements:', state.interactiveElements.length);
 console.log('Bugs detected:', state.bugs.length);
 
-// Click by selector — HumanMouse handles the trajectory automatically
-await talox.click({ selector: 'a[href="/about"]' });
+// Example Domain contains a normal link, so this remains a runnable interaction.
+await talox.click('a');
 
-// Type with realistic keystroke timing and variable cadence
-await talox.type({ text: 'hello world', selector: 'input[name="search"]' });
+// Type uses the same string-selector API when a page contains an input:
+// await talox.type('input[name="search"]', 'hello world');
 
-// Get updated state after interaction
-const nextState = await talox.getState();
-console.log('AX-Tree nodes after interaction:', nextState.nodes.length);
+const nextState = await talox.getState('agent');
+console.log('Current URL after interaction:', nextState.url);
 
 await talox.stop();

--- a/examples/browser-lab.ts
+++ b/examples/browser-lab.ts
@@ -11,7 +11,6 @@ async function main() {
     settings: {
       ...PRESETS.observe,
       humanTakeoverEnabled: true,
-      overlay: true,
       autoHeadedEscalation: false,
       verbosity: 3,
       perceptionDepth: 'full',
@@ -19,7 +18,7 @@ async function main() {
   });
 
   try {
-    await talox.launch('browser-lab', 'sandbox', {
+    await talox.launch('browser-lab', 'sandbox', 'chromium', {
       headed: true,
       overlay: true,
       record: true,
@@ -45,7 +44,7 @@ async function main() {
     console.log('Markdown snapshot:', snapshot);
 
     const structured = await tools.extractVisibleStructuredContent();
-    console.log('Structured sections:', structured.sections.map((s) => s.heading).join(', '));
+    console.log('Structured sections:', structured.sections.map((section) => section.heading).join(', '));
   } finally {
     await talox.stop();
   }

--- a/examples/debug-controller.ts
+++ b/examples/debug-controller.ts
@@ -1,9 +1,8 @@
 /**
  * Debug Session Example
  *
- * Demonstrates launching Talox in debug mode for maximum observability.
- * Debug mode captures the full AX-Tree, all console output, network failures,
- * layout bugs, and visual diffs — without interfering with agent behavior.
+ * Demonstrates maximum runtime observability with the current settings-first
+ * Talox API. Verbosity is explicit; there is no runtime setMode() contract.
  *
  * Use this pattern when:
  * - Diagnosing why an agent action failed
@@ -13,45 +12,40 @@
 
 import { TaloxController } from 'talox';
 
-const talox = new TaloxController('./profiles');
+const talox = new TaloxController('./profiles', {
+  settings: {
+    verbosity: 3,
+    navigationWaitUntil: 'domcontentloaded',
+  },
+});
 
-// 'qa' profile gives full perception depth and visual regression support
-await talox.launch('debug-agent', 'qa', 'debug');
+await talox.launch('debug-agent', 'qa', 'chromium');
 
 const state = await talox.navigate('https://example.com');
 
-// Console output — errors, warnings, and logs are all captured
 console.log('Console errors:', state.console.errors);
 console.log('Console warnings:', state.console.warnings);
-
-// Network failures — any 4xx/5xx responses
 console.log('Failed requests:', state.network.failedRequests);
 
-// Layout bugs detected by the Rules Engine
 if (state.bugs.length > 0) {
-  state.bugs.forEach(bug => {
+  state.bugs.forEach((bug) => {
     console.log(`[${bug.severity}] ${bug.type}: ${bug.description}`);
   });
 }
 
-// Full AX-Tree is available in debug mode (perceptionDepth: 'full')
-console.log('AX-Tree root role:', state.axTree?.role);
+console.log('ARIA root role:', state.axTree?.role);
 console.log('Total nodes:', state.nodes.length);
 
-// Visual regression — compare against a saved baseline
-const diff = await talox.verifyVisual({
-  baselinePath: './baselines/example-home.png',
-  threshold: 0.01, // 1% pixel difference tolerance
-});
-console.log('Visual match:', diff.ssimScore > 0.99 ? 'PASS' : 'FAIL');
+// autoSave=true creates the baseline when it does not exist yet.
+const diff = await talox.verifyVisual('example-home', true);
+console.log('Visual match:', diff.isMatch ? 'PASS' : 'DIFF');
 console.log('SSIM score:', diff.ssimScore);
 
-// Switch to stealth for the actual agent action, then back to debug to verify
-await talox.setMode('stealth');
-await talox.click({ selector: 'a[href="/login"]' });
+// Runtime diagnostics are controlled explicitly rather than by mode switching.
+talox.setVerbosity(2);
+await talox.click('a');
 
-await talox.setMode('debug');
-const postClickState = await talox.getState();
+const postClickState = await talox.getState('debug');
 console.log('After click — URL:', postClickState.url);
 console.log('After click — bugs:', postClickState.bugs.length);
 

--- a/examples/gaming-ops-flow.test.ts
+++ b/examples/gaming-ops-flow.test.ts
@@ -1,51 +1,50 @@
-import { describe, it, expect } from 'vitest';
-import { TaloxController } from '../src/core/TaloxController.js';
+import { describe, expect, it } from 'vitest';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { TaloxController } from 'talox';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 describe('End-to-End Gaming/Ops Flow', () => {
-  it('should interact smoothly in Browse mode', async () => {
-    console.log("🎮 Starting Talox Gaming/Ops Flow...");
-    const controller = new TaloxController(path.join(__dirname, '../tests/temp-profiles'));
-    
+  it('interacts smoothly with human-paced settings', async () => {
+    console.log('🎮 Starting Talox Gaming/Ops Flow...');
+    const controller = new TaloxController(path.join(__dirname, '../tests/temp-profiles'), {
+      settings: {
+        humanStealth: 1,
+        fidgetEnabled: true,
+        navigationWaitUntil: 'domcontentloaded',
+      },
+    });
+
     try {
-        // 1. Launch in Browse mode (Biomechanical Ghost)
-        await controller.launch('gaming-session', 'sandbox', 'browse');
-        
-        // 2. Navigate to the clicker game
-        const localFile = `file://${path.resolve(__dirname, '../tests/manual/clicker.html')}`;
-        console.log(`🌐 Navigating to: ${localFile}`);
-        await controller.navigate(localFile);
-        
-        // 3. Play the game: Click the target 3 times
-        for (let i = 0; i < 3; i++) {
-            console.log(`🎯 Clicking target (Turn ${i+1})...`);
-            await controller.click('#target');
-        }
+      await controller.launch('gaming-session', 'sandbox', 'chromium');
 
-        // 4. Fill in the name
-        console.log(`⌨️ Typing name...`);
-        await controller.type('#nameInput', 'Agent Biomech');
+      const localFile = `file://${path.resolve(__dirname, '../tests/manual/clicker.html')}`;
+      console.log(`🌐 Navigating to: ${localFile}`);
+      await controller.navigate(localFile);
 
-        // 5. Verify score and greeting using evaluate
-        const score = await controller.evaluate<string>('document.querySelector("#score")?.textContent ?? ""');
-        const greeting = await controller.evaluate<string>('document.querySelector("#greeting")?.textContent ?? ""');
-        
-        console.log(`📈 Final Results: ${score}, ${greeting}`);
-        
-        expect(score).toContain('3');
-        expect(greeting).toContain('Agent Biomech');
+      for (let i = 0; i < 3; i++) {
+        console.log(`🎯 Clicking target (Turn ${i + 1})...`);
+        await controller.click('#target');
+      }
 
-        // 6. Clean up
-        await controller.stop();
-        console.log("\n✅ Gaming/Ops Flow Complete.");
-    } catch (error) {
-        console.error("❌ Gaming/Ops Flow Failed:", error);
-        await controller.stop();
-        throw error;
+      console.log('⌨️ Typing name...');
+      await controller.type('#nameInput', 'Agent Biomech');
+
+      const score = await controller.evaluate<string>('document.querySelector("#score")?.textContent ?? ""');
+      const greeting = await controller.evaluate<string>(
+        'document.querySelector("#greeting")?.textContent ?? ""',
+      );
+
+      console.log(`📈 Final Results: ${score}, ${greeting}`);
+
+      expect(score).toContain('3');
+      expect(greeting).toContain('Agent Biomech');
+
+      console.log('\n✅ Gaming/Ops Flow Complete.');
+    } finally {
+      await controller.stop();
     }
-  }, 120000);
+  }, 120_000);
 });

--- a/examples/minimal-agent.ts
+++ b/examples/minimal-agent.ts
@@ -16,10 +16,8 @@ const talox = new TaloxController('./profiles', {
   settings: { verbosity: 0 },
 });
 
-// Launch a persistent browser profile in ops mode
-await talox.launch('my-agent', 'ops');
+await talox.launch('my-agent', 'ops', 'chromium');
 
-// Navigate — returns a structured JSON state contract
 const state = await talox.navigate('https://example.com');
 
 console.log('URL:', state.url);
@@ -27,12 +25,11 @@ console.log('Title:', state.title);
 console.log('Interactive elements:', state.interactiveElements.length);
 console.log('Layout bugs detected:', state.bugs.length);
 
-// Interact — HumanMouse handles trajectory, timing, and stealth automatically
-// await talox.click('button[type=submit]');
-// await talox.type({ selector: 'input[name=q]', text: 'hello' });
+// Interactions use string selectors.
+// await talox.click('button[type="submit"]');
+// await talox.type('input[name="q"]', 'hello');
 
-// Pull full page state at any time
 const updated = await talox.getState();
-console.log('AX-Tree nodes:', updated.nodes.length);
+console.log('ARIA nodes:', updated.nodes.length);
 
 await talox.stop();

--- a/examples/observe-session.ts
+++ b/examples/observe-session.ts
@@ -1,20 +1,25 @@
 /**
  * @file observe-session.ts
- * @description Example: Observe mode — human drives the browser, agent watches.
+ * @description Example: human-driven observe session with structured reporting.
  *
  * Launch with:
- *   npx ts-node examples/observe-session.ts
+ *   npx tsx examples/observe-session.ts
  *
  * The browser opens. Browse normally. Right-click anywhere to access the Talox
- * overlay menu. Close the browser when done — the session report is written
- * automatically to ./talox-sessions/
+ * overlay menu. Close the browser when done; the session report is written to
+ * ./talox-sessions/.
  */
 
-import { TaloxController } from '../src/index.js';
+import { TaloxController } from 'talox';
 
-const talox = new TaloxController('./profiles');
-
-// ── Event listeners ───────────────────────────────────────────────────────────
+const talox = new TaloxController('./profiles', {
+  observe: true,
+  settings: {
+    headed: true,
+    verbosity: 2,
+    humanTakeoverEnabled: true,
+  },
+});
 
 talox.on('navigation', ({ url }) => {
   console.log(`[Talox] → ${url}`);
@@ -28,7 +33,7 @@ talox.on('annotationAdded', ({ entry, bufferSize }) => {
   const labels = entry.labels.join(', ') || 'unlabelled';
   console.log(
     `[Talox] Annotation #${bufferSize}: [${labels}] "${entry.comment}" ` +
-    `on <${entry.element.tag}> "${entry.element.text ?? ''}"`,
+      `on <${entry.element.tag}> "${entry.element.text ?? ''}"`,
   );
 });
 
@@ -50,15 +55,16 @@ talox.on('sessionEnd', ({ sessionId, reportPath, durationMs, interactionCount, a
   console.log('╚══════════════════════════════════════════╝');
 });
 
-// ── Launch ────────────────────────────────────────────────────────────────────
-
-await talox.launch('human-test', 'qa', 'observe', 'chromium', {
-  output:    'both',           // generates both JSON and Markdown reports
+await talox.launch('human-test', 'qa', 'chromium', {
+  headed: true,
+  overlay: true,
+  record: true,
+  output: 'both',
   outputDir: './talox-sessions',
 });
 
 console.log('');
-console.log('  🔍 Talox Observe Mode');
+console.log('  🔍 Talox Observe Session');
 console.log('  Browser is open. Browse normally.');
 console.log('  Right-click anywhere to access the Talox overlay:');
 console.log('    → Comment Mode  — annotate elements');

--- a/examples/qa-flow.test.ts
+++ b/examples/qa-flow.test.ts
@@ -3,46 +3,45 @@
  *
  * Demonstrates using Talox as a QA agent to detect layout bugs, JS errors,
  * and visual regressions on a page. Uses the built-in Rules Engine and
- * VisionGate to generate structured bug reports.
+ * structured page-state contract.
  *
  * Run with: npx vitest examples/qa-flow.test.ts
  */
 
-import { describe, it, expect } from 'vitest';
-import { TaloxController } from 'talox';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { TaloxController } from 'talox';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('QA Flow', () => {
-  it('detects bugs on a page and generates a report', async () => {
-    const talox = new TaloxController(path.join(__dirname, '../tests/temp-profiles'));
+  it('detects bugs on a page and generates structured state', async () => {
+    const talox = new TaloxController(path.join(__dirname, '../tests/temp-profiles'), {
+      settings: {
+        verbosity: 3,
+        safeMode: true,
+      },
+    });
 
     try {
-      // 'qa' profile + 'debug' mode = maximum perception
-      await talox.launch('qa-agent', 'qa', 'debug');
+      await talox.launch('qa-agent', 'qa', 'chromium');
 
-      // Navigate to the local buggy test page
       const pageUrl = `file://${path.resolve(__dirname, '../tests/manual/buggy.html')}`;
       const state = await talox.navigate(pageUrl);
 
       console.log(`Detected ${state.bugs.length} bugs:`);
-      state.bugs.forEach(bug => {
+      state.bugs.forEach((bug) => {
         console.log(`  [${bug.severity}] ${bug.type} — ${bug.description}`);
       });
 
-      // Verify the Rules Engine is working
       expect(state.bugs).toBeDefined();
       expect(Array.isArray(state.bugs)).toBe(true);
-
-      // Verify the page state contract is complete
       expect(state.url).toBeTruthy();
       expect(state.nodes).toBeDefined();
       expect(state.interactiveElements).toBeDefined();
       expect(state.console.errors).toBeDefined();
       expect(state.network.failedRequests).toBeDefined();
-
     } finally {
       await talox.stop();
     }

--- a/examples/stealth-test.ts
+++ b/examples/stealth-test.ts
@@ -1,56 +1,51 @@
 /**
  * Stealth Detection Test
  *
- * Runs Talox in adaptive mode against known bot-detection fingerprinting sites
- * and captures what signals are exposed. Compare screenshots against a plain
- * Playwright session to verify the Biomechanical Ghost Engine + stealth plugin
- * are doing their job.
- *
- * Sites tested:
- * - bot.sannysoft.com   — WebDriver flag, user agent, canvas, WebGL, plugins
- * - fingerprint.com/demo — commercial fingerprinting (FingerprintJS Pro)
- * - abrahamjuliot.github.io/creepjs — deep browser fingerprint analysis
+ * Runs Talox with explicit high-stealth settings against known browser
+ * fingerprinting sites and records observable detection signals.
  */
 
-import { TaloxController } from '../src/index.js';
+import { TaloxController } from 'talox';
 
 const SITES = [
-  { name: 'sannysoft',     url: 'https://bot.sannysoft.com' },
+  { name: 'sannysoft', url: 'https://bot.sannysoft.com' },
   { name: 'fingerprintjs', url: 'https://fingerprint.com/demo' },
-  { name: 'creepjs',       url: 'https://abrahamjuliot.github.io/creepjs' },
+  { name: 'creepjs', url: 'https://abrahamjuliot.github.io/creepjs' },
 ];
 
-const talox = new TaloxController('./test-profiles');
-await talox.launch('stealth-test', 'sandbox', 'adaptive');
+const talox = new TaloxController('./test-profiles', {
+  settings: {
+    stealthLevel: 'high',
+    adaptiveStealthEnabled: true,
+    humanStealth: 1,
+    navigationWaitUntil: 'domcontentloaded',
+  },
+});
+
+await talox.launch('stealth-test', 'sandbox', 'chromium');
 
 for (const site of SITES) {
   console.log(`\n── ${site.name}: ${site.url}`);
 
   const state = await talox.navigate(site.url);
 
-  // Let JS fingerprinting scripts finish
   await talox.waitForTimeout(4000);
-
-  // Screenshot for visual inspection
   await talox.screenshot({ path: `./test-profiles/${site.name}.png` });
 
-  // Check console for detection signals
   if (state.console.errors.length) {
     console.log('  Console errors:', state.console.errors);
   }
 
-  // Scan AX-tree for detection result text
-  const signals = state.nodes.filter(n =>
-    /bot|detected|pass|fail|webdriver|automation/i.test(n.name ?? '')
+  const signals = state.nodes.filter((node) =>
+    /bot|detected|pass|fail|webdriver|automation/i.test(node.name ?? ''),
   );
   if (signals.length) {
-    console.log('  Detection signals in AX-tree:');
-    signals.forEach(n => console.log(`    [${n.role}] ${n.name}`));
+    console.log('  Detection signals in ARIA state:');
+    signals.forEach((node) => console.log(`    [${node.role}] ${node.name}`));
   } else {
-    console.log('  No detection signals in AX-tree ✓');
+    console.log('  No detection signals in ARIA state ✓');
   }
 
-  // Human-readable page summary
   const description = await talox.describePage();
   console.log('  Page summary:', description.slice(0, 200));
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "lint": "biome check src tests",
     "lint:fix": "biome check --fix src tests",
     "format": "biome format --write src tests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:examples": "tsc --noEmit -p tsconfig.examples.json"
   },
   "keywords": [
     "browser-runtime",

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": ".",
+    "paths": {
+      "talox": ["./src/index.ts"]
+    }
+  },
+  "include": ["examples/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tsconfig.examples.json
+++ b/tsconfig.examples.json
@@ -8,6 +8,6 @@
       "talox": ["./src/index.ts"]
     }
   },
-  "include": ["examples/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "examples/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Repair every TypeScript example against the current v9 public API and add a permanent CI typecheck so copy-paste examples cannot silently drift away from `TaloxController` again.

## Root cause

The main `tsconfig.json` explicitly excludes `examples/`, so repository CI could stay completely green while public examples accumulated invalid API calls across architecture generations.

Confirmed stale examples included:

- legacy Talox modes passed into the third `launch()` argument, which is now `browserType`
- a full observe-options object passed into the browser-type position
- nonexistent runtime `setMode()` calls
- object-shaped `click({ selector })` / `type({ selector, text })` calls instead of string selectors
- obsolete visual-verification options
- invalid settings such as `overlay` inside `TaloxSettings`
- examples importing internal source paths instead of the public `talox` surface

## Changes

- modernize all eight TypeScript files under `examples/`
- use explicit settings and `chromium` as the launch browser type
- use current string-selector interaction methods
- update visual verification to `verifyVisual(baselineKey, autoSave)`
- normalize examples to import from `talox`
- add `tsconfig.examples.json` that resolves `talox` to `src/index.ts`, so examples are checked against public exports rather than private internals
- add `npm run typecheck:examples`
- run the examples typecheck in the normal `Lint & Typecheck` CI job on every PR/push

## Why

Examples are part of the public API experience. A README can be stale and confusing; a copy-paste TypeScript example that cannot compile is worse. This PR makes example correctness an enforced contract instead of a manual maintenance hope.