### PR TITLE
fix: isolate NetworkMocker route cleanup

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -25,6 +25,13 @@ export interface NetworkMockerOptions {
 	page: Page;
 }
 
+type RouteHandler = (route: Route, request: Request) => Promise<void>;
+
+interface MockRouteRegistration {
+	mock: MockResponse;
+	handler: RouteHandler;
+}
+
 /**
  * Records and replays network traffic for testing and replay scenarios.
  * Captures full request/response pairs (headers, bodies), replays saved
@@ -37,9 +44,10 @@ export class NetworkMocker {
 	private isRecording: boolean = false;
 	private isReplaying: boolean = false;
 	private recordings: NetworkRecording[] = [];
-	private mocks: MockResponse[] = [];
 	private recordingHandler: ((recording: NetworkRecording) => void) | null = null;
-	private readonly savedRoutes: Map<string, () => Promise<void>> = new Map();
+	private recordingRouteHandler: RouteHandler | null = null;
+	private replayRouteHandler: RouteHandler | null = null;
+	private mockRoutes: MockRouteRegistration[] = [];
 
 	constructor(options: NetworkMockerOptions) {
 		this.context = options.context;
@@ -59,12 +67,12 @@ export class NetworkMocker {
 
 	async startRecording(onRecording?: (recording: NetworkRecording) => void): Promise<void> {
 		if (this.isRecording) return;
+		if (this.recordingRouteHandler) await this.removeRecordingRoute();
 
-		this.isRecording = true;
 		this.recordings = [];
 		this.recordingHandler = onRecording || null;
 
-		await this.page.route("**/*", async (route: Route, request: Request) => {
+		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.isRecording) {
 				await route.continue();
 				return;
@@ -117,13 +125,30 @@ export class NetworkMocker {
 			} catch {
 				await route.continue();
 			}
-		});
+		};
+
+		try {
+			await this.page.route("**/*", handler);
+			this.recordingRouteHandler = handler;
+			this.isRecording = true;
+		} catch (error) {
+			this.recordingHandler = null;
+			throw error;
+		}
 	}
 
 	async stopRecording(): Promise<NetworkRecording[]> {
 		this.isRecording = false;
 		this.recordingHandler = null;
+		await this.removeRecordingRoute();
 		return [...this.recordings];
+	}
+
+	private async removeRecordingRoute(): Promise<void> {
+		const handler = this.recordingRouteHandler;
+		if (!handler) return;
+		await this.page.unroute("**/*", handler);
+		if (this.recordingRouteHandler === handler) this.recordingRouteHandler = null;
 	}
 
 	getRecordings(): NetworkRecording[] {
@@ -132,15 +157,13 @@ export class NetworkMocker {
 
 	async startReplaying(recordings?: NetworkRecording[]): Promise<void> {
 		if (this.isReplaying) return;
+		if (this.replayRouteHandler) await this.removeReplayRoute();
 
 		if (recordings) {
 			this.recordings = recordings;
 		}
 
-		this.isReplaying = true;
-		this.savedRoutes.clear();
-
-		await this.page.route("**/*", async (route: Route, request: Request) => {
+		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.isReplaying) {
 				await route.continue();
 				return;
@@ -166,19 +189,27 @@ export class NetworkMocker {
 			} else {
 				await route.continue();
 			}
-		});
+		};
+
+		await this.page.route("**/*", handler);
+		this.replayRouteHandler = handler;
+		this.isReplaying = true;
 	}
 
 	async stopReplaying(): Promise<void> {
 		this.isReplaying = false;
-		this.savedRoutes.clear();
-		await this.page.unrouteAll({ behavior: "ignoreErrors" });
+		await this.removeReplayRoute();
+	}
+
+	private async removeReplayRoute(): Promise<void> {
+		const handler = this.replayRouteHandler;
+		if (!handler) return;
+		await this.page.unroute("**/*", handler);
+		if (this.replayRouteHandler === handler) this.replayRouteHandler = null;
 	}
 
 	async addMock(mock: MockResponse): Promise<void> {
-		this.mocks.push(mock);
-
-		await this.page.route(mock.urlPattern, async (route: Route, request: Request) => {
+		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.matchesPattern(request.url(), mock.urlPattern)) {
 				await route.continue();
 				return;
@@ -203,16 +234,38 @@ export class NetworkMocker {
 			}
 
 			await route.fulfill(fulfillOptions);
-		});
+		};
+
+		await this.page.route(mock.urlPattern, handler);
+		this.mockRoutes.push({ mock, handler });
 	}
 
 	async clearMocks(): Promise<void> {
-		this.mocks = [];
-		await this.page.unrouteAll({ behavior: "ignoreErrors" });
+		const registrations = [...this.mockRoutes];
+		if (registrations.length === 0) return;
+
+		const results = await Promise.allSettled(
+			registrations.map(({ mock, handler }) => this.page.unroute(mock.urlPattern, handler)),
+		);
+		const removedHandlers = new Set<RouteHandler>();
+		let firstFailure: unknown;
+
+		for (const [index, result] of results.entries()) {
+			const registration = registrations[index];
+			if (!registration) continue;
+			if (result.status === "fulfilled") {
+				removedHandlers.add(registration.handler);
+			} else if (firstFailure === undefined) {
+				firstFailure = result.reason;
+			}
+		}
+
+		this.mockRoutes = this.mockRoutes.filter(({ handler }) => !removedHandlers.has(handler));
+		if (firstFailure !== undefined) throw firstFailure;
 	}
 
 	getMocks(): MockResponse[] {
-		return [...this.mocks];
+		return this.mockRoutes.map(({ mock }) => mock);
 	}
 
 	async saveToFile(filePath: string): Promise<void> {
@@ -237,10 +290,20 @@ export class NetworkMocker {
 	}
 
 	async destroy(): Promise<void> {
-		await this.stopRecording();
-		await this.stopReplaying();
-		await this.clearMocks();
+		const failures: unknown[] = [];
+		for (const cleanup of [
+			() => this.stopRecording(),
+			() => this.stopReplaying(),
+			() => this.clearMocks(),
+		]) {
+			try {
+				await cleanup();
+			} catch (error) {
+				failures.push(error);
+			}
+		}
 		this.recordings = [];
+		if (failures.length > 0) throw failures[0];
 	}
 }
 

