### PR TITLE
fix: own HAR recorder page listeners

### DIFF
--- a/src/core/HarRecorder.ts
+++ b/src/core/HarRecorder.ts
@@ -92,6 +92,9 @@ interface PendingRequest {
 	timestamp: number;
 }
 
+type RequestHandler = (request: Request) => void;
+type ResponseHandler = (response: Response) => void;
+
 // ─── HarRecorder ────────────────────────────────────────────────────────────
 
 export class HarRecorder {
@@ -100,6 +103,11 @@ export class HarRecorder {
 	private recording = false;
 	private readonly entries: HarEntry[] = [];
 	private readonly pending = new Map<Request, PendingRequest>();
+	private readonly responseCaptures = new Set<Promise<void>>();
+	private page: Page | null = null;
+	private requestHandler: RequestHandler | null = null;
+	private responseHandler: ResponseHandler | null = null;
+	private stopInFlight: Promise<HarResult> | null = null;
 	private readonly version = "5.0.1";
 
 	constructor(options: HarRecorderOptions) {
@@ -115,17 +123,79 @@ export class HarRecorder {
 	 */
 	start(page: Page): void {
 		if (this.recording) return;
-		this.recording = true;
+		if (this.page || this.requestHandler || this.responseHandler) {
+			throw new Error("Cannot start HAR recording while previous page listeners await cleanup. Call stop() again first.");
+		}
 
-		page.on("request", (req: Request) => this.captureRequest(req));
-		page.on("response", (res: Response) => this.captureResponse(res));
+		const requestHandler: RequestHandler = (request) => {
+			if (this.recording) this.captureRequest(request);
+		};
+		const responseHandler: ResponseHandler = (response) => {
+			if (!this.recording) return;
+			const capture = this.captureResponse(response);
+			this.responseCaptures.add(capture);
+			void capture.then(
+				() => this.responseCaptures.delete(capture),
+				() => this.responseCaptures.delete(capture),
+			);
+		};
+
+		page.on("request", requestHandler);
+		this.page = page;
+		this.requestHandler = requestHandler;
+
+		try {
+			page.on("response", responseHandler);
+			this.responseHandler = responseHandler;
+		} catch (error) {
+			try {
+				page.off("request", requestHandler);
+				this.page = null;
+				this.requestHandler = null;
+			} catch {
+				// Keep listener ownership so a later stop() can retry cleanup.
+			}
+			throw error;
+		}
+
+		this.recording = true;
 	}
 
 	/**
 	 * Flush all captured entries to a HAR 1.2 file and return a summary.
 	 */
-	async stop(): Promise<HarResult> {
+	stop(): Promise<HarResult> {
+		if (this.stopInFlight) return this.stopInFlight;
+
+		const attempt = this.runStop();
+		this.stopInFlight = attempt;
+		attempt.then(
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+			() => {
+				if (this.stopInFlight === attempt) this.stopInFlight = null;
+			},
+		);
+		return attempt;
+	}
+
+	private async runStop(): Promise<HarResult> {
 		this.recording = false;
+
+		let listenerFailure: unknown;
+		let listenerCleanupFailed = false;
+		try {
+			this.detachPageListeners();
+		} catch (error) {
+			listenerFailure = error;
+			listenerCleanupFailed = true;
+		}
+
+		if (this.responseCaptures.size > 0) {
+			await Promise.allSettled([...this.responseCaptures]);
+		}
+		this.pending.clear();
 
 		const har: HarFile = {
 			log: {
@@ -137,11 +207,14 @@ export class HarRecorder {
 
 		writeFileSync(this.outputPath, JSON.stringify(har, null, 2), "utf-8");
 
-		return {
+		const result = {
 			outputPath: this.outputPath,
 			entryCount: this.entries.length,
 			totalDurationMs: this.computeTotalDuration(),
 		};
+
+		if (listenerCleanupFailed) throw listenerFailure;
+		return result;
 	}
 
 	isRecording(): boolean {
@@ -153,6 +226,40 @@ export class HarRecorder {
 	}
 
 	// ── Internal helpers ───────────────────────────────────────────────────
+
+	private detachPageListeners(): void {
+		const page = this.page;
+		if (!page) return;
+
+		let firstFailure: unknown;
+		let failed = false;
+		const requestHandler = this.requestHandler;
+		if (requestHandler) {
+			try {
+				page.off("request", requestHandler);
+				if (this.requestHandler === requestHandler) this.requestHandler = null;
+			} catch (error) {
+				firstFailure = error;
+				failed = true;
+			}
+		}
+
+		const responseHandler = this.responseHandler;
+		if (responseHandler) {
+			try {
+				page.off("response", responseHandler);
+				if (this.responseHandler === responseHandler) this.responseHandler = null;
+			} catch (error) {
+				if (!failed) firstFailure = error;
+				failed = true;
+			}
+		}
+
+		if (!this.requestHandler && !this.responseHandler && this.page === page) {
+			this.page = null;
+		}
+		if (failed) throw firstFailure;
+	}
 
 	private captureRequest(req: Request): void {
 		const headers = this.headersToArray(req.headers());

--- a/src/core/HarRecorder.ts
+++ b/src/core/HarRecorder.ts
@@ -93,7 +93,7 @@ interface PendingRequest {
 }
 
 type RequestHandler = (request: Request) => void;
-type ResponseHandler = (response: Response) => void;
+type ResponseHandler = (response: Response) => Promise<void>;
 
 // ─── HarRecorder ────────────────────────────────────────────────────────────
 
@@ -131,13 +131,14 @@ export class HarRecorder {
 			if (this.recording) this.captureRequest(request);
 		};
 		const responseHandler: ResponseHandler = (response) => {
-			if (!this.recording) return;
+			if (!this.recording) return Promise.resolve();
 			const capture = this.captureResponse(response);
 			this.responseCaptures.add(capture);
 			void capture.then(
 				() => this.responseCaptures.delete(capture),
 				() => this.responseCaptures.delete(capture),
 			);
+			return capture;
 		};
 
 		page.on("request", requestHandler);

--- a/tests/unit/HarRecorder.test.ts
+++ b/tests/unit/HarRecorder.test.ts
@@ -53,6 +53,9 @@ function createMockPage() {
 			listeners[event] = listeners[event] || [];
 			listeners[event].push(handler);
 		}),
+		off: vi.fn().mockImplementation((event: string, handler: (...args: any[]) => any) => {
+			listeners[event] = (listeners[event] || []).filter((candidate) => candidate !== handler);
+		}),
 		getListeners: (event: string) => listeners[event] || [],
 	};
 }
@@ -82,7 +85,7 @@ describe("HarRecorder", () => {
 			const page = createMockPage();
 			recorder.start(page as any);
 			recorder.start(page as any);
-			expect(page.on).toHaveBeenCalledTimes(2); // once per start call
+			expect(page.on).toHaveBeenCalledTimes(2); // one request + one response listener
 		});
 
 		it("stop sets recording to false", async () => {

--- a/tests/unit/HarRecorderListenerLifecycle.test.ts
+++ b/tests/unit/HarRecorderListenerLifecycle.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+	writeFileSync: vi.fn(),
+}));
+
+import { writeFileSync } from "node:fs";
+import { HarRecorder } from "../../src/core/HarRecorder.js";
+
+function deferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function createPage() {
+	const listeners = new Map<string, Array<(...args: any[]) => any>>();
+	const page = {
+		on: vi.fn((event: string, handler: (...args: any[]) => any) => {
+			const current = listeners.get(event) ?? [];
+			current.push(handler);
+			listeners.set(event, current);
+		}),
+		off: vi.fn((event: string, handler: (...args: any[]) => any) => {
+			listeners.set(
+				event,
+				(listeners.get(event) ?? []).filter((candidate) => candidate !== handler),
+			);
+		}),
+		listeners: (event: string) => [...(listeners.get(event) ?? [])],
+	};
+	return page;
+}
+
+function createRequest(url = "https://example.com/data") {
+	return {
+		method: vi.fn(() => "GET"),
+		url: vi.fn(() => url),
+		headers: vi.fn(() => ({ accept: "application/json" })),
+		postData: vi.fn(() => null),
+	};
+}
+
+function createResponse(request: ReturnType<typeof createRequest>, text: () => Promise<string> = async () => "{}") {
+	return {
+		request: vi.fn(() => request),
+		status: vi.fn(() => 200),
+		statusText: vi.fn(() => "OK"),
+		headers: vi.fn(() => ({ "content-type": "application/json" })),
+		text: vi.fn(text),
+	};
+}
+
+describe("HarRecorder listener lifecycle", () => {
+	beforeEach(() => {
+		vi.mocked(writeFileSync).mockReset();
+	});
+
+	it("removes exactly its owned request and response listeners on stop", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/listeners.har" });
+		const page = createPage();
+		recorder.start(page as any);
+
+		const requestHandler = page.listeners("request")[0]!;
+		const responseHandler = page.listeners("response")[0]!;
+
+		await recorder.stop();
+
+		expect(page.off).toHaveBeenCalledWith("request", requestHandler);
+		expect(page.off).toHaveBeenCalledWith("response", responseHandler);
+		expect(page.listeners("request")).toEqual([]);
+		expect(page.listeners("response")).toEqual([]);
+	});
+
+	it("keeps stale handler references inert after stop", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/stale.har" });
+		const page = createPage();
+		recorder.start(page as any);
+		const requestHandler = page.listeners("request")[0]!;
+		const responseHandler = page.listeners("response")[0]!;
+
+		await recorder.stop();
+
+		const request = createRequest();
+		requestHandler(request);
+		await responseHandler(createResponse(request));
+
+		expect(recorder.getEntries()).toEqual([]);
+	});
+
+	it("can restart on the same page without stacking listeners or stale pending requests", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/restart.har" });
+		const page = createPage();
+		recorder.start(page as any);
+		const oldRequestHandler = page.listeners("request")[0]!;
+		const oldResponseHandler = page.listeners("response")[0]!;
+		const abandonedRequest = createRequest("https://example.com/abandoned");
+		oldRequestHandler(abandonedRequest);
+
+		await recorder.stop();
+		recorder.start(page as any);
+
+		expect(page.listeners("request")).toHaveLength(1);
+		expect(page.listeners("response")).toHaveLength(1);
+
+		await oldResponseHandler(createResponse(abandonedRequest));
+		expect(recorder.getEntries()).toEqual([]);
+
+		const request = createRequest("https://example.com/fresh");
+		page.listeners("request")[0]!(request);
+		await page.listeners("response")[0]!(createResponse(request));
+
+		expect(recorder.getEntries()).toHaveLength(1);
+		expect(recorder.getEntries()[0]!.request.url).toBe("https://example.com/fresh");
+	});
+
+	it("waits for an in-flight response capture before writing the HAR file", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/in-flight.har" });
+		const page = createPage();
+		recorder.start(page as any);
+
+		const request = createRequest();
+		page.listeners("request")[0]!(request);
+		const body = deferred<string>();
+		const responseCapture = page.listeners("response")[0]!(createResponse(request, () => body.promise));
+
+		const stop = recorder.stop();
+		await Promise.resolve();
+		expect(writeFileSync).not.toHaveBeenCalled();
+
+		body.resolve('{"done":true}');
+		await responseCapture;
+		const result = await stop;
+
+		expect(result.entryCount).toBe(1);
+		expect(writeFileSync).toHaveBeenCalledTimes(1);
+		const har = JSON.parse(vi.mocked(writeFileSync).mock.calls[0]![1] as string);
+		expect(har.log.entries).toHaveLength(1);
+		expect(har.log.entries[0].response.content.text).toBe('{"done":true}');
+	});
+
+	it("retains a listener whose removal fails and retries cleanup on a later stop", async () => {
+		const recorder = new HarRecorder({ outputPath: "/tmp/off-retry.har" });
+		const page = createPage();
+		recorder.start(page as any);
+		const requestHandler = page.listeners("request")[0]!;
+		const failure = new Error("request listener removal failed");
+		page.off.mockImplementationOnce((event: string, handler: (...args: any[]) => any) => {
+			if (event === "request") throw failure;
+			page.listeners(event).filter((candidate) => candidate !== handler);
+		});
+
+		await expect(recorder.stop()).rejects.toBe(failure);
+
+		expect(writeFileSync).toHaveBeenCalledTimes(1);
+		expect(page.listeners("request")).toContain(requestHandler);
+		expect(page.listeners("response")).toEqual([]);
+		expect(() => recorder.start(page as any)).toThrow("previous page listeners await cleanup");
+
+		await expect(recorder.stop()).resolves.toMatchObject({ outputPath: "/tmp/off-retry.har" });
+		expect(writeFileSync).toHaveBeenCalledTimes(2);
+		expect(page.listeners("request")).toEqual([]);
+
+		expect(() => recorder.start(page as any)).not.toThrow();
+	});
+});

--- a/tests/unit/HarRecorderStopRetry.test.ts
+++ b/tests/unit/HarRecorderStopRetry.test.ts
@@ -13,6 +13,9 @@ function createPage() {
 		on: vi.fn((event: string, handler: (...args: any[]) => any) => {
 			listeners.set(event, handler);
 		}),
+		off: vi.fn((event: string, handler: (...args: any[]) => any) => {
+			if (listeners.get(event) === handler) listeners.delete(event);
+		}),
 		listener: (event: string) => {
 			const handler = listeners.get(event);
 			if (!handler) throw new Error(`missing ${event} listener`);


### PR DESCRIPTION
## Summary

- store exact HAR request/response listener references instead of anonymous handlers
- remove only HarRecorder-owned page listeners on stop
- make stale listener callbacks inert after recording stops
- block restart while a previous listener cleanup is still unresolved
- make stop single-flight and retry failed listener removal without losing ownership
- wait for already-started response captures before writing the HAR file
- clear incomplete pending requests so a later restart cannot complete stale traffic

## Why

HarRecorder previously installed anonymous `request` and `response` listeners and never removed them. A start → stop → start cycle on the same page stacked handlers and could duplicate captured traffic. Worse, the listeners did not check the recorder state, so traffic after `stop()` could still be captured even though `isRecording()` returned false.

There was also a stop race: a response handler could begin before stop, await the response body, and append its HAR entry after the file had already been written. That made the persisted HAR incomplete while the in-memory recorder changed after stop had supposedly completed.

The recorder now owns its exact listeners, detaches them explicitly, waits for in-flight response captures, drops incomplete pending requests, and only then writes the final HAR. Partial listener cleanup failures retain the remaining handler for a later retry.

## Verification

- existing HarRecorder tests now model targeted `page.off(event, handler)` cleanup
- `tests/unit/HarRecorderListenerLifecycle.test.ts`
  - stop unregisters exactly the owned request/response handlers
  - saved stale handler references are inert after stop
  - restart on the same page does not stack listeners and stale pending requests cannot leak into the new run
  - stop waits for an in-flight response body capture before writing the HAR
  - failed listener removal is retained, blocks premature restart, and succeeds on a later stop retry
- existing HAR write-retry coverage remains compatible with listener cleanup
- full repository CI and Docker gates requested via this PR
