### PR TITLE
fix: reconcile BrowserManager registry on close

### DIFF
--- a/src/core/BrowserManager.ts
+++ b/src/core/BrowserManager.ts
@@ -908,13 +908,20 @@ export class BrowserManager {
 		}
 	}
 
-	async close() {
-		if (this.context) {
-			await this.context.close();
-			this.context = null;
+	async close(): Promise<void> {
+		const ctx = this.context;
+		if (ctx) {
+			await ctx.close();
+			this.contexts.delete(ctx);
+			if (this.context === ctx) this.context = null;
+			if (this.profileOwnerContext === ctx) this.releasePersistentProfileOwnership();
+			this.unregisterProcessCleanupIfIdle();
 		}
-		this.releasePersistentProfileOwnership();
-		this.stopXvfb();
+
+		if (this.contexts.size === 0) {
+			if (this.ownedProfileDir !== null) this.releasePersistentProfileOwnership();
+			this.stopXvfb();
+		}
 	}
 
 	getContext(): BrowserContext | null {

--- a/tests/unit/BrowserManagerClose.test.ts
+++ b/tests/unit/BrowserManagerClose.test.ts
@@ -1,0 +1,66 @@
+import type { BrowserContext } from "playwright-core";
+import { describe, expect, it, vi } from "vitest";
+import { BrowserManager } from "../../src/core/BrowserManager.js";
+
+type BrowserManagerState = {
+	contexts: Set<BrowserContext>;
+	context: BrowserContext | null;
+	ownedProfileDir: string | null;
+	profileOwnerContext: BrowserContext | null;
+	releasePersistentProfileOwnership: () => void;
+};
+
+describe("BrowserManager close reconciliation", () => {
+	it("removes a successfully closed context even when no close event is emitted", async () => {
+		const manager = new BrowserManager();
+		const context = { close: vi.fn().mockResolvedValue(undefined) } as unknown as BrowserContext;
+		const state = manager as unknown as BrowserManagerState;
+		state.contexts.add(context);
+		state.context = context;
+		state.ownedProfileDir = "/tmp/talox-close-success";
+		state.profileOwnerContext = context;
+		const releaseOwnership = vi.spyOn(state, "releasePersistentProfileOwnership");
+		const stopXvfb = vi.spyOn(manager, "stopXvfb");
+
+		await manager.close();
+
+		expect(context.close).toHaveBeenCalledTimes(1);
+		expect(state.contexts.size).toBe(0);
+		expect(manager.getContext()).toBeNull();
+		expect(state.ownedProfileDir).toBeNull();
+		expect(releaseOwnership).toHaveBeenCalledTimes(1);
+		expect(stopXvfb).toHaveBeenCalledTimes(1);
+	});
+
+	it("retains a context and shared resources when close rejects so the close can be retried", async () => {
+		const manager = new BrowserManager();
+		const closeFailure = new Error("close failed");
+		const close = vi.fn().mockRejectedValueOnce(closeFailure).mockResolvedValue(undefined);
+		const context = { close } as unknown as BrowserContext;
+		const state = manager as unknown as BrowserManagerState;
+		state.contexts.add(context);
+		state.context = context;
+		state.ownedProfileDir = "/tmp/talox-close-retry";
+		state.profileOwnerContext = context;
+		const releaseOwnership = vi.spyOn(state, "releasePersistentProfileOwnership");
+		const stopXvfb = vi.spyOn(manager, "stopXvfb");
+
+		await expect(manager.close()).rejects.toBe(closeFailure);
+
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(state.contexts.has(context)).toBe(true);
+		expect(manager.getContext()).toBe(context);
+		expect(state.ownedProfileDir).toBe("/tmp/talox-close-retry");
+		expect(releaseOwnership).not.toHaveBeenCalled();
+		expect(stopXvfb).not.toHaveBeenCalled();
+
+		await expect(manager.close()).resolves.toBeUndefined();
+
+		expect(close).toHaveBeenCalledTimes(2);
+		expect(state.contexts.size).toBe(0);
+		expect(manager.getContext()).toBeNull();
+		expect(state.ownedProfileDir).toBeNull();
+		expect(releaseOwnership).toHaveBeenCalledTimes(1);
+		expect(stopXvfb).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- reconcile the explicitly closed context out of `BrowserManager`'s tracked context set after a successful `close()`
- keep the operation idempotent with the normal Playwright `close` event handler
- only tear down shared profile/Xvfb resources when no tracked contexts remain
- preserve the existing safe retry behavior when `context.close()` rejects
- add focused regression coverage for successful close without an emitted close event and reject-then-retry behavior

## Why

`BrowserManager.close()` previously set the public/current context reference to `null` after a successful `context.close()`, but it relied entirely on Playwright's separate `close` event callback to remove that context from the internal `contexts` registry. If that event is delayed or absent, a successfully closed context stays tracked and can keep the manager's process-cleanup registration alive unnecessarily.

The other lifecycle paths (`closeAll()` and relaunch cleanup) already reconcile successful closes explicitly. `close()` should have the same deterministic postcondition instead of depending on event timing.

A rejected close remains deliberately different: Talox keeps the context, profile ownership, and Xvfb state so the caller can safely retry instead of pretending an uncertain browser shutdown succeeded.

## Verification

- regression tests in `tests/unit/BrowserManagerClose.test.ts`
- successful close is verified to clear the registry even when the mock emits no close event
- failed close is verified to retain context/profile resources and then cleanly succeed on retry
- source diff is limited to the `close()` reconciliation path (+13/-6)
- branch is based on current `main` commit `d140eba`
- full repository CI and Docker gates requested via this PR
