### PR TITLE
fix: preserve nested BrowserManager config defaults

### DIFF
--- a/src/core/BrowserManager.ts
+++ b/src/core/BrowserManager.ts
@@ -46,6 +46,10 @@ export interface TaloxConfig {
 	settings: TaloxSettings;
 }
 
+export type TaloxConfigOverrides = {
+	[K in keyof TaloxConfig]?: Partial<TaloxConfig[K]>;
+};
+
 export const DEFAULT_CONFIG: TaloxConfig = {
 	browser: {
 		autoDetect: true,
@@ -106,6 +110,15 @@ export function getDefaultConfig(): TaloxConfig {
 
 export function resolveConfigDir(): string {
 	return process.cwd();
+}
+
+function mergeConfig(base: TaloxConfig, overrides?: TaloxConfigOverrides): TaloxConfig {
+	if (!overrides) return base;
+	return {
+		browser: { ...base.browser, ...overrides.browser },
+		profile: { ...base.profile, ...overrides.profile },
+		settings: { ...base.settings, ...overrides.settings },
+	};
 }
 
 /**
@@ -207,8 +220,8 @@ export class BrowserManager {
 	private xvfbProcess: ChildProcess | null = null;
 	private xvfbDisplay: string | null = null;
 
-	constructor(config?: Partial<TaloxConfig>) {
-		this.config = { ...getDefaultConfig(), ...config };
+	constructor(config?: TaloxConfigOverrides) {
+		this.config = mergeConfig(getDefaultConfig(), config);
 
 		// Auto-enable virtualDisplay on Linux without a real DISPLAY
 		if (this.config.settings.virtualDisplay === false && process.platform === "linux" && !process.env.DISPLAY) {
@@ -464,8 +477,8 @@ export class BrowserManager {
 		return this.config;
 	}
 
-	updateConfig(config: Partial<TaloxConfig>): void {
-		this.config = { ...this.config, ...config };
+	updateConfig(config: TaloxConfigOverrides): void {
+		this.config = mergeConfig(this.config, config);
 	}
 
 	private attachCloseHandler(ctx: BrowserContext): void {

--- a/tests/unit/BrowserManager.test.ts
+++ b/tests/unit/BrowserManager.test.ts
@@ -102,13 +102,13 @@ describe("BrowserManager", () => {
 
 		it("merges partial config overrides with defaults", () => {
 			const mgr = new BrowserManager({
-				browser: { headless: false, preferred: "firefox" } as any,
+				browser: { headless: false, preferred: "firefox" },
 			});
 			const config = mgr.getConfig();
 			expect(config.browser.headless).toBe(false);
 			expect(config.browser.preferred).toBe("firefox");
-			// Shallow merge: nested objects are replaced wholesale, so autoDetect is lost
-			expect(config.browser.autoDetect).toBeUndefined();
+			// Nested overrides preserve sibling defaults.
+			expect(config.browser.autoDetect).toBe(true);
 		});
 
 		it("does not register process handlers before owning cleanup resources", () => {

--- a/tests/unit/BrowserManagerConfigMerge.test.ts
+++ b/tests/unit/BrowserManagerConfigMerge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { BrowserManager, DEFAULT_CONFIG } from "../../src/core/BrowserManager.js";
+
+describe("BrowserManager nested config merging", () => {
+	it("preserves sibling defaults for nested constructor overrides", () => {
+		const manager = new BrowserManager({
+			browser: { headless: false },
+			profile: { defaultClass: "ops" },
+			settings: { verbosity: 2 },
+		});
+		const config = manager.getConfig();
+
+		expect(config.browser.headless).toBe(false);
+		expect(config.browser.autoDetect).toBe(DEFAULT_CONFIG.browser.autoDetect);
+		expect(config.browser.preferred).toBe(DEFAULT_CONFIG.browser.preferred);
+		expect(config.browser.chromiumSandbox).toBe(DEFAULT_CONFIG.browser.chromiumSandbox);
+		expect(config.profile.defaultClass).toBe("ops");
+		expect(config.profile.vaultDir).toBe(DEFAULT_CONFIG.profile.vaultDir);
+		expect(config.settings.verbosity).toBe(2);
+		expect(config.settings.mouseSpeed).toBe(DEFAULT_CONFIG.settings.mouseSpeed);
+	});
+
+	it("preserves existing nested values across updateConfig calls", () => {
+		const manager = new BrowserManager({
+			browser: { autoDetect: false, preferred: "firefox" },
+			settings: { mouseSpeed: 1.5, verbosity: 1 },
+		});
+
+		manager.updateConfig({
+			browser: { headless: false },
+			settings: { verbosity: 3 },
+		});
+
+		const config = manager.getConfig();
+		expect(config.browser.headless).toBe(false);
+		expect(config.browser.autoDetect).toBe(false);
+		expect(config.browser.preferred).toBe("firefox");
+		expect(config.browser.chromiumSandbox).toBe(DEFAULT_CONFIG.browser.chromiumSandbox);
+		expect(config.settings.verbosity).toBe(3);
+		expect(config.settings.mouseSpeed).toBe(1.5);
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
       'tests/unit/**/*.test.ts',
       'tests/core/**/*.test.ts',
     ],
+    // Keep generic browser-manager tests independent of the CI host's lack of a
+    // desktop session. Dedicated Xvfb tests explicitly unset DISPLAY when they
+    // verify Linux virtual-display auto-detection.
+    env: {
+      DISPLAY: ':99',
+    },
     // Long timeout to accommodate browser tests in tests/core/
     testTimeout: 120_000,
     hookTimeout: 120_000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,12 +6,6 @@ export default defineConfig({
       'tests/unit/**/*.test.ts',
       'tests/core/**/*.test.ts',
     ],
-    // Keep generic browser-manager tests independent of the CI host's lack of a
-    // desktop session. Dedicated Xvfb tests explicitly unset DISPLAY when they
-    // verify Linux virtual-display auto-detection.
-    env: {
-      DISPLAY: ':99',
-    },
     // Long timeout to accommodate browser tests in tests/core/
     testTimeout: 120_000,
     hookTimeout: 120_000,

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -6,6 +6,12 @@ export default defineConfig({
     include: [
       'tests/unit/**/*.test.ts',
     ],
+    // Keep generic BrowserManager unit tests independent of whether the CI host
+    // has a desktop session. Dedicated Xvfb tests explicitly unset DISPLAY when
+    // they verify Linux virtual-display auto-detection.
+    env: {
+      DISPLAY: ':99',
+    },
     testTimeout: 5_000,
     hookTimeout: 10_000,
     coverage: {


### PR DESCRIPTION
## Summary

- add a typed `TaloxConfigOverrides` contract so callers can provide partial nested `browser`, `profile`, and `settings` groups without casts
- merge those three config groups independently in both the constructor and `updateConfig()`
- preserve sibling defaults and previously configured nested values instead of replacing whole groups
- update the legacy unit expectation that encoded the old shallow-merge bug
- add focused constructor/update regression coverage
- isolate pure unit tests from the CI host's desktop state via `vitest.config.unit.ts`; dedicated Xvfb tests explicitly unset `DISPLAY` when they verify Linux virtual-display auto-detection

## Why

`Partial<TaloxConfig>` only made the top-level groups optional, while `BrowserManager` then shallow-merged those groups. A caller attempting `{ browser: { headless: false } }` either needed a cast or had to provide every browser field; at runtime a cast could silently erase `autoDetect`, `preferred`, `chromiumSandbox`, and similar defaults. The same failure mode applied to partial settings updates.

This keeps the merge intentionally one level deep: Talox merges the known config groups but does not recursively merge arbitrary nested values such as proxy objects or arrays.

The corrected merge also exposed a hidden unit-test assumption on Linux: those tests had accidentally depended on the shallow merge deleting `virtualDisplay:false`, thereby bypassing Talox's no-`DISPLAY` Xvfb auto-enable path. The unit harness now supplies a dummy display explicitly; Xvfb-specific tests continue to override/unset it themselves.

## Verification

- focused regression tests in `tests/unit/BrowserManagerConfigMerge.test.ts`
- existing BrowserManager config test now asserts sibling defaults survive nested overrides
- unit harness isolation lives in the actual unit-test config, `vitest.config.unit.ts`
- branch is based on current `main` commit `8d9e1ae`
- full repository CI and Docker gates run on the PR
