### PR TITLE
docs: align active source contracts with v9

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 /**
  * @file index.ts
- * @description Public exports for the Talox package (v4.0).
+ * @description Public exports for the Talox v9 package.
  *
- * All public APIs are re-exported from this file.
+ * All supported public APIs are re-exported from this file.
  */
 
 // ─── Multi-Agent Coordinator ───────────────────────────────────────────────
@@ -53,7 +53,7 @@ export { ChatSession } from "./core/chat/ChatSession.js";
 export type { AccelerationCurve, MovementStyle, TypingRhythm } from "./core/controller/ActionExecutor.js";
 export { EventBus } from "./core/controller/EventBus.js";
 export type { TakeoverReason, TakeoverState, TakeoverSummary } from "./core/controller/TakeoverBridge.js";
-// ─── Takeover Bridge (v2) ───────────────────────────────────────────────────
+// ─── Takeover Bridge ────────────────────────────────────────────────────────
 export { TakeoverBridge } from "./core/controller/TakeoverBridge.js";
 export type { AttentionFrame, DebugSnapshot } from "./core/controller/TaloxController.js";
 // ─── Core Controller ────────────────────────────────────────────────────────────
@@ -116,7 +116,7 @@ export type * from "./core/loop/types.js";
 export type { OriginHeaderConfig } from "./core/OriginHeaders.js";
 export { OriginHeaders } from "./core/OriginHeaders.js";
 export { AnnotationBuffer } from "./core/observe/AnnotationBuffer.js";
-// ─── Observe Mode ─────────────────────────────────────────────────────────────
+// ─── Observe Sessions ─────────────────────────────────────────────────────────
 export { ObserveSession } from "./core/observe/ObserveSession.js";
 export { SessionReporter } from "./core/observe/SessionReporter.js";
 export * from "./core/PageStateCollector.js";
@@ -154,7 +154,7 @@ export type { LoadedSkill, SkillManifest } from "./core/skills/SkillLoader.js";
 export { SkillLoader } from "./core/skills/SkillLoader.js";
 export { SkillWriter } from "./core/skills/SkillWriter.js";
 export type { AdaptationRecord } from "./core/smart/AdaptationEngine.js";
-// ─── Smart Mode (now always-on) ──────────────────────────────────────────────
+// ─── Adaptive Runtime (always on) ────────────────────────────────────────────
 export { AdaptationEngine } from "./core/smart/AdaptationEngine.js";
 export { BotDetector } from "./core/smart/BotDetector.js";
 export type { DomainMemorySnapshot, DomainRecord, StrategyScore } from "./core/smart/DomainMemory.js";
@@ -178,17 +178,17 @@ export {
 } from "./core/VisualReasoner.js";
 export { PRESETS, type PresetName } from "./presets.js";
 export { getPracticalTools } from "./tools/practical-tools.js";
-// ─── v2 Config & Settings ────────────────────────────────────────────────────
+// ─── Config & Settings ───────────────────────────────────────────────────────
 export type { TaloxConfig } from "./types/config.js";
-// ─── Types (v2) ──────────────────────────────────────────────────────────────
+// ─── Core Types ──────────────────────────────────────────────────────────────
 // TALOX_STATE_CONTRACT_VERSION, TaloxStateDiff, TaloxStateTiming, diffPageState
 // and all core types are exported via the wildcard below.
 export * from "./types/index.js";
 
-// ─── Legacy Mode Compatibility (v1 → v2) ─────────────────────────────────────
+// ─── Legacy Mode Compatibility ───────────────────────────────────────────────
 /**
- * @deprecated Legacy modes are deprecated in v2. Use `TaloxSettings` directly.
- * These exports provide backwards compatibility for code using the old mode system.
+ * @deprecated Legacy modes are compatibility aliases in v9. Use `TaloxSettings` directly.
+ * These exports remain available for code migrating from the old mode system.
  *
  * Migration guide:
  * - `mode: 'smart'` → Use `DEFAULT_SETTINGS` plus `navigationWaitUntil: 'domcontentloaded'`
@@ -212,7 +212,7 @@ export * from "./types/index.js";
  *   const settings = resolveLegacyMode(userInput);
  * }
  *
- * // See all valid modes
+ * // See all valid legacy aliases
  * console.log(LEGACY_MODE_VALUES); // ['smart', 'debug', 'speed', ...]
  * ```
  */

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -10,10 +10,10 @@ import type { AnnotationEntry } from "./annotation.js";
 import type { TaloxBug, TaloxPageState } from "./index.js";
 import type { TaloxSettings } from "./settings.js";
 
