### PR TITLE
fix: retry failed observe finalization

### DIFF
--- a/src/core/observe/ObserveSession.ts
+++ b/src/core/observe/ObserveSession.ts
@@ -245,7 +245,8 @@ export class ObserveSession {
 
 	/**
 	 * Explicitly end the session and write the report.
-	 * Safe to call multiple times — subsequent calls await the same finalization.
+	 * Safe to call multiple times: concurrent calls share one attempt, successful
+	 * finalization stays cached, and a failed attempt may be retried later.
 	 */
 	async endSession(): Promise<void> {
 		await this.finalize();
@@ -285,10 +286,14 @@ export class ObserveSession {
 	// ─── Private ─────────────────────────────────────────────────────────────────
 
 	private finalize(): Promise<void> {
-		if (this.finalizePromise === null) {
-			this.finalizePromise = this.runFinalize();
-		}
-		return this.finalizePromise;
+		if (this.finalizePromise !== null) return this.finalizePromise;
+
+		const attempt = this.runFinalize();
+		this.finalizePromise = attempt;
+		attempt.catch(() => {
+			if (this.finalizePromise === attempt) this.finalizePromise = null;
+		});
+		return attempt;
 	}
 
 	private async runFinalize(): Promise<void> {

--- a/tests/unit/ObserveSessionFinalizeRace.test.ts
+++ b/tests/unit/ObserveSessionFinalizeRace.test.ts
@@ -68,4 +68,45 @@ describe("ObserveSession finalization race", () => {
 		expect(reporterWrite).toHaveBeenCalledTimes(1);
 		expect(sessionEnd).toHaveBeenCalledTimes(1);
 	});
+
+	it("allows a failed report write to be retried without duplicating sessionEnd", async () => {
+		const page = {
+			url: vi.fn(() => "https://example.com"),
+			on: vi.fn(),
+			mainFrame: vi.fn(() => ({ url: () => "https://example.com" })),
+			screenshot: vi.fn(() => Promise.resolve(Buffer.from("fake"))),
+		};
+		const context = {
+			on: vi.fn(),
+			close: vi.fn(() => Promise.resolve()),
+		};
+		const eventBus = new EventBus<TaloxEventMap>();
+		const artifactBuilder = { toActionFrames: vi.fn(() => []) };
+		const session = new ObserveSession(page as any, context as any, eventBus, artifactBuilder as any, {
+			overlay: false,
+			record: true,
+		});
+		const reporterWrite = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("synthetic report write failure"))
+			.mockResolvedValueOnce({ json: "/tmp/retried-report.json" });
+		(session as any).reporter.write = reporterWrite;
+		const sessionEnd = vi.fn();
+		eventBus.on("sessionEnd", sessionEnd);
+
+		await session.start();
+
+		await expect(session.endSession()).rejects.toThrow("synthetic report write failure");
+		expect(reporterWrite).toHaveBeenCalledTimes(1);
+		expect(sessionEnd).not.toHaveBeenCalled();
+
+		await session.endSession();
+		expect(reporterWrite).toHaveBeenCalledTimes(2);
+		expect(sessionEnd).toHaveBeenCalledTimes(1);
+		expect(sessionEnd).toHaveBeenCalledWith(expect.objectContaining({ reportPath: "/tmp/retried-report.json" }));
+
+		await session.endSession();
+		expect(reporterWrite).toHaveBeenCalledTimes(2);
+		expect(sessionEnd).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Summary

- keep observe finalization single-flight while an attempt is running
- keep successful finalization cached and idempotent
- clear only the failed in-flight finalization attempt so a later explicit stop can retry report persistence
- preserve exactly-once `sessionEnd` emission after a successful retry
- document the retry semantics on `endSession()`

## Why

The single-flight finalization fix correctly prevented browser-close and explicit-end races, but it also cached a rejected finalization promise forever. If `SessionReporter.write()` failed transiently, every later `endSession()` returned the same rejection and the higher controller/MCP/daemon retry path could never recover.

Finalization writes the report before it records or emits `sessionEnd`, and EventBus listener failures do not propagate. Therefore a report-write failure can safely release the failed promise for a later retry without duplicating session-end side effects.

## Verification

- existing close-vs-explicit-end race test remains in place
- new regression: first report write fails, second `endSession()` retries successfully
- `sessionEnd` is not emitted on the failed attempt
- successful retry emits `sessionEnd` exactly once
- later `endSession()` remains idempotent and does not rewrite the report
- source diff is limited to `ObserveSession.ts` (+10/-5) plus focused test coverage
- branch is based on current `main` commit `6ec7118`
- full repository CI and Docker gates requested via this PR
