### PR TITLE
fix: preserve MCP sessions across failed stops

### DIFF
--- a/src/core/mcp/TaloxMcpServer.ts
+++ b/src/core/mcp/TaloxMcpServer.ts
@@ -194,6 +194,7 @@ function requestedModernProtocol(params: unknown): boolean {
 export class TaloxMcpSession {
 	private readonly controllerFactory: McpControllerFactory;
 	private controller: McpController | null = null;
+	private stopInFlight: Promise<void> | null = null;
 	private era: ProtocolEra = "unknown";
 
 	constructor(controllerFactory: McpControllerFactory = defaultControllerFactory) {
@@ -254,10 +255,29 @@ export class TaloxMcpSession {
 	}
 
 	async close(): Promise<void> {
-		if (!this.controller) return;
+		await this.stopController();
+	}
+
+	private stopController(): Promise<void> {
+		if (this.stopInFlight) return this.stopInFlight;
 		const controller = this.controller;
-		this.controller = null;
-		await controller.stop();
+		if (!controller) return Promise.resolve();
+
+		const attempt = Promise.resolve()
+			.then(() => controller.stop())
+			.then(() => {
+				if (this.controller === controller) this.controller = null;
+			});
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
 	}
 
 	private handleNotification(request: JsonRpcRequest): null {
@@ -446,9 +466,7 @@ export class TaloxMcpSession {
 
 	private async stop(): Promise<ToolCallResult> {
 		if (!this.controller) return textResult({ stopped: false, reason: "no active session" });
-		const controller = this.controller;
-		this.controller = null;
-		await controller.stop();
+		await this.stopController();
 		return textResult({ stopped: true });
 	}
 

--- a/tests/unit/TaloxMcpStopRetry.test.ts
+++ b/tests/unit/TaloxMcpStopRetry.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaloxMcpSession } from "../../src/core/mcp/TaloxMcpServer.js";
+
+function request(id: number, method: string, params?: Record<string, unknown>) {
+	return { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+}
+
+function toolCall(id: number, name: string, args: Record<string, unknown> = {}) {
+	return request(id, "tools/call", { name, arguments: args });
+}
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+class RetryController {
+	stopCalls = 0;
+	stopFailures: Error[] = [];
+	stopImplementation: (() => Promise<void>) | null = null;
+
+	async launch() {}
+
+	async stop() {
+		this.stopCalls += 1;
+		if (this.stopImplementation) return this.stopImplementation();
+		const failure = this.stopFailures.shift();
+		if (failure) throw failure;
+	}
+
+	async navigate(url: string) {
+		return { url, title: "Example" };
+	}
+
+	async click() {
+		return { url: "https://example.com/clicked", title: "Clicked" };
+	}
+
+	async type() {
+		return { url: "https://example.com/form", title: "Form" };
+	}
+
+	async getState() {
+		return { url: "https://example.com", title: "Example", nodes: [] };
+	}
+
+	async screenshot() {
+		return Buffer.from("fake-png");
+	}
+}
+
+describe("TaloxMcpSession stop retry", () => {
+	it("retains the controller after a failed talox_stop so the session can be retried", async () => {
+		const controller = new RetryController();
+		controller.stopFailures.push(new Error("stop failed"));
+		const session = new TaloxMcpSession(() => controller);
+
+		await session.handle(toolCall(1, "talox_launch"));
+		const failedStop = await session.handle(toolCall(2, "talox_stop"));
+
+		expect(failedStop).toMatchObject({
+			result: {
+				isError: true,
+				content: [{ type: "text", text: "stop failed" }],
+			},
+		});
+		expect(controller.stopCalls).toBe(1);
+
+		const state = await session.handle(toolCall(3, "talox_state"));
+		expect(state).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining("Example") }] } });
+
+		const retryStop = await session.handle(toolCall(4, "talox_stop"));
+		expect(retryStop).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"stopped": true') }] } });
+		expect(controller.stopCalls).toBe(2);
+
+		const noActiveStop = await session.handle(toolCall(5, "talox_stop"));
+		expect(noActiveStop).toMatchObject({ result: { content: [{ type: "text", text: expect.stringContaining('"stopped": false') }] } });
+		expect(controller.stopCalls).toBe(2);
+	});
+
+	it("retains the controller when session.close fails and succeeds on a later close retry", async () => {
+		const controller = new RetryController();
+		controller.stopFailures.push(new Error("stop failed"));
+		const session = new TaloxMcpSession(() => controller);
+
+		await session.handle(toolCall(1, "talox_launch"));
+		await expect(session.close()).rejects.toThrow("stop failed");
+		expect(controller.stopCalls).toBe(1);
+
+		await expect(session.close()).resolves.toBeUndefined();
+		expect(controller.stopCalls).toBe(2);
+
+		await expect(session.close()).resolves.toBeUndefined();
+		expect(controller.stopCalls).toBe(2);
+	});
+
+	it("shares one in-flight controller stop across concurrent close calls", async () => {
+		const controller = new RetryController();
+		const pendingStop = deferred<void>();
+		controller.stopImplementation = vi.fn(() => pendingStop.promise);
+		const session = new TaloxMcpSession(() => controller);
+
+		await session.handle(toolCall(1, "talox_launch"));
+		const firstClose = session.close();
+		const secondClose = session.close();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(controller.stopCalls).toBe(1);
+		expect(controller.stopImplementation).toHaveBeenCalledTimes(1);
+
+		pendingStop.resolve();
+		await Promise.all([firstClose, secondClose]);
+
+		expect(controller.stopCalls).toBe(1);
+		await session.close();
+		expect(controller.stopCalls).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- keep the active MCP controller reference until `controller.stop()` actually succeeds
- make MCP shutdown single-flight so concurrent `talox_stop`, session `close()`, or stdio teardown share one stop attempt
- clear the in-flight marker after either success or failure so failed shutdowns remain retryable
- preserve the existing controller after a failed stop instead of reporting a false "no active session" state
- add focused regression coverage for tool-stop retry, session-close retry, and concurrent shutdown

## Why

`TaloxMcpSession.close()` and the `talox_stop` tool previously set `this.controller = null` before awaiting `controller.stop()`. If shutdown rejected, MCP lost its only reference to a potentially still-live Talox session. A second stop then reported no active session, making cleanup impossible through MCP.

Simply moving the assignment after the await would preserve retryability but leave concurrent stop calls able to invoke `controller.stop()` more than once. The new `stopController()` path is single-flight: the first caller owns the stop attempt, every concurrent caller awaits that same promise, and the controller is cleared only after success. Failure clears only the in-flight marker, leaving the controller available for retry.

## Verification

- `tests/unit/TaloxMcpStopRetry.test.ts`
- failed `talox_stop` returns a tool error while the controller remains usable, then a second stop succeeds
- failed `TaloxMcpSession.close()` rejects, then a later close retries and succeeds
- concurrent close calls share exactly one controller stop invocation
- source diff is limited to the MCP shutdown path (+24/-6)
- branch is based on current `main` commit `72fc519`
- full repository CI and Docker gates requested via this PR
