### PR TITLE
fix: await in-flight observe finalization

### DIFF
--- a/src/core/observe/ObserveSession.ts
+++ b/src/core/observe/ObserveSession.ts
@@ -68,7 +68,7 @@ export class ObserveSession {
 	private readonly options: Required<ObserveSessionOptions>;
 
 	private startUrl: string = "";
-	private finalised: boolean = false;
+	private finalizePromise: Promise<void> | null = null;
 	private readonly eventLog: EventLogEntry[] = [];
 	private readonly failureLog: FailureEntry[] = [];
 	private readonly diffLog: InteractionDiff[] = [];
@@ -245,7 +245,7 @@ export class ObserveSession {
 
 	/**
 	 * Explicitly end the session and write the report.
-	 * Safe to call multiple times — subsequent calls are no-ops.
+	 * Safe to call multiple times — subsequent calls await the same finalization.
 	 */
 	async endSession(): Promise<void> {
 		await this.finalize();
@@ -284,10 +284,14 @@ export class ObserveSession {
 
 	// ─── Private ─────────────────────────────────────────────────────────────────
 
-	private async finalize(): Promise<void> {
-		if (this.finalised) return;
-		this.finalised = true;
+	private finalize(): Promise<void> {
+		if (this.finalizePromise === null) {
+			this.finalizePromise = this.runFinalize();
+		}
+		return this.finalizePromise;
+	}
 
+	private async runFinalize(): Promise<void> {
 		const report = this.buildReport();
 		let reportPath: string = this.options.outputDir;
 		const extras: SessionReportExtras = {

--- a/tests/unit/ObserveSessionFinalizeRace.test.ts
+++ b/tests/unit/ObserveSessionFinalizeRace.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+import { ObserveSession } from "../../src/core/observe/ObserveSession.js";
+import type { TaloxEventMap } from "../../src/types/events.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("ObserveSession finalization race", () => {
+	it("makes an explicit end wait for finalization already started by browser close", async () => {
+		let closeHandler: (() => void) | undefined;
+		const page = {
+			url: vi.fn(() => "https://example.com"),
+			on: vi.fn(),
+			mainFrame: vi.fn(() => ({ url: () => "https://example.com" })),
+			screenshot: vi.fn(() => Promise.resolve(Buffer.from("fake"))),
+		};
+		const context = {
+			on: vi.fn((event: string, handler: () => void) => {
+				if (event === "close") closeHandler = handler;
+			}),
+			close: vi.fn(() => Promise.resolve()),
+		};
+		const eventBus = new EventBus<TaloxEventMap>();
+		const artifactBuilder = { toActionFrames: vi.fn(() => []) };
+		const session = new ObserveSession(page as any, context as any, eventBus, artifactBuilder as any, {
+			overlay: false,
+			record: true,
+		});
+		const write = deferred<{ json: string }>();
+		const reporterWrite = vi.fn(() => write.promise);
+		(session as any).reporter.write = reporterWrite;
+		const sessionEnd = vi.fn();
+		eventBus.on("sessionEnd", sessionEnd);
+
+		await session.start();
+		expect(closeHandler).toBeDefined();
+
+		closeHandler?.();
+		expect(reporterWrite).toHaveBeenCalledTimes(1);
+
+		let explicitEndResolved = false;
+		const explicitEnd = session.endSession().then(() => {
+			explicitEndResolved = true;
+		});
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(explicitEndResolved).toBe(false);
+		expect(sessionEnd).not.toHaveBeenCalled();
+		expect(reporterWrite).toHaveBeenCalledTimes(1);
+
+		write.resolve({ json: "/tmp/report.json" });
+		await explicitEnd;
+
+		expect(explicitEndResolved).toBe(true);
+		expect(sessionEnd).toHaveBeenCalledTimes(1);
+		expect(sessionEnd).toHaveBeenCalledWith(expect.objectContaining({ reportPath: "/tmp/report.json" }));
+
+		await session.endSession();
+		expect(reporterWrite).toHaveBeenCalledTimes(1);
+		expect(sessionEnd).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- replace the eager `finalised` boolean guard with a shared in-flight `finalizePromise`
- make browser-close auto-finalization, overlay-driven finalization, and explicit `endSession()` await the same work
- preserve idempotency after finalization completes without allowing concurrent callers to return early
- add a deterministic regression test with a deliberately delayed report write

## Why

`ObserveSession.finalize()` previously set `finalised = true` before awaiting `reporter.write()`. If browser close started finalization and another caller immediately invoked `endSession()`, the second call saw `finalised === true` and returned even though the report was still being written and `sessionEnd` had not fired.

This is observable from `SessionManager.stop()`, which closes browser contexts and then awaits `observeSession.endSession()`: the browser close event can start finalization first, allowing `stop()` to resolve before observe evidence is fully persisted.

A shared promise turns finalization into a single-flight operation: the first caller starts it and every concurrent or later caller receives the same promise.

## Verification

- focused regression test in `tests/unit/ObserveSessionFinalizeRace.test.ts`
- test holds `reporter.write()` pending, triggers browser close, then calls `endSession()` and asserts it remains pending until report persistence completes
- verifies only one report write and one `sessionEnd` emission occur across concurrent and repeated finalization calls
- branch is based on current `main` commit `535af52`
- full repository CI and Docker gates requested via this PR
