### PR TITLE
fix: preserve daemon sessions across failed shutdowns

### DIFF
--- a/src/core/daemon/TaloxDaemon.ts
+++ b/src/core/daemon/TaloxDaemon.ts
@@ -59,6 +59,7 @@ export class TaloxDaemon {
 	private readonly log = createLogger("Daemon");
 	private readonly config: DaemonConfig;
 	private readonly sessions: Map<string, SessionRecord> = new Map();
+	private readonly launchTasks: Set<Promise<void>> = new Set();
 	private readonly sessionStops: Map<string, Promise<void>> = new Map();
 	private server: net.Server | null = null;
 	private running = false;
@@ -133,6 +134,9 @@ export class TaloxDaemon {
 	}
 
 	private async runStop(): Promise<void> {
+		const launches = Array.from(this.launchTasks);
+		if (launches.length > 0) await Promise.allSettled(launches);
+
 		const sessions = Array.from(this.sessions.values());
 		const results = await Promise.allSettled(sessions.map((session) => this.stopSession(session)));
 		const failures: string[] = [];
@@ -318,26 +322,25 @@ export class TaloxDaemon {
 
 		const sessionId = generateSessionId();
 		const controller = new TaloxController(process.cwd());
+		const launchTask = Promise.resolve()
+			.then(() => controller.launch(profileId, profileClass, browserType))
+			.then(() => {
+				this.sessions.set(sessionId, {
+					id: sessionId,
+					controller,
+					createdAt: Date.now(),
+				});
+			});
+		this.launchTasks.add(launchTask);
 
 		try {
-			await controller.launch(profileId, profileClass, browserType);
+			await launchTask;
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			return { id: command.id, success: false, error: message };
+		} finally {
+			this.launchTasks.delete(launchTask);
 		}
-
-		if (this.stopInFlight) {
-			await controller.stop().catch((err: unknown) => {
-				this.log.error(`Cleanup after launch raced with daemon shutdown: ${err instanceof Error ? err.message : String(err)}`);
-			});
-			return { id: command.id, success: false, error: "Daemon is shutting down" };
-		}
-
-		this.sessions.set(sessionId, {
-			id: sessionId,
-			controller,
-			createdAt: Date.now(),
-		});
 
 		return { id: command.id, success: true, data: { sessionId } };
 	}

--- a/src/core/daemon/TaloxDaemon.ts
+++ b/src/core/daemon/TaloxDaemon.ts
@@ -59,8 +59,10 @@ export class TaloxDaemon {
 	private readonly log = createLogger("Daemon");
 	private readonly config: DaemonConfig;
 	private readonly sessions: Map<string, SessionRecord> = new Map();
+	private readonly sessionStops: Map<string, Promise<void>> = new Map();
 	private server: net.Server | null = null;
 	private running = false;
+	private stopInFlight: Promise<void> | null = null;
 	private startedAt: number | null = null;
 
 	constructor(config?: DaemonConfig) {
@@ -111,31 +113,78 @@ export class TaloxDaemon {
 
 	/**
 	 * Gracefully stop the daemon: close all sessions then shut down the server.
+	 * Failed session stops remain registered so a later stop can retry them.
 	 */
-	async stop(): Promise<void> {
-		if (!this.running || !this.server) {
-			return;
+	stop(): Promise<void> {
+		if (this.stopInFlight) return this.stopInFlight;
+		if (!this.running || !this.server) return Promise.resolve();
+
+		const attempt = this.runStop();
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runStop(): Promise<void> {
+		const sessions = Array.from(this.sessions.values());
+		const results = await Promise.allSettled(sessions.map((session) => this.stopSession(session)));
+		const failures: string[] = [];
+
+		for (const [index, result] of results.entries()) {
+			if (result.status === "fulfilled") continue;
+			const session = sessions[index];
+			if (!session) continue;
+			const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+			this.log.error(`Error stopping session ${session.id}: ${message}`);
+			failures.push(`${session.id}: ${message}`);
 		}
 
-		// Close all active sessions
-		const stopPromises: Promise<void>[] = [];
-		this.sessions.forEach((session) => {
-			stopPromises.push(
-				session.controller.stop().catch((err: Error) => {
-					this.log.error(`Error stopping session ${session.id}: ${err.message}`);
-				}),
-			);
-		});
-		await Promise.all(stopPromises);
-		this.sessions.clear();
+		if (failures.length > 0) {
+			throw new Error(`Failed to stop ${failures.length} daemon session(s): ${failures.join("; ")}`);
+		}
 
-		// Close the server
-		await new Promise<void>((resolve) => {
-			this.server!.close(() => resolve());
+		const server = this.server;
+		if (!server) {
+			this.running = false;
+			return;
+		}
+		await new Promise<void>((resolve, reject) => {
+			server.close((error?: Error) => {
+				if (error) reject(error);
+				else resolve();
+			});
 		});
 
+		if (this.server === server) this.server = null;
 		this.running = false;
-		this.server = null;
+	}
+
+	private stopSession(session: SessionRecord): Promise<void> {
+		const existing = this.sessionStops.get(session.id);
+		if (existing) return existing;
+
+		const attempt = Promise.resolve()
+			.then(() => session.controller.stop())
+			.then(() => {
+				if (this.sessions.get(session.id) === session) this.sessions.delete(session.id);
+			});
+		this.sessionStops.set(session.id, attempt);
+		attempt.then(
+			() => {
+				if (this.sessionStops.get(session.id) === attempt) this.sessionStops.delete(session.id);
+			},
+			() => {
+				if (this.sessionStops.get(session.id) === attempt) this.sessionStops.delete(session.id);
+			},
+		);
+		return attempt;
 	}
 
 	/**
@@ -240,6 +289,13 @@ export class TaloxDaemon {
 							error: `Session not found: ${sessionId}`,
 						};
 					}
+					if (this.sessionStops.has(sessionId)) {
+						return {
+							id: command.id,
+							success: false,
+							error: `Session is stopping: ${sessionId}`,
+						};
+					}
 					return await handleCommand(session.controller, command);
 				}
 			}
@@ -252,6 +308,10 @@ export class TaloxDaemon {
 	// ─── Daemon-Level Actions ───────────────────────────────────────────────
 
 	private async handleLaunch(command: DaemonCommand): Promise<DaemonResponse> {
+		if (this.stopInFlight) {
+			return { id: command.id, success: false, error: "Daemon is shutting down" };
+		}
+
 		const profileId = (command.params?.["profileId"] as string | undefined) ?? "daemon";
 		const profileClass = (command.params?.["profileClass"] as ProfileClass | undefined) ?? "ops";
 		const browserType = (command.params?.["browser"] as BrowserType | undefined) ?? "chromium";
@@ -264,6 +324,13 @@ export class TaloxDaemon {
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			return { id: command.id, success: false, error: message };
+		}
+
+		if (this.stopInFlight) {
+			await controller.stop().catch((err: unknown) => {
+				this.log.error(`Cleanup after launch raced with daemon shutdown: ${err instanceof Error ? err.message : String(err)}`);
+			});
+			return { id: command.id, success: false, error: "Daemon is shutting down" };
 		}
 
 		this.sessions.set(sessionId, {
@@ -294,13 +361,12 @@ export class TaloxDaemon {
 		}
 
 		try {
-			await session.controller.stop();
+			await this.stopSession(session);
 		} catch (err: unknown) {
 			const message = err instanceof Error ? err.message : String(err);
 			return { id: command.id, success: false, error: message };
 		}
 
-		this.sessions.delete(sessionId);
 		return { id: command.id, success: true, data: { stopped: sessionId } };
 	}
 

--- a/src/core/daemon/TaloxDaemon.ts
+++ b/src/core/daemon/TaloxDaemon.ts
@@ -276,6 +276,9 @@ export class TaloxDaemon {
 				case "health":
 					return this.handleHealth(command);
 				default: {
+					if (this.stopInFlight) {
+						return { id: command.id, success: false, error: "Daemon is shutting down" };
+					}
 					// Session-scoped actions
 					const sessionId = command.params?.["sessionId"];
 					if (typeof sessionId !== "string") {

--- a/tests/unit/TaloxDaemonStopRetry.test.ts
+++ b/tests/unit/TaloxDaemonStopRetry.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest";
+import type { DaemonCommand, DaemonResponse } from "../../src/core/daemon/TaloxDaemon.js";
+import { TaloxDaemon } from "../../src/core/daemon/TaloxDaemon.js";
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+type TestController = {
+	stop: ReturnType<typeof vi.fn>;
+};
+
+type TestSession = {
+	id: string;
+	controller: TestController;
+	createdAt: number;
+};
+
+type DaemonState = {
+	sessions: Map<string, TestSession>;
+	launchTasks: Set<Promise<void>>;
+	server: { close: ReturnType<typeof vi.fn> } | null;
+	running: boolean;
+	handleStop(command: DaemonCommand): Promise<DaemonResponse>;
+};
+
+function runningDaemon() {
+	const daemon = new TaloxDaemon();
+	const state = daemon as unknown as DaemonState;
+	const server = {
+		close: vi.fn((callback: (error?: Error) => void) => callback()),
+	};
+	state.server = server;
+	state.running = true;
+	return { daemon, state, server };
+}
+
+function addSession(state: DaemonState, id: string, stop: ReturnType<typeof vi.fn>) {
+	state.sessions.set(id, { id, controller: { stop }, createdAt: Date.now() });
+}
+
+describe("TaloxDaemon shutdown retry", () => {
+	it("removes successful sessions but retains failed sessions and the server for retry", async () => {
+		const { daemon, state, server } = runningDaemon();
+		const successfulStop = vi.fn().mockResolvedValue(undefined);
+		const failedStop = vi.fn().mockRejectedValueOnce(new Error("browser still alive")).mockResolvedValue(undefined);
+		addSession(state, "ok", successfulStop);
+		addSession(state, "retry", failedStop);
+
+		await expect(daemon.stop()).rejects.toThrow("Failed to stop 1 daemon session");
+
+		expect(successfulStop).toHaveBeenCalledTimes(1);
+		expect(failedStop).toHaveBeenCalledTimes(1);
+		expect(state.sessions.has("ok")).toBe(false);
+		expect(state.sessions.has("retry")).toBe(true);
+		expect(daemon.isRunning()).toBe(true);
+		expect(server.close).not.toHaveBeenCalled();
+
+		await expect(daemon.stop()).resolves.toBeUndefined();
+
+		expect(successfulStop).toHaveBeenCalledTimes(1);
+		expect(failedStop).toHaveBeenCalledTimes(2);
+		expect(state.sessions.size).toBe(0);
+		expect(daemon.isRunning()).toBe(false);
+		expect(server.close).toHaveBeenCalledTimes(1);
+	});
+
+	it("shares one global shutdown attempt across concurrent stop calls", async () => {
+		const { daemon, state, server } = runningDaemon();
+		const gate = deferred<void>();
+		const stop = vi.fn(() => gate.promise);
+		addSession(state, "shared", stop);
+
+		const first = daemon.stop();
+		const second = daemon.stop();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(server.close).not.toHaveBeenCalled();
+
+		gate.resolve();
+		await Promise.all([first, second]);
+
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(server.close).toHaveBeenCalledTimes(1);
+		expect(daemon.isRunning()).toBe(false);
+	});
+
+	it("shares a per-session stop between a stop command and global shutdown", async () => {
+		const { daemon, state, server } = runningDaemon();
+		const gate = deferred<void>();
+		const stop = vi.fn(() => gate.promise);
+		addSession(state, "session-a", stop);
+
+		const commandStop = state.handleStop({ id: "cmd-stop", action: "stop", params: { sessionId: "session-a" } });
+		const globalStop = daemon.stop();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(stop).toHaveBeenCalledTimes(1);
+
+		gate.resolve();
+		const [response] = await Promise.all([commandStop, globalStop]);
+
+		expect(response).toEqual({ id: "cmd-stop", success: true, data: { stopped: "session-a" } });
+		expect(stop).toHaveBeenCalledTimes(1);
+		expect(state.sessions.size).toBe(0);
+		expect(server.close).toHaveBeenCalledTimes(1);
+	});
+
+	it("waits for a launch already in progress before taking the shutdown session snapshot", async () => {
+		const { daemon, state, server } = runningDaemon();
+		const launchGate = deferred<void>();
+		const launchedStop = vi.fn().mockResolvedValue(undefined);
+		const launchTask = (async () => {
+			await launchGate.promise;
+			addSession(state, "late-session", launchedStop);
+		})();
+		state.launchTasks.add(launchTask);
+
+		const shutdown = daemon.stop();
+		await Promise.resolve();
+		expect(server.close).not.toHaveBeenCalled();
+		expect(launchedStop).not.toHaveBeenCalled();
+
+		launchGate.resolve();
+		await shutdown;
+
+		expect(launchedStop).toHaveBeenCalledTimes(1);
+		expect(state.sessions.size).toBe(0);
+		expect(server.close).toHaveBeenCalledTimes(1);
+		expect(daemon.isRunning()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- retain daemon sessions whose controller stop fails instead of clearing the entire session registry
- remove each session only after its own stop succeeds, so a later global stop can retry failures
- make global daemon shutdown single-flight
- make per-session shutdown single-flight so a direct `stop` command and global shutdown share the same controller stop attempt
- wait for launches that were already in progress before taking the global shutdown session snapshot
- reject new launches and normal session actions once global shutdown is in flight
- keep the server listening when session shutdown is incomplete, preserving the recovery interface

## Why

`TaloxDaemon.stop()` previously caught and logged every session stop error, then unconditionally called `this.sessions.clear()` and closed the daemon server. A browser/controller that failed to stop was therefore forgotten even though it could still be alive, leaving no daemon-level route to retry cleanup.

There were adjacent races as well: concurrent global stops could double-stop controllers, a direct session stop could race global shutdown, and a launch already underway could complete after the shutdown code had taken its session snapshot.

The new lifecycle coordinates three explicit in-flight states: launches, per-session stops, and the global stop. Successful sessions disappear immediately; failed sessions remain addressable; shutdown closes the server only after all tracked sessions are actually stopped.

## Verification

- `tests/unit/TaloxDaemonStopRetry.test.ts`
- partial shutdown failure removes successful sessions, retains failed ones, keeps the server alive, and succeeds on retry
- concurrent daemon stops share one shutdown attempt
- direct session stop and global shutdown share one controller stop
- global shutdown waits for a launch already in progress before stopping the newly registered session
- source diff is limited to `TaloxDaemon.ts` plus focused regression coverage
- branch is based on current `main` commit `1149b9c`
- full repository CI and Docker gates requested via this PR