--- a/tests/unit/NetworkMocker.test.ts
+++ b/tests/unit/NetworkMocker.test.ts
@@ -6,8 +6,12 @@ function makeMockPage() {
 	const handlers: Array<(route: any, request: any) => Promise<void>> = [];
 
 	return {
-		route: vi.fn(async (_pattern: string, handler: (route: any, request: any) => Promise<void>) => {
+		route: vi.fn(async (_pattern: string | RegExp, handler: (route: any, request: any) => Promise<void>) => {
 			handlers.push(handler);
+		}),
+		unroute: vi.fn(async (_pattern: string | RegExp, handler: (route: any, request: any) => Promise<void>) => {
+			const index = handlers.indexOf(handler);
+			if (index >= 0) handlers.splice(index, 1);
 		}),
 		unrouteAll: vi.fn(async () => {
 			handlers.length = 0;
@@ -76,7 +80,7 @@ describe("NetworkMocker", () => {
 
 		it("does not double-start recording", async () => {
 			await mocker.startRecording();
-			await mocker.startRecording(); // second call should be no-op
+			await mocker.startRecording();
 			expect(mockPage.route).toHaveBeenCalledTimes(1);
 		});
 
@@ -85,6 +89,7 @@ describe("NetworkMocker", () => {
 			const recordings = await mocker.stopRecording();
 			expect(recordings).toEqual([]);
 			expect(mocker.isRecordingActive).toBe(false);
+			expect(mockPage.unroute).toHaveBeenCalledWith("**/*", expect.any(Function));
 		});
 	});
 
@@ -92,8 +97,6 @@ describe("NetworkMocker", () => {
 		it("records a request when handler is invoked", async () => {
 			const onRecording = vi.fn();
 			await mocker.startRecording(onRecording);
-
-			// Get the registered handler
 			const handler = mockPage._handlers[0]!;
 
 			const route = makeRoute();
@@ -148,7 +151,6 @@ describe("NetworkMocker", () => {
 			const request = makeRequest();
 			await handler(route, request);
 
-			// Should just continue, not record
 			expect(mocker.getRecordings()).toEqual([]);
 		});
 	});
@@ -206,6 +208,7 @@ describe("NetworkMocker", () => {
 			await mocker.startReplaying();
 			await mocker.stopReplaying();
 			expect(mocker.isReplayingActive).toBe(false);
+			expect(mockPage.unroute).toHaveBeenCalledWith("**/*", expect.any(Function));
 		});
 
 		it("does not double-start replaying", async () => {
@@ -233,7 +236,8 @@ describe("NetworkMocker", () => {
 			await mocker.addMock({ urlPattern: "**/data/**", status: 404 });
 			await mocker.clearMocks();
 			expect(mocker.getMocks()).toEqual([]);
-			expect(mockPage.unrouteAll).toHaveBeenCalled();
+			expect(mockPage.unroute).toHaveBeenCalledTimes(2);
+			expect(mockPage.unrouteAll).not.toHaveBeenCalled();
 		});
 	});
 
@@ -244,17 +248,6 @@ describe("NetworkMocker", () => {
 				readFile: vi.fn().mockResolvedValue("[]"),
 			}));
 
-			// Push a recording manually
-			const recording: NetworkRecording = {
-				id: "1",
-				url: "https://example.com",
-				method: "GET",
-				status: 200,
-				requestHeaders: {},
-				responseHeaders: {},
-				timestamp: 0,
-			};
-			// Use internal recordings via getRecordings after startRecording
 			await mocker.startRecording();
 			const handler = mockPage._handlers[0]!;
 

--- a/tests/unit/NetworkMockerRouteOwnership.test.ts
+++ b/tests/unit/NetworkMockerRouteOwnership.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+import { NetworkMocker } from "../../src/core/NetworkMocker.js";
+
+type Registration = {
+	pattern: string | RegExp;
+	handler: (route: any, request: any) => Promise<void>;
+};
+
+function makeOwnedRoutePage() {
+	const registrations: Registration[] = [];
+	const page = {
+		route: vi.fn(async (pattern: string | RegExp, handler: Registration["handler"]) => {
+			registrations.push({ pattern, handler });
+		}),
+		unroute: vi.fn(async (pattern: string | RegExp, handler: Registration["handler"]) => {
+			const index = registrations.findIndex(
+				(entry) => entry.pattern === pattern && entry.handler === handler,
+			);
+			if (index >= 0) registrations.splice(index, 1);
+		}),
+		unrouteAll: vi.fn(async () => {
+			registrations.length = 0;
+		}),
+		_registrations: registrations,
+	};
+	return page;
+}
+
+describe("NetworkMocker route ownership", () => {
+	it("stopping recording removes only the recording handler", async () => {
+		const page = makeOwnedRoutePage();
+		const externalHandler = vi.fn(async () => {});
+		await page.route("**/*", externalHandler);
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+
+		await mocker.startRecording();
+		await mocker.addMock({ urlPattern: "api.example.com", body: "mock" });
+		expect(page._registrations).toHaveLength(3);
+
+		await mocker.stopRecording();
+
+		expect(page._registrations).toHaveLength(2);
+		expect(page._registrations.some(({ handler }) => handler === externalHandler)).toBe(true);
+		expect(page._registrations.some(({ pattern }) => pattern === "api.example.com")).toBe(true);
+		expect(page.unrouteAll).not.toHaveBeenCalled();
+	});
+
+	it("stopping replay does not remove recording, mocks, or external routes", async () => {
+		const page = makeOwnedRoutePage();
+		const externalHandler = vi.fn(async () => {});
+		await page.route("**/*", externalHandler);
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+
+		await mocker.startRecording();
+		await mocker.startReplaying([]);
+		await mocker.addMock({ urlPattern: "mock.example", body: "mock" });
+		expect(page._registrations).toHaveLength(4);
+
+		await mocker.stopReplaying();
+
+		expect(page._registrations).toHaveLength(3);
+		expect(mocker.isRecordingActive).toBe(true);
+		expect(mocker.getMocks()).toHaveLength(1);
+		expect(page._registrations.some(({ handler }) => handler === externalHandler)).toBe(true);
+		expect(page.unrouteAll).not.toHaveBeenCalled();
+	});
+
+	it("clearMocks removes only mock-owned routes", async () => {
+		const page = makeOwnedRoutePage();
+		const externalHandler = vi.fn(async () => {});
+		await page.route("**/*", externalHandler);
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+
+		await mocker.startRecording();
+		await mocker.startReplaying([]);
+		await mocker.addMock({ urlPattern: "mock-a.example", body: "a" });
+		await mocker.addMock({ urlPattern: "mock-b.example", body: "b" });
+
+		await mocker.clearMocks();
+
+		expect(mocker.getMocks()).toEqual([]);
+		expect(page._registrations).toHaveLength(3);
+		expect(page._registrations.some(({ handler }) => handler === externalHandler)).toBe(true);
+		expect(mocker.isRecordingActive).toBe(true);
+		expect(mocker.isReplayingActive).toBe(true);
+		expect(page.unrouteAll).not.toHaveBeenCalled();
+	});
+
+	it("retains a mock registration when targeted unroute fails so cleanup can retry", async () => {
+		const page = makeOwnedRoutePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		await mocker.addMock({ urlPattern: "retry.example", body: "mock" });
+
+		const originalUnroute = page.unroute.getMockImplementation()!;
+		page.unroute
+			.mockRejectedValueOnce(new Error("synthetic unroute failure"))
+			.mockImplementation(originalUnroute);
+
+		await expect(mocker.clearMocks()).rejects.toThrow("synthetic unroute failure");
+		expect(mocker.getMocks()).toHaveLength(1);
+		expect(page._registrations).toHaveLength(1);
+
+		await mocker.clearMocks();
+		expect(mocker.getMocks()).toEqual([]);
+		expect(page._registrations).toHaveLength(0);
+	});
+
+	it("start-stop-start recording does not accumulate stale recording handlers", async () => {
+		const page = makeOwnedRoutePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+
+		await mocker.startRecording();
+		expect(page._registrations).toHaveLength(1);
+		await mocker.stopRecording();
+		expect(page._registrations).toHaveLength(0);
+		await mocker.startRecording();
+
+		expect(page._registrations).toHaveLength(1);
+		expect(page.unrouteAll).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

- track recording, replay, and mock route handlers explicitly
- remove only NetworkMocker-owned handlers with `page.unroute(pattern, handler)`
- stop recording now actually removes its installed route instead of leaving a dormant handler behind
- stop replay no longer calls `unrouteAll()` and therefore cannot delete unrelated routes
- clear mocks removes each mock-owned route individually and retains failed removals for retry
- only publish a mock registration after `page.route()` succeeds
- make `destroy()` attempt every cleanup category even if an earlier cleanup fails, then surface the first failure

## Why

NetworkMocker previously had no ownership boundary around Playwright routes. `stopRecording()` merely flipped a boolean, so repeated start/stop cycles accumulated stale route handlers. More seriously, `stopReplaying()` and `clearMocks()` used `page.unrouteAll()`, which removes every route registered on the page, including routes owned by other Talox components or application integrations.

The new lifecycle stores exact handler references and unregisters only what NetworkMocker installed. Cleanup state now reflects actual removal success, so transient `unroute()` failures remain retryable instead of losing the cleanup handle.

## Verification

- existing `NetworkMocker.test.ts` fake page now models targeted `unroute(pattern, handler)`
- `tests/unit/NetworkMockerRouteOwnership.test.ts`
- stopping recording preserves external and mock routes
- stopping replay preserves recording, mocks, and external routes
- `clearMocks()` removes only mock routes
- failed mock `unroute()` retains the registration and succeeds on a later retry
- recording start/stop/start does not accumulate stale handlers
- `unrouteAll()` is explicitly asserted unused by these cleanup paths
- full repository CI and Docker gates requested via this PR