-// ─── Smart Mode: Adaptation ──────────────────────────────────────────────────
+// ─── Adaptive Runtime ────────────────────────────────────────────────────────
 
 /**
- * The reason `smart` mode triggered an adaptation.
+ * The reason Talox's always-on adaptation engine changed runtime behavior.
  * Semantically distinct from `bugDetected` — this describes Talox's own
  * internal self-adjustment, not a problem with the website.
  */
@@ -29,7 +29,7 @@ export type AdaptationReason =
 
 /**
  * Payload for the `adapted` event.
- * Emitted only in `smart` mode when the adaptation engine changes settings.
+ * Emitted when the always-on adaptation engine applies a settings change.
  */
 export interface AdaptedEvent {
 	/** What triggered the adaptation. */
@@ -42,11 +42,11 @@ export interface AdaptedEvent {
 	to: Partial<TaloxSettings>;
 }
 
-// ─── Observe Mode: Session ───────────────────────────────────────────────────
+// ─── Observe Session Events ──────────────────────────────────────────────────
 
 /**
  * Payload for the `sessionEnd` event.
- * Emitted only in `observe` mode when the human closes the browser or calls endSession().
+ * Emitted by an active observe session when it is finalized.
  */
 export interface SessionEndEvent {
 	/** UUID of the session that just ended. */
@@ -66,7 +66,7 @@ export interface SessionEndEvent {
 
 /**
  * Payload for the `annotationAdded` event.
- * Emitted only in `observe` mode when the human submits an annotation.
+ * Emitted by an active observe session when the human submits an annotation.
  */
 export interface AnnotationAddedEvent {
 	/** The annotation that was just added. */
@@ -77,7 +77,7 @@ export interface AnnotationAddedEvent {
 
 /**
  * Payload for the `annotationUndone` event.
- * Emitted only in `observe` mode when the human presses Ctrl/Cmd+Z.
+ * Emitted by an active observe session when the human presses Ctrl/Cmd+Z.
  */
 export interface AnnotationUndoneEvent {
 	/** The annotation that was removed. */
@@ -132,7 +132,7 @@ export interface TakeoverSummary {
  * @example
  * ```ts
  * talox.on('adapted', (e) => {
- *   console.log(`Smart mode adjusted: ${e.reason} → ${e.strategy}`)
+ *   console.log(`Talox adapted: ${e.reason} → ${e.strategy}`)
  * })
  *
  * talox.on('sessionEnd', (e) => {
@@ -141,69 +141,61 @@ export interface TakeoverSummary {
  * ```
  */
 export interface TaloxEventMap {
-	// ── Available in all modes ────────────────────────────────────────────────
+	// ── Core runtime ──────────────────────────────────────────────────────────
 	/** Fired after every page navigation (goto, link click, redirect). */
 	navigation: { url: string; title: string };
 	/** Fired for internal Talox errors (not website errors). */
 	error: { message: string; stack?: string };
-
-	// ── smart + speed + debug ─────────────────────────────────────────────────
-	/** Fired after every interaction that produces a new `TaloxPageState`. */
+	/** Fired when Talox publishes a new page-state snapshot. */
 	stateChanged: TaloxPageState;
 	/** Fired when a DOM element changes after an interaction. */
 	elementChanged: undefined;
 
-	// ── debug + observe ───────────────────────────────────────────────────────
-	/** Console error captured from the page. Silent in smart/speed modes. */
+	// ── Diagnostic telemetry ─────────────────────────────────────────────────
+	/** Console error captured from the page when diagnostic/observe telemetry is active. */
 	consoleError: { error: string; url: string };
-	/** Network request failure captured from the page. Silent in smart/speed modes. */
+	/** Network request failure surfaced by observation telemetry. */
 	networkError: { url: string; status: number; type?: string };
-
-	// ── debug only ────────────────────────────────────────────────────────────
-	/** Console warning from the page. Debug mode only. */
+	/** Typed channel for a captured console warning. */
 	consoleWarning: { warning: string; url: string };
-	/** Console log from the page. Debug mode only. */
+	/** Typed channel for a captured console log. */
 	consoleLog: { message: string; url: string };
-	/**
-	 * A layout/JS bug detected by the `RulesEngine`.
-	 * **Debug mode only** — in all other modes bugs are collected into
-	 * `TaloxPageState.bugs` silently without emitting this event.
-	 */
+	/** A layout/JS bug detected by the `RulesEngine` and surfaced through diagnostic telemetry. */
 	bugDetected: TaloxBug;
 
-	// ── smart only ────────────────────────────────────────────────────────────
+	// ── Adaptive runtime ──────────────────────────────────────────────────────
 	/**
-	 * Smart mode changed its own settings in response to an outcome.
-	 * NOT a website bug — this is Talox adjusting itself.
+	 * Talox changed runtime settings in response to an observed outcome.
+	 * NOT a website bug — this is the always-on adaptation loop adjusting itself.
 	 */
 	adapted: AdaptedEvent;
 
-	// ── observe only ─────────────────────────────────────────────────────────
+	// ── Observe session ───────────────────────────────────────────────────────
 	/** Human submitted an annotation via the overlay Comment Mode. */
 	annotationAdded: AnnotationAddedEvent;
 	/** Human pressed Ctrl/Cmd+Z — last annotation removed from buffer. */
 	annotationUndone: AnnotationUndoneEvent;
-	/** Browser closed or endSession() called — session report written to disk. */
+	/** Observe session finalized — session report written to disk. */
 	sessionEnd: SessionEndEvent;
 
-	// ── v2 events ─────────────────────────────────────────────────────────────
+	// ── Runtime controls & takeover ───────────────────────────────────────────
 	/** Fired when verbosity level is changed via `setVerbosity()`. */
 	verbosityChanged: { level: 0 | 1 | 2 | 3 };
 	/** Fired when human takeover is requested. */
 	humanTakeoverRequested: { reason?: string; timestamp: string };
 	/** Fired when agent resumes after human takeover. */
 	agentResumed: { reason: "timeout" | "manual"; summary?: TakeoverSummary };
-	/** Fired when Talox auto-escalates from headless to headed mode. */
+	/** Fired when Talox auto-escalates from headless to headed browser operation. */
 	headedEscalation: { reason: string; previousMode: "headless" | "headed" };
-	/** Fired when Talox returns to headless mode after headed escalation. */
+	/** Fired when Talox returns to headless browser operation after escalation. */
 	headlessRestored: { reason: string };
-	/** Fired when mouse moves - used to sync visual fake cursor. */
+	/** Fired when mouse coordinates are published for visual cursor synchronization. */
 	cursorMoved: { x: number; y: number };
-	/** Fired when agent is about to perform a mouse action - starts cursor movement animation. */
+	/** Fired when the agent is about to perform a mouse action. */
 	agentActing: undefined;
-	/** Fired when agent is waiting / reading / processing - cursor enters think state. */
+	/** Fired when the agent is waiting, reading, or processing. */
 	agentThinking: undefined;
-	/** Fired when a click happens at given coords - triggers ripple animation on fake cursor. */
+	/** Fired when a click happens at the given coordinates. */
 	cursorClicked: { x: number; y: number };
 
 	// ── Auto-dialog handling ─────────────────────────────────────────────────

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -3,11 +3,11 @@
  * @description TaloxSettings - the full settings surface, and DEFAULT_SETTINGS
  */
 
-// ─── Legacy Mode Compatibility (v1 → v2) ───────────────────────────────────────
+// ─── Legacy Mode Compatibility ────────────────────────────────────────────────
 
 /**
- * @deprecated Legacy modes are deprecated in v2. Use `TaloxSettings` directly.
- * Kept for backwards compatibility - these map to the new agent-first control model.
+ * @deprecated Legacy modes are compatibility aliases in v9. Use `TaloxSettings` directly.
+ * Kept for backwards compatibility; these map to the current settings-first control model.
  *
  * Deprecated aliases (map to 'smart'):
  * - 'stealth' — was alias for adaptive (max stealth)
@@ -27,7 +27,7 @@ export type LegacyTaloxMode =
 
 /**
  * All valid legacy mode values.
- * @deprecated Legacy modes are deprecated in v2.
+ * @deprecated Legacy modes are compatibility aliases in v9.
  * 'stealth', 'balanced', 'qa' are deprecated aliases for 'smart'.
  */
 export const LEGACY_MODE_VALUES: LegacyTaloxMode[] = [
@@ -45,7 +45,7 @@ export const LEGACY_MODE_VALUES: LegacyTaloxMode[] = [
 
 /**
  * Check if a value is a valid legacy mode.
- * @deprecated Legacy modes are deprecated in v2.
+ * @deprecated Legacy modes are compatibility aliases in v9.
  * @param value - The value to check
  * @returns True if value is a valid LegacyTaloxMode
  *
@@ -65,7 +65,7 @@ export function isLegacyMode(value: unknown): value is LegacyTaloxMode {
 }
 
 /**
- * Maps a legacy mode to the new agent-first settings.
+ * Maps a legacy mode to the current agent-first settings model.
  *
  * @deprecated Use `TaloxSettings` directly instead of modes.
  * @param mode - The legacy mode to convert
@@ -81,10 +81,10 @@ export function isLegacyMode(value: unknown): value is LegacyTaloxMode {
  *
  * Migration guide:
  * ```typescript
- * // v1 (legacy)
+ * // Legacy compatibility form
  * const talox = new TaloxController('./profiles', { mode: 'debug' });
  *
- * // v2 (explicit settings - recommended)
+ * // v9 settings-first form (recommended)
  * const talox = new TaloxController('./profiles', {
  *   settings: {
  *     verbosity: 3,
@@ -93,10 +93,10 @@ export function isLegacyMode(value: unknown): value is LegacyTaloxMode {
  *   }
  * });
  *
- * // v2 (backwards compatible - mode still works)
+ * // Legacy mode can still be combined with explicit overrides while migrating
  * const talox = new TaloxController('./profiles', {
- *   mode: 'debug',              // Legacy mode maps to settings
- *   settings: { mouseSpeed: 1.5 } // Additional overrides
+ *   mode: 'debug',
+ *   settings: { mouseSpeed: 1.5 }
  * });
  *
  * // Inspect what a mode maps to
@@ -115,7 +115,7 @@ export function resolveLegacyMode(mode: LegacyTaloxMode): Partial<TaloxSettings>
 			// High stealth, adaptive behavior, full perception - the "works everywhere" default.
 			// Modern SPAs frequently keep analytics/WebSocket/long-poll requests alive,
 			// so waiting for networkidle can turn a usable page into a navigation stall.
-			// Smart mode proceeds once the DOM is ready; callers can still explicitly
+			// Legacy smart-like aliases proceed once the DOM is ready; callers can still
 			// request networkidle when their target genuinely has a stable idle state.
 			return {
 				mouseSpeed: 0.7,
@@ -197,7 +197,7 @@ export interface TaloxSettings {
 	adaptiveStealthEnabled: boolean; // self-healing. Default: true
 	automaticThinkingEnabled: boolean; // Default: true
 
-	// Perception (always full in v2 — field kept for future use)
+	// Perception (the current public contract is always full; field retained for compatibility)
 	perceptionDepth: "full";
 
 	// Browser — managed automatically, but overrideable
@@ -260,23 +260,23 @@ export interface TaloxSettings {
 
 	/**
 	 * Use Xvfb virtual display on headless Linux so Chromium runs in headed
-	 * mode against a fake X server.  Headed Chromium has a real browser
+	 * mode against a fake X server. Headed Chromium has a real browser
 	 * fingerprint, making it significantly harder for bot-detection systems
 	 * to identify it as automated.
 	 *
-	 * - On Linux without a DISPLAY env var, defaults to true.
-	 * - On all other platforms (or when DISPLAY is set), defaults to false.
+	 * - On Linux without a DISPLAY env var, the runtime can enable this automatically.
+	 * - On all other platforms (or when DISPLAY is set), it remains disabled unless configured.
 	 * - Requires Xvfb to be installed (sudo apt install xvfb).
 	 *
-	 * @default true on Linux without DISPLAY, false otherwise
+	 * @default false in DEFAULT_SETTINGS
 	 */
 	virtualDisplay: boolean;
 
 	/**
 	 * Content safety level for prompt injection defense.
-	 * - `"off"` — page content passes through unchanged (currently default).
+	 * - `"off"` — page content passes through unchanged.
 	 * - `"warn"` — wraps scraped content in structural markers so the LLM
-	 *   knows it is external, untrusted data — never instructions.
+	 *   knows it is external, untrusted data — never instructions. This is the default.
 	 * - `"strict"` — warn + heuristic filtering of known injection patterns
 	 *   from element text, aria-labels, placeholders, and title attributes.
 	 * @default "warn"


### PR DESCRIPTION
## Summary

Align active TypeScript source comments and hover documentation with Talox v9's settings-first, always-on runtime model.

## Drift found

Several active source-of-truth files still described older architecture generations even after the public README, `llms.txt`, tools, and examples were updated:

- `src/index.ts` called the package exports `v4.0` and labelled current exports as v2-era APIs
- `TaloxSettings` still described legacy modes as the v2 model
- `contentSafety` claimed `off` was the current default even though `DEFAULT_SETTINGS.contentSafety` is `warn`
- `virtualDisplay` documentation claimed a Linux-dependent default while `DEFAULT_SETTINGS.virtualDisplay` is `false`
- `TaloxEventMap` described adaptation as `smart only` even though `AdaptationEngine` is an always-on outcome-feedback loop
- diagnostic event comments were organized around removed runtime modes instead of current telemetry/settings behavior

## Changes

- describe the package entrypoint as Talox v9 and remove stale v2/v4 labels from active exports
- describe legacy modes as compatibility aliases rather than the current operating model
- align `contentSafety`, `virtualDisplay`, and perception comments with actual defaults/contracts
- rename event documentation around adaptive runtime, diagnostic telemetry, observe sessions, and runtime controls
- document `adapted` as an always-on adaptation event rather than a smart-mode-only event
- keep runtime code and public types unchanged

## Scope

Documentation/JSDoc only. No runtime behavior, exports, event payload types, or default values are changed.