### PR TITLE
fix: wait for inspect server socket cleanup

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -381,7 +381,7 @@ export class TaloxController {
 	private async runStop(): Promise<void> {
 		await this.flushHarRecorder();
 		this.disposeCrossOriginManager();
-		this.detachInspectServer();
+		await this.detachInspectServer();
 		await this.flushVideoRecorder();
 		this.persistTakeoverHistory();
 		await this.disposeOriginHeaders();
@@ -416,10 +416,11 @@ export class TaloxController {
 	}
 
 	/** Detach inspect server if active. */
-	private detachInspectServer(): void {
+	private async detachInspectServer(): Promise<void> {
 		if (!this.inspectServer) return;
-		this.inspectServer.detach();
-		this.inspectServer = null;
+		const server = this.inspectServer;
+		await server.detach();
+		if (this.inspectServer === server) this.inspectServer = null;
 	}
 
 	/** Flush video recording if active. */

--- a/src/core/inspect/InspectServer.ts
+++ b/src/core/inspect/InspectServer.ts
@@ -146,16 +146,18 @@ export class InspectServer {
 
 		const cdpSession = this.cdpSession;
 		this.cdpSession = null;
-		if (cdpSession) {
-			await cdpSession.detach().catch(() => {}); // NOSONAR — detach may fail
-		}
+		const cdpDetach = cdpSession ? cdpSession.detach().catch(() => {}) : Promise.resolve();
 
 		this.page = null;
 
-		if (!this.running) return;
+		if (!this.running) {
+			await cdpDetach;
+			return;
+		}
 
-		await this.closeWebSocketServer();
-		await this.closeHttpServer();
+		const webSocketClose = this.closeWebSocketServer();
+		const httpClose = this.closeHttpServer();
+		await Promise.all([cdpDetach, webSocketClose, httpClose]);
 		this.running = false;
 	}
 

--- a/src/core/inspect/InspectServer.ts
+++ b/src/core/inspect/InspectServer.ts
@@ -48,6 +48,9 @@ export class InspectServer {
 	private cdpSession: import("playwright-core").CDPSession | null = null;
 	private readonly devtoolsClients: Set<WebSocket> = new Set();
 	private running = false;
+	private startInFlight: Promise<void> | null = null;
+	private detachInFlight: Promise<void> | null = null;
+	private connectionHandlerInstalled = false;
 
 	constructor(config?: InspectServerConfig) {
 		this.port = config?.port ?? 9222;
@@ -61,9 +64,11 @@ export class InspectServer {
 	/**
 	 * Attach to a Playwright page and start proxying CDP messages.
 	 *
-	 * Starts the HTTP and WebSocket servers if not already running.
+	 * Starts the HTTP and WebSocket servers if not already running. Concurrent
+	 * callers share one listen attempt, and a failed listen remains retryable.
 	 */
 	async attach(page: Page): Promise<void> {
+		if (this.detachInFlight) await this.detachInFlight;
 		this.page = page;
 
 		try {
@@ -72,49 +77,106 @@ export class InspectServer {
 			// NOSONAR — CDP session creation may fail in some browsers
 		}
 
-		if (!this.running) {
-			this.running = true;
+		if (this.running) return;
+		if (this.startInFlight) {
+			await this.startInFlight;
+			return;
+		}
 
+		if (!this.connectionHandlerInstalled) {
 			this.wss.on("connection", (ws: WebSocket) => {
 				this.handleDevToolsConnection(ws);
 			});
+			this.connectionHandlerInstalled = true;
+		}
 
-			await new Promise<void>((resolve, reject) => {
-				this.httpServer.once("error", reject);
-				this.httpServer.listen(this.port, this.host, () => {
-					this.httpServer.removeListener("error", reject);
-					resolve();
-				});
+		const attempt = new Promise<void>((resolve, reject) => {
+			this.httpServer.once("error", reject);
+			this.httpServer.listen(this.port, this.host, () => {
+				this.httpServer.removeListener("error", reject);
+				this.running = true;
+				resolve();
 			});
+		});
+		this.startInFlight = attempt;
+
+		try {
+			await attempt;
+		} finally {
+			if (this.startInFlight === attempt) this.startInFlight = null;
 		}
 	}
 
 	/**
-	 * Stop proxying and shut down the servers.
+	 * Stop proxying and wait until the inspect sockets are actually released.
 	 */
-	detach(): void {
+	detach(): Promise<void> {
+		if (this.detachInFlight) return this.detachInFlight;
+
+		const attempt = this.runDetach();
+		this.detachInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.detachInFlight === attempt) this.detachInFlight = null;
+			},
+			() => {
+				if (this.detachInFlight === attempt) this.detachInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runDetach(): Promise<void> {
+		const start = this.startInFlight;
+		if (start) await start.catch(() => {});
+
 		const clients = Array.from(this.devtoolsClients);
 		for (const ws of clients) {
 			try {
-				ws.close();
+				ws.terminate();
 			} catch {
-				// NOSONAR
+				try {
+					ws.close();
+				} catch {
+					// NOSONAR — client may already be closed
+				}
 			}
 		}
 		this.devtoolsClients.clear();
 
-		if (this.cdpSession) {
-			this.cdpSession.detach().catch(() => {}); // NOSONAR — detach may fail
-			this.cdpSession = null;
+		const cdpSession = this.cdpSession;
+		this.cdpSession = null;
+		if (cdpSession) {
+			await cdpSession.detach().catch(() => {}); // NOSONAR — detach may fail
 		}
 
 		this.page = null;
 
-		if (this.running) {
-			this.running = false;
-			this.wss.close();
-			this.httpServer.close();
-		}
+		if (!this.running) return;
+
+		await this.closeWebSocketServer();
+		await this.closeHttpServer();
+		this.running = false;
+	}
+
+	private closeWebSocketServer(): Promise<void> {
+		return new Promise<void>((resolve) => {
+			try {
+				this.wss.close(() => resolve());
+			} catch {
+				resolve();
+			}
+		});
+	}
+
+	private closeHttpServer(): Promise<void> {
+		return new Promise<void>((resolve) => {
+			try {
+				this.httpServer.close(() => resolve());
+			} catch {
+				resolve();
+			}
+		});
 	}
 
 	/**

--- a/src/core/inspect/InspectServer.ts
+++ b/src/core/inspect/InspectServer.ts
@@ -48,7 +48,7 @@ export class InspectServer {
 	private cdpSession: import("playwright-core").CDPSession | null = null;
 	private readonly devtoolsClients: Set<WebSocket> = new Set();
 	private running = false;
-	private startInFlight: Promise<void> | null = null;
+	private attachInFlight: Promise<void> | null = null;
 	private detachInFlight: Promise<void> | null = null;
 	private connectionHandlerInstalled = false;
 
@@ -64,24 +64,46 @@ export class InspectServer {
 	/**
 	 * Attach to a Playwright page and start proxying CDP messages.
 	 *
-	 * Starts the HTTP and WebSocket servers if not already running. Concurrent
-	 * callers share one listen attempt, and a failed listen remains retryable.
+	 * Attachments are serialized so concurrent callers cannot race server start
+	 * or leak multiple CDP sessions. Failed attempts leave the next attach free
+	 * to retry.
 	 */
 	async attach(page: Page): Promise<void> {
-		if (this.detachInFlight) await this.detachInFlight;
+		while (this.attachInFlight) {
+			await this.attachInFlight.catch(() => {});
+		}
+
+		const attempt = this.runAttach(page);
+		this.attachInFlight = attempt;
+		try {
+			await attempt;
+		} finally {
+			if (this.attachInFlight === attempt) this.attachInFlight = null;
+		}
+	}
+
+	private async runAttach(page: Page): Promise<void> {
+		const detach = this.detachInFlight;
+		if (detach) await detach;
+
 		this.page = page;
+		await this.ensureServerStarted();
+
+		const previousSession = this.cdpSession;
+		this.cdpSession = null;
+		if (previousSession) {
+			await previousSession.detach().catch(() => {}); // NOSONAR — previous page may already be closed
+		}
 
 		try {
 			this.cdpSession = await page.context().newCDPSession(page);
 		} catch {
 			// NOSONAR — CDP session creation may fail in some browsers
 		}
+	}
 
+	private async ensureServerStarted(): Promise<void> {
 		if (this.running) return;
-		if (this.startInFlight) {
-			await this.startInFlight;
-			return;
-		}
 
 		if (!this.connectionHandlerInstalled) {
 			this.wss.on("connection", (ws: WebSocket) => {
@@ -90,7 +112,7 @@ export class InspectServer {
 			this.connectionHandlerInstalled = true;
 		}
 
-		const attempt = new Promise<void>((resolve, reject) => {
+		await new Promise<void>((resolve, reject) => {
 			this.httpServer.once("error", reject);
 			this.httpServer.listen(this.port, this.host, () => {
 				this.httpServer.removeListener("error", reject);
@@ -98,13 +120,6 @@ export class InspectServer {
 				resolve();
 			});
 		});
-		this.startInFlight = attempt;
-
-		try {
-			await attempt;
-		} finally {
-			if (this.startInFlight === attempt) this.startInFlight = null;
-		}
 	}
 
 	/**
@@ -127,8 +142,8 @@ export class InspectServer {
 	}
 
 	private async runDetach(): Promise<void> {
-		const start = this.startInFlight;
-		if (start) await start.catch(() => {});
+		const attach = this.attachInFlight;
+		if (attach) await attach.catch(() => {});
 
 		const clients = Array.from(this.devtoolsClients);
 		for (const ws of clients) {

--- a/tests/unit/InspectServerLifecycle.test.ts
+++ b/tests/unit/InspectServerLifecycle.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHttpServer, mockWss, mockCreateServer } = vi.hoisted(() => {
+	const mockHttpServer = {
+		listen: vi.fn(),
+		close: vi.fn(),
+		once: vi.fn(),
+		removeListener: vi.fn(),
+	};
+	const mockWss = {
+		on: vi.fn(),
+		close: vi.fn(),
+	};
+	const mockCreateServer = vi.fn(() => mockHttpServer);
+	return { mockHttpServer, mockWss, mockCreateServer };
+});
+
+vi.mock("node:http", () => ({ createServer: mockCreateServer }));
+vi.mock("node:crypto", () => ({ randomUUID: vi.fn(() => "inspect-lifecycle-id") }));
+vi.mock("ws", () => ({
+	WebSocketServer: vi.fn().mockImplementation(function (this: any) {
+		return mockWss;
+	}),
+	WebSocket: { OPEN: 1 },
+}));
+vi.mock("playwright-core", () => ({}));
+
+import { InspectServer } from "../../src/core/inspect/InspectServer.js";
+
+function createPage() {
+	const cdpSession = {
+		on: vi.fn(),
+		off: vi.fn(),
+		send: vi.fn().mockResolvedValue({}),
+		detach: vi.fn().mockResolvedValue(undefined),
+	};
+	return {
+		url: vi.fn(() => "https://example.com"),
+		context: vi.fn(() => ({ newCDPSession: vi.fn().mockResolvedValue(cdpSession) })),
+		_cdpSession: cdpSession,
+	};
+}
+
+describe("InspectServer lifecycle", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHttpServer.once.mockReturnValue(mockHttpServer);
+		mockHttpServer.removeListener.mockReturnValue(mockHttpServer);
+		mockHttpServer.listen.mockImplementation((_port: number, _host: string, callback: () => void) => {
+			callback();
+			return mockHttpServer;
+		});
+		mockHttpServer.close.mockImplementation((callback?: () => void) => {
+			callback?.();
+			return mockHttpServer;
+		});
+		mockWss.on.mockReturnValue(mockWss);
+		mockWss.close.mockImplementation((callback?: () => void) => {
+			callback?.();
+		});
+	});
+
+	it("can retry after the first listen attempt fails", async () => {
+		const server = new InspectServer({ port: 9222 });
+		const page = createPage();
+		const failure = new Error("EADDRINUSE");
+		let errorHandler: ((error: Error) => void) | undefined;
+
+		mockHttpServer.once.mockImplementation((event: string, handler: (error: Error) => void) => {
+			if (event === "error") errorHandler = handler;
+			return mockHttpServer;
+		});
+		mockHttpServer.listen.mockImplementationOnce(() => {
+			errorHandler?.(failure);
+			return mockHttpServer;
+		});
+
+		await expect(server.attach(page as any)).rejects.toBe(failure);
+		await expect(server.attach(page as any)).resolves.toBeUndefined();
+
+		expect(mockHttpServer.listen).toHaveBeenCalledTimes(2);
+		expect(mockWss.on).toHaveBeenCalledTimes(1);
+	});
+
+	it("shares one listen attempt across concurrent attach callers", async () => {
+		const server = new InspectServer({ port: 9222 });
+		const page = createPage();
+		let listenCallback: (() => void) | undefined;
+		mockHttpServer.listen.mockImplementation((_port: number, _host: string, callback: () => void) => {
+			listenCallback = callback;
+			return mockHttpServer;
+		});
+
+		const first = server.attach(page as any);
+		const second = server.attach(page as any);
+		await vi.waitFor(() => expect(mockHttpServer.listen).toHaveBeenCalledTimes(1));
+
+		listenCallback?.();
+		await Promise.all([first, second]);
+
+		expect(mockHttpServer.listen).toHaveBeenCalledTimes(1);
+		expect(mockWss.on).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not resolve detach until WebSocket and HTTP close callbacks complete", async () => {
+		const server = new InspectServer({ port: 9222 });
+		const page = createPage();
+		await server.attach(page as any);
+
+		let wsClosed: (() => void) | undefined;
+		let httpClosed: (() => void) | undefined;
+		mockWss.close.mockImplementation((callback?: () => void) => {
+			wsClosed = callback;
+		});
+		mockHttpServer.close.mockImplementation((callback?: () => void) => {
+			httpClosed = callback;
+			return mockHttpServer;
+		});
+
+		let resolved = false;
+		const detach = server.detach().then(() => {
+			resolved = true;
+		});
+		await vi.waitFor(() => expect(mockHttpServer.close).toHaveBeenCalledTimes(1));
+		expect(resolved).toBe(false);
+
+		wsClosed?.();
+		await Promise.resolve();
+		expect(resolved).toBe(false);
+
+		httpClosed?.();
+		await detach;
+		expect(resolved).toBe(true);
+	});
+});

--- a/tests/unit/TaloxControllerInspectShutdown.test.ts
+++ b/tests/unit/TaloxControllerInspectShutdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe("TaloxController inspect shutdown", () => {
+	it("waits for inspect socket release before finishing session shutdown", async () => {
+		const controller = new TaloxController();
+		const gate = deferred<void>();
+		const inspectServer = { detach: vi.fn(() => gate.promise) };
+		(controller as any).inspectServer = inspectServer;
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		let resolved = false;
+		const stop = controller.stop().then(() => {
+			resolved = true;
+		});
+
+		await vi.waitFor(() => expect(inspectServer.detach).toHaveBeenCalledTimes(1));
+		expect(sessionStop).not.toHaveBeenCalled();
+		expect(resolved).toBe(false);
+
+		gate.resolve();
+		await stop;
+
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect(resolved).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- serialize InspectServer attachments so concurrent callers cannot race `listen()` or leak CDP sessions
- mark the inspect server running only after `listen()` succeeds, leaving failed starts retryable
- install the WebSocket connection handler once across start retries
- detach the previous CDP session before attaching a replacement page
- make `detach()` single-flight and wait for CDP, WebSocket, and HTTP shutdown completion
- terminate connected DevTools clients before closing the servers
- make `TaloxController.stop()` await inspect-server shutdown before continuing session teardown

## Why

InspectServer previously set `running = true` before the HTTP server had actually bound its port. A failed `listen()` could therefore leave the instance believing it was running, making retries silently skip server startup.

Shutdown was also fire-and-forget: `detach()` called `wss.close()` and `httpServer.close()` but returned immediately, while `TaloxController.stop()` discarded the InspectServer reference. An immediate new controller using the same inspect port could race the old socket release.

The new lifecycle makes start and stop promises match reality: failed binds remain retryable, concurrent attachments are serialized, and an awaited controller stop does not finish until inspect sockets have actually released.

## Verification

- `tests/unit/InspectServerLifecycle.test.ts`
- failed first `listen()` can retry successfully and does not duplicate the WebSocket handler
- concurrent attachments trigger only one server listen
- `detach()` remains pending until both WebSocket and HTTP close callbacks complete
- `tests/unit/TaloxControllerInspectShutdown.test.ts`
- controller session shutdown does not proceed until inspect detach completes
- controller source diff is limited to awaiting the inspect cleanup contract (+5/-4)
- full repository CI and Docker gates requested via this PR
