### PR TITLE
fix: continue recorded routes only once

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -80,7 +80,11 @@ export class NetworkMocker {
 
 			try {
 				await route.continue();
+			} catch {
+				return;
+			}
 
+			try {
 				const response: Response | null = await request.response();
 				let responseBody: string | undefined;
 				let responseStatus = 0;
@@ -123,7 +127,7 @@ export class NetworkMocker {
 					this.recordingHandler(recording);
 				}
 			} catch {
-				await route.continue();
+				// Recording is best-effort after the request has already continued.
 			}
 		};
 

--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -78,11 +78,7 @@ export class NetworkMocker {
 				return;
 			}
 
-			try {
-				await route.continue();
-			} catch {
-				return;
-			}
+			await route.continue();
 
 			try {
 				const response: Response | null = await request.response();

--- a/tests/unit/NetworkMockerRecordingErrorPaths.test.ts
+++ b/tests/unit/NetworkMockerRecordingErrorPaths.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { NetworkMocker } from "../../src/core/NetworkMocker.js";
+
+type RouteHandler = (route: any, request: any) => Promise<void>;
+
+function createMocker() {
+	let handler: RouteHandler | null = null;
+	const page = {
+		route: vi.fn(async (_pattern: string, registeredHandler: RouteHandler) => {
+			handler = registeredHandler;
+		}),
+		unroute: vi.fn(async () => {}),
+	};
+	const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+	return {
+		mocker,
+		page,
+		getHandler: () => {
+			if (!handler) throw new Error("recording route was not registered");
+			return handler;
+		},
+	};
+}
+
+function createRequest(overrides: Record<string, unknown> = {}) {
+	return {
+		response: vi.fn(async () => null),
+		postDataBuffer: vi.fn(() => null),
+		url: vi.fn(() => "https://example.com/data"),
+		method: vi.fn(() => "GET"),
+		headers: vi.fn(() => ({ accept: "*/*" })),
+		...overrides,
+	};
+}
+
+describe("NetworkMocker recording route error paths", () => {
+	it("does not continue a request twice when response inspection fails", async () => {
+		const { mocker, getHandler } = createMocker();
+		await mocker.startRecording();
+
+		const continueRequest = vi.fn(async () => {});
+		const response = vi.fn(async () => {
+			throw new Error("response unavailable");
+		});
+		const request = createRequest({ response });
+
+		await expect(getHandler()({ continue: continueRequest }, request)).resolves.toBeUndefined();
+
+		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(response).toHaveBeenCalledTimes(1);
+		expect(mocker.getRecordings()).toEqual([]);
+	});
+
+	it("does not continue a request twice when the recording callback throws", async () => {
+		const { mocker, getHandler } = createMocker();
+		const onRecording = vi.fn(() => {
+			throw new Error("consumer callback failed");
+		});
+		await mocker.startRecording(onRecording);
+
+		const continueRequest = vi.fn(async () => {});
+		const request = createRequest();
+
+		await expect(getHandler()({ continue: continueRequest }, request)).resolves.toBeUndefined();
+
+		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(onRecording).toHaveBeenCalledTimes(1);
+		expect(mocker.getRecordings()).toHaveLength(1);
+	});
+
+	it("surfaces a continue failure without retrying the same route", async () => {
+		const { mocker, getHandler } = createMocker();
+		await mocker.startRecording();
+
+		const failure = new Error("route continue failed");
+		const continueRequest = vi.fn(async () => {
+			throw failure;
+		});
+		const response = vi.fn(async () => null);
+		const request = createRequest({ response });
+
+		await expect(getHandler()({ continue: continueRequest }, request)).rejects.toBe(failure);
+
+		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(response).not.toHaveBeenCalled();
+		expect(mocker.getRecordings()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- ensure NetworkMocker recording handlers call `route.continue()` at most once per request
- isolate post-continue recording inspection from request routing
- keep response/body/callback recording failures best-effort after the request has already continued
- surface an actual `route.continue()` failure instead of retrying the same Playwright route

## Why

The recording handler previously wrapped both `route.continue()` and all later response inspection in one `try` block, then called `route.continue()` again in `catch`. If response inspection or a consumer callback failed after the request had already continued, Talox attempted to handle the same Playwright route a second time, potentially masking the original recording error with an already-handled route failure.

The handler now has a strict boundary: continue the request exactly once, then treat recording extraction as best-effort without touching the route again.

## Verification

- `tests/unit/NetworkMockerRecordingErrorPaths.test.ts`
- response inspection failure after a successful continue does not trigger a second continue
- consumer recording callback failure does not trigger a second continue and the captured recording remains available
- a real `route.continue()` failure is surfaced and is not retried
- source diff is limited to 3 additions / 3 deletions in `NetworkMocker.ts`
- full repository CI and Docker gates requested via this PR
