### PR TITLE
fix: keep MCP server metadata aligned with package version

### DIFF
--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -13,10 +13,12 @@ const packDir = join(workspace, "pack");
 const consumerDir = join(workspace, "consumer");
 
 function run(command, args, options = {}) {
+	const capture = options.capture === true;
 	return execFileSync(command, args, {
 		cwd: options.cwd ?? repoRoot,
 		encoding: "utf8",
-		stdio: options.capture ? ["ignore", "pipe", "inherit"] : "inherit",
+		stdio: capture ? [options.input === undefined ? "ignore" : "pipe", "pipe", "inherit"] : "inherit",
+		input: options.input,
 		env: process.env,
 	});
 }
@@ -48,6 +50,7 @@ try {
 				type: "module",
 				scripts: {
 					"smoke:cli": "talox --help",
+					"smoke:mcp": "talox mcp",
 					"smoke:types": "tsc --noEmit --strict --target ESNext --module NodeNext --moduleResolution NodeNext type-smoke.ts",
 				},
 				devDependencies: {
@@ -115,6 +118,25 @@ void publicSurface;
 	// still proving that the installed package generated a working `talox` bin.
 	const cliOutput = run(npmCommand, ["run", "--silent", "smoke:cli"], { cwd: consumerDir, capture: true });
 	assert(/talox/i.test(cliOutput), "Packed CLI smoke produced no Talox help output");
+
+	const discoverRequest = `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "server/discover" })}\n`;
+	const mcpOutput = run(npmCommand, ["run", "--silent", "smoke:mcp"], {
+		cwd: consumerDir,
+		capture: true,
+		input: discoverRequest,
+	});
+	const mcpLine = mcpOutput
+		.trim()
+		.split("\n")
+		.find((line) => line.trim().length > 0);
+	assert(mcpLine, "Packed MCP smoke produced no JSON-RPC response");
+	const mcpResponse = JSON.parse(mcpLine);
+	const mcpVersion = mcpResponse?.result?._meta?.["io.modelcontextprotocol/serverInfo"]?.version;
+	assert(
+		mcpVersion === packageJson.version,
+		`packed MCP server version mismatch: expected ${packageJson.version}, received ${String(mcpVersion)}`,
+	);
+	process.stdout.write(`Packed MCP metadata OK: talox@${mcpVersion}\n`);
 
 	const size = typeof artifact.size === "number" ? `${(artifact.size / 1024).toFixed(1)} kB` : "unknown";
 	const unpacked = typeof artifact.unpackedSize === "number" ? `${(artifact.unpackedSize / 1024 / 1024).toFixed(2)} MB` : "unknown";

--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -6,6 +6,7 @@
  * 2025 clients and the stateless 2026-07-28 discovery flow over stdio.
  */
 
+import { createRequire } from "node:module";
 import { createInterface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
 import type { ProfileClass } from "../../types/index.js";
@@ -15,7 +16,12 @@ import { TaloxController } from "../controller/TaloxController.js";
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
 const LEGACY_PROTOCOL_VERSION = "2025-11-25";
 const LEGACY_PROTOCOL_VERSIONS = new Set(["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]);
-const SERVER_INFO = { name: "talox", version: "8.1.0" } as const;
+const requireFromHere = createRequire(import.meta.url);
+const packageMetadata = requireFromHere("../../../package.json") as { version?: unknown };
+if (typeof packageMetadata.version !== "string" || packageMetadata.version.length === 0) {
+	throw new Error("Talox package metadata is missing a valid version.");
+}
+const SERVER_INFO = { name: "talox", version: packageMetadata.version } as const;
 const SERVER_INSTRUCTIONS =
 	"Use Talox tools to launch and control one persistent browser session. Launch before navigation or interaction, then stop when finished.";
 

--- a/tests/unit/TaloxMcpServer.test.ts
+++ b/tests/unit/TaloxMcpServer.test.ts
@@ -1,6 +1,10 @@
+import { readFileSync } from "node:fs";
 import { Readable, Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { TaloxMcpSession, TaloxMcpStdioServer, TALOX_MCP_TOOLS } from "../../src/core/mcp/TaloxMcpServer.js";
+
+const PACKAGE_VERSION = (JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf8")) as { version: string })
+	.version;
 
 class FakeController {
 	launchCalls: Array<[string, string, string | undefined]> = [];
@@ -52,7 +56,7 @@ function toolCall(id: number, name: string, args: Record<string, unknown> = {}) 
 }
 
 describe("TaloxMcpSession", () => {
-	it("advertises the modern 2026-07-28 MCP era", async () => {
+	it("advertises the modern 2026-07-28 MCP era with the package version", async () => {
 		const session = new TaloxMcpSession(() => new FakeController());
 		const response = await session.handle(request(1, "server/discover"));
 
@@ -65,12 +69,12 @@ describe("TaloxMcpSession", () => {
 				capabilities: { tools: { listChanged: false } },
 				ttlMs: 60_000,
 				cacheScope: "public",
-				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: PACKAGE_VERSION } },
 			},
 		});
 	});
 
-	it("keeps handshake-era compatibility for legacy MCP clients", async () => {
+	it("keeps handshake-era compatibility for legacy MCP clients and reports the package version", async () => {
 		const session = new TaloxMcpSession(() => new FakeController());
 		const initialized = await session.handle(
 			request(1, "initialize", {
@@ -81,7 +85,12 @@ describe("TaloxMcpSession", () => {
 		);
 		const tools = await session.handle(request(2, "tools/list"));
 
-		expect(initialized).toMatchObject({ result: { protocolVersion: "2025-06-18" } });
+		expect(initialized).toMatchObject({
+			result: {
+				protocolVersion: "2025-06-18",
+				serverInfo: { name: "talox", version: PACKAGE_VERSION },
+			},
+		});
 		expect(tools).toMatchObject({ result: { tools: TALOX_MCP_TOOLS } });
 		expect(JSON.stringify(tools)).not.toContain("ttlMs");
 	});
@@ -97,7 +106,7 @@ describe("TaloxMcpSession", () => {
 				resultType: "complete",
 				ttlMs: 60_000,
 				cacheScope: "public",
-				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: PACKAGE_VERSION } },
 			},
 		});
 	});
@@ -113,7 +122,7 @@ describe("TaloxMcpSession", () => {
 		expect(response).toMatchObject({
 			result: {
 				resultType: "complete",
-				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: "8.1.0" } },
+				_meta: { "io.modelcontextprotocol/serverInfo": { name: "talox", version: PACKAGE_VERSION } },
 			},
 		});
 	});


### PR DESCRIPTION
## Summary

Fix Talox MCP server metadata so installed v9 packages report the actual package version instead of the stale hard-coded `8.1.0` value.

## Broken contract

`src/core/mcp/TaloxMcpServer.ts` hard-coded:

```ts
{ name: "talox", version: "8.1.0" }
```

while `package.json` is `9.0.0`. That stale version is exposed to MCP clients through both legacy `initialize.serverInfo` and modern `io.modelcontextprotocol/serverInfo` metadata.

## Changes

- derive MCP `serverInfo.version` from the installed package's `package.json`
- fail fast if package metadata has no valid version
- update unit protocol tests to compare modern and legacy server metadata against the repository package version
- extend the packed-package smoke test to launch the installed `talox mcp` CLI, send a real `server/discover` JSON-RPC frame over stdin, and assert the returned MCP version matches the packed package version

## Why this approach

Changing `8.1.0` to `9.0.0` would repair today and fail again at a future release. Package metadata is already the release source of truth, so MCP now reads that source directly. The packed smoke additionally proves the relative metadata lookup still works after `npm pack` and installation into a clean consumer project.