### PR TITLE
fix: propagate controller stop failures

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -148,6 +148,7 @@ export class TaloxController {
 	private videoRecorder: VideoRecorderType | null = null;
 	private readonly videoRecordingConfig: import("../../types/config.js").TaloxConfig["videoRecording"];
 	private readonly log = createLogger("Controller");
+	private stopInFlight: Promise<void> | null = null;
 	private readonly _sanitizer: ContentSanitizer;
 	readonly quality = new QualityTracker();
 
@@ -350,7 +351,23 @@ export class TaloxController {
 	/**
 	 * Close the browser and finalise any active observe session.
 	 */
-	async stop(): Promise<void> {
+	stop(): Promise<void> {
+		if (this.stopInFlight) return this.stopInFlight;
+
+		const attempt = this.runStop();
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runStop(): Promise<void> {
 		await this.flushHarRecorder();
 		this.disposeCrossOriginManager();
 		this.detachInspectServer();
@@ -362,6 +379,7 @@ export class TaloxController {
 			await this._session.stop();
 		} catch (e) {
 			this.log.error(`Error during stop(): ${e instanceof Error ? e.message : String(e)}`);
+			throw e;
 		}
 	}
 

--- a/tests/unit/TaloxControllerStopRetry.test.ts
+++ b/tests/unit/TaloxControllerStopRetry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("TaloxController stop retry", () => {
+	it("surfaces SessionManager stop failures and retries on a later stop", async () => {
+		const controller = new TaloxController();
+		const failure = new Error("browser close failed");
+		const sessionStop = vi
+			.spyOn(controller._session, "stop")
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(failure);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+	});
+
+	it("shares one in-flight SessionManager stop across concurrent callers", async () => {
+		const controller = new TaloxController();
+		const gate = deferred<void>();
+		const sessionStop = vi.spyOn(controller._session, "stop").mockImplementation(() => gate.promise);
+
+		const firstStop = controller.stop();
+		const secondStop = controller.stop();
+		await vi.waitFor(() => expect(sessionStop).toHaveBeenCalledTimes(1));
+
+		gate.resolve();
+		await Promise.all([firstStop, secondStop]);
+
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- make `TaloxController.stop()` single-flight so concurrent callers share one shutdown attempt
- preserve the existing best-effort HAR/video/auxiliary cleanup behavior
- rethrow `SessionManager.stop()` failures after logging instead of silently reporting success
- clear the in-flight marker after success or failure so a later stop can retry
- add focused regression coverage for failure propagation/retry and concurrent stop deduplication

## Why

`SessionManager.stop()` correctly propagates browser-close and observe-finalization failures, but `TaloxController.stop()` caught and logged those errors without rethrowing them. That made every higher reliability layer believe shutdown succeeded even when the browser/session might still be active.

This was especially important after hardening MCP and daemon shutdown retry semantics: those layers can only retain and retry failed sessions if the central controller actually surfaces the failure.

The new controller stop path is single-flight. The first caller performs cleanup and session shutdown, concurrent callers await that same promise, and a failed attempt becomes retryable once the shared promise settles.

## Verification

- `tests/unit/TaloxControllerStopRetry.test.ts`
- SessionManager stop failure is surfaced unchanged and a later controller stop retries successfully
- concurrent controller stops invoke SessionManager stop exactly once
- source diff is limited to the controller stop path (+19/-1)
- branch is based on current `main` commit `a7c5a5a`
- full repository CI and Docker gates requested via this PR
