### PR TITLE
fix: retry failed video finalization

### DIFF
--- a/src/core/VideoRecorder.ts
+++ b/src/core/VideoRecorder.ts
@@ -37,6 +37,8 @@ export class VideoRecorder {
 	private readonly format: VideoFormat;
 
 	private recording = false;
+	private finalizationPending = false;
+	private stopInFlight: Promise<string> | null = null;
 	private frames: Buffer[] = [];
 	private interval: NodeJS.Timeout | null = null;
 	private page: Page | null = null;
@@ -56,8 +58,12 @@ export class VideoRecorder {
 		if (this.recording) {
 			return;
 		}
+		if (this.finalizationPending) {
+			throw new Error("Cannot start a new video recording while the previous recording awaits finalization.");
+		}
 		this.page = page;
 		this.recording = true;
+		this.finalizationPending = true;
 		this.frames = [];
 
 		const intervalMs = Math.round(1000 / this.fps);
@@ -71,13 +77,28 @@ export class VideoRecorder {
 
 	/**
 	 * Stop capturing and encode the recorded frames into the output file.
+	 * Failed finalization keeps captured frames available for a later retry.
 	 *
 	 * @returns The absolute path to the encoded video or viewer HTML.
 	 */
-	async stop(): Promise<string> {
-		if (!this.recording) {
-			return "";
-		}
+	stop(): Promise<string> {
+		if (this.stopInFlight) return this.stopInFlight;
+		if (!this.finalizationPending) return Promise.resolve("");
+
+		const attempt = this.runStop();
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runStop(): Promise<string> {
 		if (this.interval) {
 			clearInterval(this.interval);
 			this.interval = null;
@@ -89,19 +110,19 @@ export class VideoRecorder {
 		if (this.frames.length === 0) {
 			await mkdir(path.dirname(output), { recursive: true });
 			await writeFile(output, "");
-			return output;
-		}
-
-		const hasFfmpeg = await checkFfmpeg();
-
-		if (hasFfmpeg) {
-			await this.encodeWithFfmpeg(output);
 		} else {
-			await this.savePngSequence(output);
+			const hasFfmpeg = await checkFfmpeg();
+
+			if (hasFfmpeg) {
+				await this.encodeWithFfmpeg(output);
+			} else {
+				await this.savePngSequence(output);
+			}
 		}
 
 		this.frames = [];
 		this.page = null;
+		this.finalizationPending = false;
 		return output;
 	}
 

--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -382,7 +382,16 @@ export class TaloxController {
 		await this.flushHarRecorder();
 		this.disposeCrossOriginManager();
 		await this.detachInspectServer();
-		await this.flushVideoRecorder();
+
+		let videoFailure: unknown;
+		let videoFailed = false;
+		try {
+			await this.flushVideoRecorder();
+		} catch (error) {
+			videoFailure = error;
+			videoFailed = true;
+		}
+
 		this.persistTakeoverHistory();
 		await this.disposeOriginHeaders();
 
@@ -392,6 +401,8 @@ export class TaloxController {
 			this.log.error(`Error during stop(): ${e instanceof Error ? e.message : String(e)}`);
 			throw e;
 		}
+
+		if (videoFailed) throw videoFailure;
 	}
 
 	/** Flush HAR recording if active. */
@@ -426,15 +437,17 @@ export class TaloxController {
 	/** Flush video recording if active. */
 	private async flushVideoRecorder(): Promise<void> {
 		if (!this.videoRecorder) return;
+		const recorder = this.videoRecorder;
 		try {
-			const outputPath = await this.videoRecorder.stop();
+			const outputPath = await recorder.stop();
 			if (this.settings.verbosity >= 1) {
 				this.log.info(`Video recording saved: ${outputPath}`);
 			}
 		} catch (e) {
 			this.log.error(`Video recording flush failed: ${e instanceof Error ? e.message : String(e)}`);
+			throw e;
 		}
-		this.videoRecorder = null;
+		if (this.videoRecorder === recorder) this.videoRecorder = null;
 	}
 
 	/** Persist accumulated takeover history as a final artifact entry. */

--- a/tests/unit/TaloxControllerVideoStopRetry.test.ts
+++ b/tests/unit/TaloxControllerVideoStopRetry.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+describe("TaloxController video stop retry", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("closes the browser despite a video export failure and retries the retained recorder", async () => {
+		const controller = new TaloxController();
+		const videoFailure = new Error("video export failed");
+		const recorder = {
+			stop: vi.fn().mockRejectedValueOnce(videoFailure).mockResolvedValue("/tmp/session.webm"),
+		};
+		(controller as any).videoRecorder = recorder;
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(videoFailure);
+
+		expect(recorder.stop).toHaveBeenCalledTimes(1);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect((controller as any).videoRecorder).toBe(recorder);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+
+		expect(recorder.stop).toHaveBeenCalledTimes(2);
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+		expect((controller as any).videoRecorder).toBeNull();
+	});
+
+	it("prioritizes a session shutdown failure while retaining a failed video export for retry", async () => {
+		const controller = new TaloxController();
+		const videoFailure = new Error("video export failed");
+		const sessionFailure = new Error("browser close failed");
+		const recorder = {
+			stop: vi.fn().mockRejectedValueOnce(videoFailure).mockResolvedValue("/tmp/session.webm"),
+		};
+		(controller as any).videoRecorder = recorder;
+		const sessionStop = vi
+			.spyOn(controller._session, "stop")
+			.mockRejectedValueOnce(sessionFailure)
+			.mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(sessionFailure);
+
+		expect(recorder.stop).toHaveBeenCalledTimes(1);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect((controller as any).videoRecorder).toBe(recorder);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+
+		expect(recorder.stop).toHaveBeenCalledTimes(2);
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+		expect((controller as any).videoRecorder).toBeNull();
+	});
+});

--- a/tests/unit/VideoRecorderStopRetry.test.ts
+++ b/tests/unit/VideoRecorderStopRetry.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+	execFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+	mkdir: vi.fn().mockResolvedValue(undefined),
+	writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { execFile } from "node:child_process";
+import { VideoRecorder } from "../../src/core/VideoRecorder.js";
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function createPage() {
+	return {
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("frame")),
+	} as any;
+}
+
+describe("VideoRecorder stop retry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.mocked(execFile).mockImplementation((_cmd: string, _args: string[], cb: (...args: any[]) => any) => {
+			cb(null);
+			return {
+				stdin: {
+					write: vi.fn().mockReturnValue(true),
+					end: vi.fn(),
+					on: vi.fn(),
+				},
+			} as any;
+		});
+	});
+
+	it("retains captured frames after an export failure and retries finalization", async () => {
+		const recorder = new VideoRecorder({ outputPath: "/tmp/retry.webm", fps: 10 });
+		const page = createPage();
+		recorder.start(page);
+		await vi.advanceTimersByTimeAsync(120);
+		expect(recorder.getFrameCount()).toBeGreaterThan(0);
+
+		const failure = new Error("ffmpeg export failed");
+		const encode = vi
+			.spyOn(recorder as any, "encodeWithFfmpeg")
+			.mockRejectedValueOnce(failure)
+			.mockResolvedValue(undefined);
+
+		await expect(recorder.stop()).rejects.toBe(failure);
+
+		expect(recorder.isRecording()).toBe(false);
+		expect(recorder.getFrameCount()).toBeGreaterThan(0);
+		expect(() => recorder.start(createPage())).toThrow("previous recording awaits finalization");
+
+		await expect(recorder.stop()).resolves.toBe("/tmp/retry.webm");
+		expect(encode).toHaveBeenCalledTimes(2);
+		expect(recorder.getFrameCount()).toBe(0);
+	});
+
+	it("shares one in-flight export across concurrent stop callers", async () => {
+		const recorder = new VideoRecorder({ outputPath: "/tmp/concurrent.webm", fps: 10 });
+		recorder.start(createPage());
+		await vi.advanceTimersByTimeAsync(120);
+
+		const gate = deferred<void>();
+		const encode = vi.spyOn(recorder as any, "encodeWithFfmpeg").mockImplementation(() => gate.promise);
+
+		const firstStop = recorder.stop();
+		const secondStop = recorder.stop();
+		expect(secondStop).toBe(firstStop);
+		await vi.waitFor(() => expect(encode).toHaveBeenCalledTimes(1));
+
+		gate.resolve();
+		await Promise.all([firstStop, secondStop]);
+
+		expect(encode).toHaveBeenCalledTimes(1);
+		expect(recorder.getFrameCount()).toBe(0);
+	});
+});

--- a/tests/unit/VideoRecorderStopRetry.test.ts
+++ b/tests/unit/VideoRecorderStopRetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
 	execFile: vi.fn(),
@@ -41,6 +41,11 @@ describe("VideoRecorder stop retry", () => {
 				},
 			} as any;
 		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
 	});
 
 	it("retains captured frames after an export failure and retries finalization", async () => {


### PR DESCRIPTION
## Summary

- keep captured video frames and recorder state when finalization fails
- make `VideoRecorder.stop()` single-flight and retryable
- block a new recording while the previous recording still awaits successful finalization
- clear frames/page state only after successful export
- retain the controller's recorder reference when video export fails
- continue browser/session shutdown even when video export fails, then propagate the video failure afterward
- prioritize a SessionManager shutdown failure if both browser cleanup and video export fail

## Why

`VideoRecorder.stop()` previously set `recording = false` before encoding or filesystem persistence completed. If ffmpeg or a write failed, captured frames remained in memory but a later `stop()` returned immediately because the recorder was no longer marked recording. A subsequent `start()` could also reset those frames.

At the controller layer, `flushVideoRecorder()` swallowed export errors and unconditionally cleared the recorder reference. That meant MCP/daemon/session owners could consider shutdown successful and discard the controller, making the captured evidence effectively unrecoverable.

The new lifecycle distinguishes active capture from pending finalization. Failed exports retain frames and remain retryable, while controller shutdown still attempts the browser close and exposes the export failure so outer owners keep the retry handle.

## Verification

- `tests/unit/VideoRecorderStopRetry.test.ts`
  - failed export retains frames and blocks a new recording until retry succeeds
  - concurrent `stop()` callers share one encoder run
- `tests/unit/TaloxControllerVideoStopRetry.test.ts`
  - controller closes SessionManager even when video export fails, retains the recorder, and retries it on a later stop
  - if video export and SessionManager shutdown both fail, the browser/session failure takes priority while video evidence remains retryable
- controller diff is limited to +17/-4 around shutdown/video cleanup
- full repository CI and Docker gates requested via this PR
