### PR TITLE
fix: clean up failed controller launches

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -277,24 +277,35 @@ export class TaloxController {
 		observeOptions?: ObserveSessionOptions,
 	): Promise<void> {
 		this.behavioralDNA = this._session.generateBehavioralDNA(profileId);
-		await this._session.launch(profileId, profileClass, this.settings, browserType, observeOptions);
 
-		const page = this._session.getPlaywrightPage();
-		if (!page) return;
-
-		// headed:true activates the full agent overlay (cursor + glow + takeover button)
 		try {
-			await this._takeover.initialize(page, this.settings.headed);
-		} catch (e) {
-			await this._session.stop();
-			throw new Error(`Takeover initialization failed: ${e instanceof Error ? e.message : String(e)}`);
-		}
+			await this._session.launch(profileId, profileClass, this.settings, browserType, observeOptions);
 
-		this.setupOriginHeaders(page);
-		this.setupHarRecording(page);
-		this.setupCrossOriginManager(page);
-		await this.setupInspectServer(page);
-		this.setupVideoRecording(page);
+			const page = this._session.getPlaywrightPage();
+			if (!page) return;
+
+			// headed:true activates the full agent overlay (cursor + glow + takeover button)
+			try {
+				await this._takeover.initialize(page, this.settings.headed);
+			} catch (error) {
+				throw new Error(`Takeover initialization failed: ${error instanceof Error ? error.message : String(error)}`);
+			}
+
+			this.setupOriginHeaders(page);
+			this.setupHarRecording(page);
+			this.setupCrossOriginManager(page);
+			await this.setupInspectServer(page);
+			this.setupVideoRecording(page);
+		} catch (error) {
+			try {
+				await this.stop();
+			} catch (cleanupError) {
+				this.log.error(
+					`Cleanup after launch failure failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`,
+				);
+			}
+			throw error;
+		}
 	}
 
 	/** Install per-origin headers if configured. */

--- a/tests/unit/TaloxControllerLaunchCleanup.test.ts
+++ b/tests/unit/TaloxControllerLaunchCleanup.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+describe("TaloxController launch cleanup", () => {
+	it("cleans up when SessionManager launch fails", async () => {
+		const controller = new TaloxController();
+		const launchFailure = new Error("synthetic session launch failure");
+		vi.spyOn(controller._session, "launch").mockRejectedValue(launchFailure);
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		await expect(controller.launch("agent", "sandbox")).rejects.toBe(launchFailure);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves the launch error when cleanup fails and allows a later stop retry", async () => {
+		const controller = new TaloxController();
+		const launchFailure = new Error("primary launch failure");
+		vi.spyOn(controller._session, "launch").mockRejectedValue(launchFailure);
+		const sessionStop = vi
+			.spyOn(controller._session, "stop")
+			.mockRejectedValueOnce(new Error("secondary cleanup failure"))
+			.mockResolvedValueOnce(undefined);
+
+		await expect(controller.launch("agent", "sandbox")).rejects.toBe(launchFailure);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+	});
+
+	it("cleans up when initialization fails after the browser session started", async () => {
+		const controller = new TaloxController();
+		const page = {};
+		vi.spyOn(controller._session, "launch").mockResolvedValue(undefined);
+		vi.spyOn(controller._session, "getPlaywrightPage").mockReturnValue(page as any);
+		vi.spyOn(controller._takeover, "initialize").mockResolvedValue(undefined);
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+		const setupFailure = new Error("synthetic inspect setup failure");
+		vi.spyOn(controller as any, "setupInspectServer").mockRejectedValue(setupFailure);
+
+		await expect(controller.launch("agent", "sandbox")).rejects.toBe(setupFailure);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the takeover initialization error prefix while using the shared cleanup path", async () => {
+		const controller = new TaloxController();
+		const page = {};
+		vi.spyOn(controller._session, "launch").mockResolvedValue(undefined);
+		vi.spyOn(controller._session, "getPlaywrightPage").mockReturnValue(page as any);
+		vi.spyOn(controller._takeover, "initialize").mockRejectedValue(new Error("overlay unavailable"));
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		await expect(controller.launch("agent", "sandbox")).rejects.toThrow(
+			"Takeover initialization failed: overlay unavailable",
+		);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary

- make `TaloxController.launch()` clean up through the shared controller stop path when any launch or post-launch initialization step fails
- cover failures from `SessionManager.launch()`, takeover initialization, and optional post-session setup
- preserve the original launch error even when cleanup itself fails
- leave failed cleanup retryable through a later explicit `stop()`
- retain the existing takeover initialization error prefix while removing its one-off cleanup path

## Why

`TaloxController.launch()` previously only cleaned up one special failure case: takeover initialization. Failures from `SessionManager.launch()` after a browser had already started, or from later origin/HAR/cross-origin/inspect/video setup, could throw without reliably closing the partially-started browser/session.

The takeover-specific cleanup also awaited `_session.stop()` directly, so a cleanup failure could replace the more useful original takeover initialization error.

The launch sequence now has one failure boundary. Any error runs the existing full controller `stop()` cleanup path, cleanup failures are logged without replacing the primary launch error, and the already-hardened stop single-flight state resets so callers can retry cleanup later.

## Verification

- `tests/unit/TaloxControllerLaunchCleanup.test.ts`
- SessionManager launch failure invokes cleanup and preserves the original error
- cleanup failure does not replace the primary launch error and a later `stop()` retries successfully
- late inspect/setup failure after a session started invokes cleanup
- takeover initialization keeps its existing prefixed error while using the shared cleanup path
- controller source diff is limited to the launch failure boundary (+26/-15)
- branch is based on current `main` commit `f738562`
- full repository CI and Docker gates requested via this PR
