### PR TITLE
fix: preserve coordinator agents across failed shutdowns

### DIFF
--- a/src/core/AgentCoordinator.ts
+++ b/src/core/AgentCoordinator.ts
@@ -132,11 +132,12 @@ const log = createLogger("Coordinator");
 
 export class AgentCoordinator {
 	private readonly config: Required<CoordinatorConfig>;
-	private agents: TaloxController[] = [];
+	private agents: Array<TaloxController | undefined> = [];
 	private readonly statuses: AgentStatus[];
 	private readonly sharedState = new Map<string, unknown>();
 	private lastStates: Array<TaloxPageState | null>;
 	private launched = false;
+	private stopInFlight: Promise<void> | null = null;
 
 	constructor(config: CoordinatorConfig = {}) {
 		const agentCount = config.agents ?? 2;
@@ -177,6 +178,12 @@ export class AgentCoordinator {
 			log.warn("Coordinator already launched");
 			return;
 		}
+		if (this.stopInFlight) {
+			throw new Error("Coordinator is stopping. Wait for cleanup to finish before relaunching.");
+		}
+		if (this.agents.some((agent) => agent !== undefined)) {
+			throw new Error("Coordinator has agents awaiting cleanup. Call stop() again before relaunching.");
+		}
 
 		const profileClass = options?.profileClass ?? "ops";
 
@@ -190,43 +197,79 @@ export class AgentCoordinator {
 				};
 
 				const agent = new TaloxController(agentBaseDir, { settings: agentSettings });
-				try {
-					await agent.launch(profileId, profileClass, "chromium");
-				} catch (error) {
-					try {
-						await agent.stop();
-					} catch (stopError) {
-						log.error(
-							`Agent ${i} cleanup after launch failure failed: ${stopError instanceof Error ? stopError.message : String(stopError)}`,
-						);
-					}
-					throw error;
-				}
-
-				this.agents.push(agent);
+				this.agents[i] = agent;
+				await agent.launch(profileId, profileClass, "chromium");
 				log.info(`Agent ${i} launched (profile: ${profileId})`);
 			}
 
 			this.launched = true;
 			log.info(`All ${this.config.agents} agents launched`);
 		} catch (error) {
-			await this.stop();
+			try {
+				await this.stop();
+			} catch (cleanupError) {
+				log.error(
+					`Coordinator cleanup after launch failure failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			}
 			throw error;
 		}
 	}
 
-	/** Stop all agents and clean up browser processes. */
-	async stop(): Promise<void> {
-		for (const [i, agent] of this.agents.entries()) {
-			try {
-				await agent.stop();
-				log.info(`Agent ${i} stopped`);
-			} catch (err) {
-				log.error(`Agent ${i} stop error: ${err instanceof Error ? err.message : String(err)}`);
-			} finally {
-				const status = this.statuses[i];
-				if (status) status.busy = false;
+	/**
+	 * Stop all agents and clean up browser processes.
+	 * Successful agents are removed immediately; failed agents remain available
+	 * for a later retry and keep the coordinator in a non-runnable state.
+	 */
+	stop(): Promise<void> {
+		if (this.stopInFlight) return this.stopInFlight;
+
+		const attempt = this.runStop();
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runStop(): Promise<void> {
+		this.launched = false;
+		const activeAgents = this.agents
+			.map((agent, index) => (agent ? { agent, index } : null))
+			.filter((entry): entry is { agent: TaloxController; index: number } => entry !== null);
+		const results = await Promise.allSettled(activeAgents.map(({ agent }) => agent.stop()));
+		const failures: string[] = [];
+
+		for (const [resultIndex, result] of results.entries()) {
+			const entry = activeAgents[resultIndex];
+			if (!entry) continue;
+			const { agent, index } = entry;
+			const status = this.statuses[index];
+			if (status) status.busy = false;
+
+			if (result.status === "fulfilled") {
+				if (this.agents[index] === agent) this.agents[index] = undefined;
+				this.lastStates[index] = null;
+				if (status) {
+					delete status.currentUrl;
+					delete status.lastResult;
+				}
+				log.info(`Agent ${index} stopped`);
+				continue;
 			}
+
+			const message = result.reason instanceof Error ? result.reason.message : String(result.reason);
+			log.error(`Agent ${index} stop error: ${message}`);
+			failures.push(`agent ${index}: ${message}`);
+		}
+
+		if (failures.length > 0) {
+			throw new Error(`Failed to stop ${failures.length} coordinator agent(s): ${failures.join("; ")}`);
 		}
 
 		this.agents = [];
@@ -236,7 +279,6 @@ export class AgentCoordinator {
 			delete status.currentUrl;
 			delete status.lastResult;
 		}
-		this.launched = false;
 	}
 
 	// ─── Execution ──────────────────────────────────────────────────────────────

--- a/tests/unit/AgentCoordinatorStopRetry.test.ts
+++ b/tests/unit/AgentCoordinatorStopRetry.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentCoordinator } from "../../src/core/AgentCoordinator.js";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("AgentCoordinator stop recovery", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("retains only agents whose stop failed and retries them later", async () => {
+		vi.spyOn(TaloxController.prototype, "launch").mockResolvedValue(undefined);
+		const stop = vi.spyOn(TaloxController.prototype, "stop");
+		stop.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("synthetic agent-1 stop failure"));
+
+		const coordinator = new AgentCoordinator({ agents: 2, baseDir: "/tmp/talox-coordinator-stop-retry" });
+		await coordinator.launch({ profileClass: "sandbox" });
+
+		await expect(coordinator.stop()).rejects.toThrow("agent 1: synthetic agent-1 stop failure");
+		expect(coordinator.getAgent(0)).toBeUndefined();
+		expect(coordinator.getAgent(1)).toBeDefined();
+		await expect(coordinator.run([])).rejects.toThrow("Coordinator not launched");
+		await expect(coordinator.launch({ profileClass: "sandbox" })).rejects.toThrow("agents awaiting cleanup");
+
+		stop.mockResolvedValueOnce(undefined);
+		await coordinator.stop();
+		expect(stop).toHaveBeenCalledTimes(3);
+		expect(coordinator.getAgent(0)).toBeUndefined();
+		expect(coordinator.getAgent(1)).toBeUndefined();
+	});
+
+	it("shares one shutdown attempt across concurrent stop callers", async () => {
+		vi.spyOn(TaloxController.prototype, "launch").mockResolvedValue(undefined);
+		const pendingStop = deferred<void>();
+		const stop = vi.spyOn(TaloxController.prototype, "stop").mockReturnValue(pendingStop.promise);
+
+		const coordinator = new AgentCoordinator({ agents: 1, baseDir: "/tmp/talox-coordinator-stop-single-flight" });
+		await coordinator.launch({ profileClass: "sandbox" });
+
+		const first = coordinator.stop();
+		const second = coordinator.stop();
+		expect(second).toBe(first);
+		expect(stop).toHaveBeenCalledTimes(1);
+
+		pendingStop.resolve();
+		await first;
+		expect(coordinator.getAgent(0)).toBeUndefined();
+	});
+
+	it("keeps a controller reachable when rollback after launch failure cannot stop it", async () => {
+		const launch = vi.spyOn(TaloxController.prototype, "launch");
+		launch.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("synthetic second-agent launch failure"));
+		const stop = vi.spyOn(TaloxController.prototype, "stop");
+		stop.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("synthetic rollback stop failure"));
+
+		const coordinator = new AgentCoordinator({ agents: 2, baseDir: "/tmp/talox-coordinator-launch-rollback" });
+
+		await expect(coordinator.launch({ profileClass: "sandbox" })).rejects.toThrow(
+			"synthetic second-agent launch failure",
+		);
+		expect(stop).toHaveBeenCalledTimes(2);
+		expect(coordinator.getAgent(0)).toBeUndefined();
+		expect(coordinator.getAgent(1)).toBeDefined();
+		await expect(coordinator.launch({ profileClass: "sandbox" })).rejects.toThrow("agents awaiting cleanup");
+
+		stop.mockResolvedValueOnce(undefined);
+		await coordinator.stop();
+		expect(coordinator.getAgent(1)).toBeUndefined();
+	});
+
+	it("preserves the original launch error when rollback also fails", async () => {
+		vi.spyOn(TaloxController.prototype, "launch").mockRejectedValueOnce(new Error("primary launch failure"));
+		vi.spyOn(TaloxController.prototype, "stop").mockRejectedValueOnce(new Error("secondary cleanup failure"));
+
+		const coordinator = new AgentCoordinator({ agents: 1, baseDir: "/tmp/talox-coordinator-error-priority" });
+
+		await expect(coordinator.launch({ profileClass: "sandbox" })).rejects.toThrow("primary launch failure");
+		expect(coordinator.getAgent(0)).toBeDefined();
+	});
+});


### PR DESCRIPTION
## Summary

- make `AgentCoordinator.stop()` single-flight
- remove only agents whose controller stop succeeds
- retain failed controllers so shutdown can be retried instead of losing the recovery handle
- mark the coordinator non-runnable as soon as shutdown begins
- block relaunch while old agents still require cleanup
- register each controller before launch so rollback cannot lose a controller whose cleanup also fails
- preserve the original launch error even if rollback encounters a secondary stop failure

## Why

`AgentCoordinator.stop()` previously logged controller stop failures, then unconditionally cleared the entire controller array and marked the coordinator stopped. A browser/controller that failed to stop was therefore forgotten even though it could still be active.

Partial launch rollback had the same class of failure: the currently failing controller was not added to the coordinator until after launch succeeded. If launch failed and that controller's cleanup failed too, the coordinator lost the only reference that could retry cleanup.

The new lifecycle is degraded-but-recoverable: successful stops are removed immediately, failed agents stay addressable, task execution stays disabled, and a later `stop()` retries only what remains.

## Verification

- `tests/unit/AgentCoordinatorStopRetry.test.ts`
- partial shutdown keeps only the failed controller and retries it later
- concurrent coordinator stops share one shutdown attempt
- failed launch rollback keeps an unclosed controller reachable
- the original launch failure remains the surfaced error when rollback also fails
- source diff is limited to `AgentCoordinator.ts` plus focused regression coverage
- branch is based on current `main` commit `4aead16`
- full repository CI and Docker gates requested via this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved agent shutdown reliability, including safe retries when stopping agents fails.
  - Prevented duplicate shutdown operations from running concurrently.
  - Added automatic cleanup when agent launch fails, while preserving failed components for recovery.
  - Improved error handling so the original launch failure remains visible.

- **Tests**
  - Added coverage for shutdown retries, concurrent stop requests, and launch rollback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->