### PR TITLE
fix: retain failed HAR finalization for retry

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -379,17 +379,25 @@ export class TaloxController {
 	}
 
 	private async runStop(): Promise<void> {
-		await this.flushHarRecorder();
+		let evidenceFailure: unknown;
+		let evidenceFailed = false;
+		try {
+			await this.flushHarRecorder();
+		} catch (error) {
+			evidenceFailure = error;
+			evidenceFailed = true;
+		}
+
 		this.disposeCrossOriginManager();
 		await this.detachInspectServer();
 
-		let videoFailure: unknown;
-		let videoFailed = false;
 		try {
 			await this.flushVideoRecorder();
 		} catch (error) {
-			videoFailure = error;
-			videoFailed = true;
+			if (!evidenceFailed) {
+				evidenceFailure = error;
+				evidenceFailed = true;
+			}
 		}
 
 		this.persistTakeoverHistory();
@@ -402,21 +410,23 @@ export class TaloxController {
 			throw e;
 		}
 
-		if (videoFailed) throw videoFailure;
+		if (evidenceFailed) throw evidenceFailure;
 	}
 
 	/** Flush HAR recording if active. */
 	private async flushHarRecorder(): Promise<void> {
 		if (!this.harRecorder) return;
+		const recorder = this.harRecorder;
 		try {
-			const result = await this.harRecorder.stop();
+			const result = await recorder.stop();
 			if (this.settings.verbosity >= 1) {
 				this.log.info(`HAR recording saved: ${result.outputPath} (${result.entryCount} entries)`);
 			}
 		} catch (e) {
 			this.log.error(`HAR flush failed: ${e instanceof Error ? e.message : String(e)}`);
+			throw e;
 		}
-		this.harRecorder = null;
+		if (this.harRecorder === recorder) this.harRecorder = null;
 	}
 
 	/** Dispose cross-origin iframe manager. */

--- a/tests/unit/HarRecorderStopRetry.test.ts
+++ b/tests/unit/HarRecorderStopRetry.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+	writeFileSync: vi.fn(),
+}));
+
+import { writeFileSync } from "node:fs";
+import { HarRecorder } from "../../src/core/HarRecorder.js";
+
+function createPage() {
+	const listeners = new Map<string, (...args: any[]) => any>();
+	return {
+		on: vi.fn((event: string, handler: (...args: any[]) => any) => {
+			listeners.set(event, handler);
+		}),
+		listener: (event: string) => {
+			const handler = listeners.get(event);
+			if (!handler) throw new Error(`missing ${event} listener`);
+			return handler;
+		},
+	};
+}
+
+describe("HarRecorder stop retry", () => {
+	beforeEach(() => {
+		vi.mocked(writeFileSync).mockReset();
+	});
+
+	it("keeps captured entries available when the first HAR write fails", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/retry.har" });
+		const page = createPage();
+		recorder.start(page as any);
+
+		const request = {
+			method: vi.fn(() => "GET"),
+			url: vi.fn(() => "https://example.com/data"),
+			headers: vi.fn(() => ({ accept: "application/json" })),
+			postData: vi.fn(() => null),
+		};
+		const response = {
+			request: vi.fn(() => request),
+			status: vi.fn(() => 200),
+			statusText: vi.fn(() => "OK"),
+			headers: vi.fn(() => ({ "content-type": "application/json" })),
+			text: vi.fn(async () => "{}"),
+		};
+
+		page.listener("request")(request);
+		await page.listener("response")(response);
+		expect(recorder.getEntries()).toHaveLength(1);
+
+		const failure = new Error("disk temporarily unavailable");
+		vi.mocked(writeFileSync).mockImplementationOnce(() => {
+			throw failure;
+		});
+
+		await expect(recorder.stop()).rejects.toBe(failure);
+		expect(recorder.getEntries()).toHaveLength(1);
+		expect(recorder.isRecording()).toBe(false);
+
+		await expect(recorder.stop()).resolves.toMatchObject({
+			outputPath: "/tmp/retry.har",
+			entryCount: 1,
+		});
+		expect(writeFileSync).toHaveBeenCalledTimes(2);
+		expect(recorder.getEntries()).toHaveLength(1);
+	});
+});

