### PR TITLE
fix: clean up BrowserManager after close failures

### DIFF
--- a/src/core/BrowserManager.ts
+++ b/src/core/BrowserManager.ts
@@ -266,11 +266,23 @@ export class BrowserManager {
 	}
 
 	async closeAll(): Promise<void> {
-		const results = await Promise.allSettled(Array.from(this.contexts).map((ctx) => ctx.close()));
-		this.contexts.clear();
-		this.context = null;
-		this.releasePersistentProfileOwnership();
-		this.stopXvfb();
+		const contexts = Array.from(this.contexts);
+		const results = await Promise.allSettled(contexts.map((ctx) => ctx.close()));
+
+		for (const [index, result] of results.entries()) {
+			if (result.status !== "fulfilled") continue;
+			const ctx = contexts[index];
+			if (!ctx) continue;
+			this.contexts.delete(ctx);
+			if (this.context === ctx) this.context = null;
+			if (this.profileOwnerContext === ctx) this.releasePersistentProfileOwnership();
+		}
+
+		if (this.contexts.size === 0) {
+			this.context = null;
+			if (this.ownedProfileDir !== null) this.releasePersistentProfileOwnership();
+			this.stopXvfb();
+		}
 
 		const failedClose = results.find((result) => result.status === "rejected");
 		if (failedClose?.status === "rejected") {

--- a/src/core/BrowserManager.ts
+++ b/src/core/BrowserManager.ts
@@ -265,13 +265,17 @@ export class BrowserManager {
 		this.stopXvfb();
 	}
 
-	async closeAll() {
-		const promises = Array.from(this.contexts).map((ctx) => ctx.close());
-		await Promise.all(promises);
+	async closeAll(): Promise<void> {
+		const results = await Promise.allSettled(Array.from(this.contexts).map((ctx) => ctx.close()));
 		this.contexts.clear();
 		this.context = null;
 		this.releasePersistentProfileOwnership();
 		this.stopXvfb();
+
+		const failedClose = results.find((result) => result.status === "rejected");
+		if (failedClose?.status === "rejected") {
+			throw failedClose.reason;
+		}
 	}
 
 	async detectBrowsers(): Promise<DetectedBrowser[]> {

--- a/tests/unit/BrowserManagerCloseAll.test.ts
+++ b/tests/unit/BrowserManagerCloseAll.test.ts
@@ -1,0 +1,31 @@
+import type { BrowserContext } from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
+import { BrowserManager } from "../../src/core/BrowserManager.js";
+
+describe("BrowserManager closeAll failure cleanup", () => {
+	it("cleans every tracked resource before surfacing a context close failure", async () => {
+		const manager = new BrowserManager();
+		const closeFailure = new Error("close failed");
+		const failingContext = { close: vi.fn().mockRejectedValue(closeFailure) } as unknown as BrowserContext;
+		const healthyContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+		const state = manager as unknown as {
+			contexts: Set<BrowserContext>;
+			context: BrowserContext | null;
+			releasePersistentProfileOwnership: () => void;
+		};
+		state.contexts.add(failingContext);
+		state.contexts.add(healthyContext);
+		state.context = failingContext;
+		const releaseOwnership = vi.spyOn(state, "releasePersistentProfileOwnership");
+		const stopXvfb = vi.spyOn(manager, "stopXvfb");
+
+		await expect(manager.closeAll()).rejects.toBe(closeFailure);
+
+		expect(failingContext.close).toHaveBeenCalledTimes(1);
+		expect(healthyContext.close).toHaveBeenCalledTimes(1);
+		expect(state.contexts.size).toBe(0);
+		expect(manager.getContext()).toBeNull();
+		expect(releaseOwnership).toHaveBeenCalledTimes(1);
+		expect(stopXvfb).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/BrowserManagerCloseAll.test.ts
+++ b/tests/unit/BrowserManagerCloseAll.test.ts
@@ -3,28 +3,46 @@ import { describe, expect, it, vi } from "vitest";
 import { BrowserManager } from "../../src/core/BrowserManager.js";
 
 describe("BrowserManager closeAll failure cleanup", () => {
-	it("cleans every tracked resource before surfacing a context close failure", async () => {
+	it("waits for every close and retains failed contexts for a safe retry", async () => {
 		const manager = new BrowserManager();
 		const closeFailure = new Error("close failed");
-		const failingContext = { close: vi.fn().mockRejectedValue(closeFailure) } as unknown as BrowserContext;
-		const healthyContext = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+		const failingClose = vi.fn().mockRejectedValueOnce(closeFailure).mockResolvedValue(undefined);
+		const healthyClose = vi.fn().mockResolvedValue(undefined);
+		const failingContext = { close: failingClose } as unknown as BrowserContext;
+		const healthyContext = { close: healthyClose } as unknown as BrowserContext;
 		const state = manager as unknown as {
 			contexts: Set<BrowserContext>;
 			context: BrowserContext | null;
+			ownedProfileDir: string | null;
+			profileOwnerContext: BrowserContext | null;
 			releasePersistentProfileOwnership: () => void;
 		};
 		state.contexts.add(failingContext);
 		state.contexts.add(healthyContext);
 		state.context = failingContext;
+		state.ownedProfileDir = "/tmp/talox-close-retry";
+		state.profileOwnerContext = failingContext;
 		const releaseOwnership = vi.spyOn(state, "releasePersistentProfileOwnership");
 		const stopXvfb = vi.spyOn(manager, "stopXvfb");
 
 		await expect(manager.closeAll()).rejects.toBe(closeFailure);
 
-		expect(failingContext.close).toHaveBeenCalledTimes(1);
-		expect(healthyContext.close).toHaveBeenCalledTimes(1);
+		expect(failingClose).toHaveBeenCalledTimes(1);
+		expect(healthyClose).toHaveBeenCalledTimes(1);
+		expect(state.contexts.has(failingContext)).toBe(true);
+		expect(state.contexts.has(healthyContext)).toBe(false);
+		expect(manager.getContext()).toBe(failingContext);
+		expect(state.ownedProfileDir).toBe("/tmp/talox-close-retry");
+		expect(releaseOwnership).not.toHaveBeenCalled();
+		expect(stopXvfb).not.toHaveBeenCalled();
+
+		await expect(manager.closeAll()).resolves.toBeUndefined();
+
+		expect(failingClose).toHaveBeenCalledTimes(2);
+		expect(healthyClose).toHaveBeenCalledTimes(1);
 		expect(state.contexts.size).toBe(0);
 		expect(manager.getContext()).toBeNull();
+		expect(state.ownedProfileDir).toBeNull();
 		expect(releaseOwnership).toHaveBeenCalledTimes(1);
 		expect(stopXvfb).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
## Summary

- wait for every tracked browser-context shutdown attempt even when one close rejects
- remove successfully closed contexts immediately while retaining failed contexts for a safe retry
- keep persistent-profile ownership and Xvfb alive while a failed context may still be active
- release profile/Xvfb resources once the final tracked context closes successfully
- add focused regression coverage for failure followed by successful retry

## Why

`closeAll()` previously used `Promise.all()`, so the first rejected close surfaced before Talox had finished accounting for the other shutdown attempts. This made partial shutdown state depend too heavily on close-event timing and provided no deterministic retry path for failed contexts.

The new behavior uses `Promise.allSettled()`, reconciles each context by outcome, and only performs final shared-resource teardown when no tracked contexts remain.

## Verification

- focused regression test in `tests/unit/BrowserManagerCloseAll.test.ts`
- regression covers mixed success/failure, retained ownership after failure, and a second successful retry
- branch is based on `main` commit `63e8c9a`
- full repository CI and Docker gates run on the PR