--- a/tests/unit/TaloxControllerHarStopRetry.test.ts
+++ b/tests/unit/TaloxControllerHarStopRetry.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+describe("TaloxController HAR stop retry", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("closes the browser despite a HAR write failure and retries the retained recorder", async () => {
+		const controller = new TaloxController();
+		const harFailure = new Error("HAR write failed");
+		const recorder = {
+			stop: vi
+				.fn()
+				.mockRejectedValueOnce(harFailure)
+				.mockResolvedValue({ outputPath: "/tmp/session.har", entryCount: 3, totalDurationMs: 10 }),
+		};
+		(controller as any).harRecorder = recorder;
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(harFailure);
+
+		expect(recorder.stop).toHaveBeenCalledTimes(1);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect((controller as any).harRecorder).toBe(recorder);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+
+		expect(recorder.stop).toHaveBeenCalledTimes(2);
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+		expect((controller as any).harRecorder).toBeNull();
+	});
+
+	it("prioritizes a session shutdown failure while retaining a failed HAR write for retry", async () => {
+		const controller = new TaloxController();
+		const harFailure = new Error("HAR write failed");
+		const sessionFailure = new Error("browser close failed");
+		const recorder = {
+			stop: vi
+				.fn()
+				.mockRejectedValueOnce(harFailure)
+				.mockResolvedValue({ outputPath: "/tmp/session.har", entryCount: 1, totalDurationMs: 0 }),
+		};
+		(controller as any).harRecorder = recorder;
+		const sessionStop = vi
+			.spyOn(controller._session, "stop")
+			.mockRejectedValueOnce(sessionFailure)
+			.mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(sessionFailure);
+
+		expect(recorder.stop).toHaveBeenCalledTimes(1);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect((controller as any).harRecorder).toBe(recorder);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+		expect(recorder.stop).toHaveBeenCalledTimes(2);
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+		expect((controller as any).harRecorder).toBeNull();
+	});
+
+	it("attempts both HAR and video finalization and retains both when they fail together", async () => {
+		const controller = new TaloxController();
+		const harFailure = new Error("HAR write failed");
+		const videoFailure = new Error("video export failed");
+		const harRecorder = {
+			stop: vi
+				.fn()
+				.mockRejectedValueOnce(harFailure)
+				.mockResolvedValue({ outputPath: "/tmp/session.har", entryCount: 2, totalDurationMs: 1 }),
+		};
+		const videoRecorder = {
+			stop: vi.fn().mockRejectedValueOnce(videoFailure).mockResolvedValue("/tmp/session.webm"),
+		};
+		(controller as any).harRecorder = harRecorder;
+		(controller as any).videoRecorder = videoRecorder;
+		const sessionStop = vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+
+		await expect(controller.stop()).rejects.toBe(harFailure);
+
+		expect(harRecorder.stop).toHaveBeenCalledTimes(1);
+		expect(videoRecorder.stop).toHaveBeenCalledTimes(1);
+		expect(sessionStop).toHaveBeenCalledTimes(1);
+		expect((controller as any).harRecorder).toBe(harRecorder);
+		expect((controller as any).videoRecorder).toBe(videoRecorder);
+
+		await expect(controller.stop()).resolves.toBeUndefined();
+
+		expect(harRecorder.stop).toHaveBeenCalledTimes(2);
+		expect(videoRecorder.stop).toHaveBeenCalledTimes(2);
+		expect(sessionStop).toHaveBeenCalledTimes(2);
+		expect((controller as any).harRecorder).toBeNull();
+		expect((controller as any).videoRecorder).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

- retain the HAR recorder when persistence fails instead of discarding the only retry handle
- propagate HAR persistence failures after browser/session cleanup completes
- continue inspect, video, origin-header, and SessionManager cleanup even when HAR finalization fails
- keep the existing browser/session shutdown failure as the highest-priority stop error
- generalize auxiliary evidence cleanup so HAR and video are both attempted when they fail together
- preserve the first evidence failure for the caller while retaining every failed recorder for a later stop retry

## Why

`flushHarRecorder()` previously swallowed `HarRecorder.stop()` failures and unconditionally set `harRecorder = null`. A transient disk/write failure therefore left the captured HAR entries in the recorder object but discarded the controller's last reference to that object. Outer owners saw a successful stop and could drop the controller entirely.

Simply propagating the HAR error was also unsafe because HAR finalization happens at the start of `runStop()`: it would have prevented inspect/video cleanup and, most importantly, the browser/session close.

The controller now treats HAR/video persistence as recoverable evidence cleanup. It remembers the first evidence failure, continues all teardown, lets a SessionManager shutdown error take priority if necessary, and only then reports the evidence error so MCP/daemon/coordinator owners retain the controller for retry.

## Verification

- `tests/unit/HarRecorderStopRetry.test.ts`
  - real HarRecorder keeps captured entries after a failed write and succeeds on a later `stop()`
- `tests/unit/TaloxControllerHarStopRetry.test.ts`
  - HAR failure still closes SessionManager, retains the recorder, and retries successfully
  - simultaneous HAR + browser shutdown failure prioritizes the browser failure while retaining HAR
  - simultaneous HAR + video failures attempt both evidence finalizers, retain both, and recover on a later stop
- controller source diff is limited to +18/-8 around evidence shutdown handling
- full repository CI and Docker gates requested via this PR
