### PR TITLE
fix: prevent takeover bridge listener leaks

### DIFF
--- a/src/core/controller/TakeoverBridge.ts
+++ b/src/core/controller/TakeoverBridge.ts
@@ -250,6 +250,25 @@ export class TakeoverBridge {
 		return this.initialize(page, this.headed);
 	}
 
+	/** Release EventBus subscriptions, timers, and the current page reference. */
+	dispose(): void {
+		if (this.timeoutTimer) {
+			clearTimeout(this.timeoutTimer);
+			this.timeoutTimer = null;
+		}
+		if (this.eventSubscriptionsInstalled) {
+			this.eventBus.off("humanTakeoverRequested", this.takeoverRequestedHandler);
+			this.eventBus.off("agentResumed", this.agentResumedHandler);
+			this.eventSubscriptionsInstalled = false;
+		}
+		this.currentPage = null;
+		this.headed = false;
+		this.state = "AGENT_RUNNING";
+		this.takeoverStartedAt = null;
+		this.takeoverReason = undefined;
+		this.takeoverStartedUrl = null;
+	}
+
 	/** Signal agent is paused (human has control). */
 	async requestTakeover(reason?: string): Promise<void> {
 		const timestamp = new Date().toISOString();

--- a/src/core/controller/TakeoverBridge.ts
+++ b/src/core/controller/TakeoverBridge.ts
@@ -193,6 +193,7 @@ export class TakeoverBridge {
 	private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
 	private headed = false;
 	private currentPage: Page | null = null;
+	private currentPageCloseHandler: (() => void) | null = null;
 	private takeoverStartedAt: string | null = null;
 	private takeoverReason: string | undefined = undefined;
 	private takeoverStartedUrl: string | null = null;
@@ -212,10 +213,13 @@ export class TakeoverBridge {
 	 * Only injects when headed=true. Safe to re-call with a new page (SessionManager swaps).
 	 */
 	async initialize(page: Page, headed: boolean): Promise<void> {
+		this.detachPageCloseHandler();
 		this.headed = headed;
 		this.currentPage = page;
 
 		if (!headed) return; // headless: no overlay
+
+		this.installPageCloseHandler(page);
 
 		// 1. Inject overlay bundle — persists across ALL navigations
 		await page.addInitScript(AGENT_OVERLAY_SCRIPT);
@@ -261,6 +265,7 @@ export class TakeoverBridge {
 			this.eventBus.off("agentResumed", this.agentResumedHandler);
 			this.eventSubscriptionsInstalled = false;
 		}
+		this.detachPageCloseHandler();
 		this.currentPage = null;
 		this.headed = false;
 		this.state = "AGENT_RUNNING";
@@ -344,6 +349,20 @@ export class TakeoverBridge {
 	}
 
 	// ─── Helpers ─────────────────────────────────────────────────────────────
+
+	private installPageCloseHandler(page: Page): void {
+		const handler = () => {
+			if (this.currentPage === page) this.dispose();
+		};
+		this.currentPageCloseHandler = handler;
+		page.on("close", handler);
+	}
+
+	private detachPageCloseHandler(): void {
+		if (!this.currentPage || !this.currentPageCloseHandler) return;
+		this.currentPage.off("close", this.currentPageCloseHandler);
+		this.currentPageCloseHandler = null;
+	}
 
 	private buildSummary(endReason: "manual" | "timeout"): TakeoverSummary | undefined {
 		if (!this.takeoverStartedAt) return undefined;

--- a/src/core/controller/TakeoverBridge.ts
+++ b/src/core/controller/TakeoverBridge.ts
@@ -196,6 +196,9 @@ export class TakeoverBridge {
 	private takeoverStartedAt: string | null = null;
 	private takeoverReason: string | undefined = undefined;
 	private takeoverStartedUrl: string | null = null;
+	private eventSubscriptionsInstalled = false;
+	private readonly takeoverRequestedHandler = () => void this.onTakeoverRequested();
+	private readonly agentResumedHandler = (event: TaloxEventMap["agentResumed"]) => void this.onAgentResumed(event.reason);
 
 	constructor(eventBus: EventBus<TaloxEventMap>, timeoutMs = 120_000) {
 		this.eventBus = eventBus;
@@ -237,9 +240,7 @@ export class TakeoverBridge {
 			// Already registered
 		}
 
-		// 4. Subscribe to EventBus events
-		this.eventBus.on("humanTakeoverRequested", () => void this.onTakeoverRequested());
-		this.eventBus.on("agentResumed", (e) => void this.onAgentResumed(e.reason));
+		this.ensureEventSubscriptions();
 	}
 
 	/**
@@ -274,8 +275,19 @@ export class TakeoverBridge {
 
 	// ─── EventBus handlers ────────────────────────────────────────────────────
 
+	private ensureEventSubscriptions(): void {
+		if (this.eventSubscriptionsInstalled) return;
+		this.eventBus.on("humanTakeoverRequested", this.takeoverRequestedHandler);
+		this.eventBus.on("agentResumed", this.agentResumedHandler);
+		this.eventSubscriptionsInstalled = true;
+	}
+
 	private async onTakeoverRequested(): Promise<void> {
 		this.state = "WAITING_FOR_HUMAN";
+		if (this.timeoutTimer) {
+			clearTimeout(this.timeoutTimer);
+			this.timeoutTimer = null;
+		}
 		// Register timeout before awaiting overlay update so fake-timer tests work correctly
 		if (this.timeoutMs > 0) {
 			this.timeoutTimer = setTimeout(() => {

--- a/tests/unit/TakeoverBridge.test.ts
+++ b/tests/unit/TakeoverBridge.test.ts
@@ -14,6 +14,8 @@ function makePage() {
 		addInitScript: vi.fn().mockResolvedValue(undefined),
 		exposeFunction: vi.fn().mockResolvedValue(undefined),
 		evaluate: vi.fn().mockResolvedValue(undefined),
+		on: vi.fn(),
+		off: vi.fn(),
 		url: vi.fn().mockReturnValue("https://example.com"),
 	};
 }

--- a/tests/unit/TakeoverBridgeListenerLifecycle.test.ts
+++ b/tests/unit/TakeoverBridgeListenerLifecycle.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+import { TakeoverBridge } from "../../src/core/controller/TakeoverBridge.js";
+import type { TaloxEventMap } from "../../src/types/events.js";
+
+function makePage() {
+	const listeners = new Map<string, Set<(...args: any[]) => void>>();
+	const page = {
+		addInitScript: vi.fn().mockResolvedValue(undefined),
+		exposeFunction: vi.fn().mockResolvedValue(undefined),
+		evaluate: vi.fn().mockResolvedValue(undefined),
+		url: vi.fn().mockReturnValue("https://example.com"),
+		on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			const eventListeners = listeners.get(event) ?? new Set<(...args: any[]) => void>();
+			eventListeners.add(handler);
+			listeners.set(event, eventListeners);
+			return page;
+		}),
+		off: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			listeners.get(event)?.delete(handler);
+			return page;
+		}),
+		emit: (event: string, ...args: any[]) => {
+			for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
+		},
+		listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+	};
+	return page;
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("TakeoverBridge listener lifecycle", () => {
+	it("does not duplicate EventBus subscriptions across page reinitialization", async () => {
+		const bus = new EventBus<TaloxEventMap>();
+		const bridge = new TakeoverBridge(bus, 0);
+		const firstPage = makePage();
+		const secondPage = makePage();
+
+		await bridge.initialize(firstPage as any, true);
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(1);
+		expect(bus.listenerCount("agentResumed")).toBe(1);
+
+		await bridge.reinitialize(secondPage as any);
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(1);
+		expect(bus.listenerCount("agentResumed")).toBe(1);
+
+		await bridge.requestTakeover("manual");
+		await Promise.resolve();
+		expect(secondPage.evaluate).toHaveBeenCalledTimes(1);
+	});
+
+	it("moves page-close ownership to the current page and disposes when it closes", async () => {
+		const bus = new EventBus<TaloxEventMap>();
+		const bridge = new TakeoverBridge(bus, 0);
+		const firstPage = makePage();
+		const secondPage = makePage();
+
+		await bridge.initialize(firstPage as any, true);
+		await bridge.reinitialize(secondPage as any);
+
+		expect(firstPage.listenerCount("close")).toBe(0);
+		expect(secondPage.listenerCount("close")).toBe(1);
+
+		firstPage.emit("close");
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(1);
+
+		secondPage.emit("close");
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(0);
+		expect(bus.listenerCount("agentResumed")).toBe(0);
+		expect(secondPage.listenerCount("close")).toBe(0);
+		expect(bridge.getState()).toBe("AGENT_RUNNING");
+	});
+
+	it("dispose clears an active takeover timeout and owned subscriptions", async () => {
+		vi.useFakeTimers();
+		const bus = new EventBus<TaloxEventMap>();
+		const bridge = new TakeoverBridge(bus, 5_000);
+		const page = makePage();
+
+		await bridge.initialize(page as any, true);
+		await bridge.requestTakeover("manual");
+		expect(vi.getTimerCount()).toBe(1);
+
+		bridge.dispose();
+
+		expect(vi.getTimerCount()).toBe(0);
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(0);
+		expect(bus.listenerCount("agentResumed")).toBe(0);
+		expect(page.listenerCount("close")).toBe(0);
+		expect(bridge.getState()).toBe("AGENT_RUNNING");
+	});
+
+	it("replaces the takeover timeout instead of stacking timers", async () => {
+		vi.useFakeTimers();
+		const bus = new EventBus<TaloxEventMap>();
+		const bridge = new TakeoverBridge(bus, 5_000);
+		const page = makePage();
+
+		await bridge.initialize(page as any, true);
+		await bridge.requestTakeover("first");
+		await bridge.requestTakeover("second");
+
+		expect(vi.getTimerCount()).toBe(1);
+	});
+
+	it("can subscribe again after page-close disposal", async () => {
+		const bus = new EventBus<TaloxEventMap>();
+		const bridge = new TakeoverBridge(bus, 0);
+		const firstPage = makePage();
+		const secondPage = makePage();
+
+		await bridge.initialize(firstPage as any, true);
+		firstPage.emit("close");
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(0);
+
+		await bridge.initialize(secondPage as any, true);
+		expect(bus.listenerCount("humanTakeoverRequested")).toBe(1);
+		expect(bus.listenerCount("agentResumed")).toBe(1);
+		expect(secondPage.listenerCount("close")).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- make TakeoverBridge EventBus subscriptions idempotent across page reinitialization
- store exact takeover/resume handler references instead of adding anonymous handlers per page
- own the current page's `close` listener and move that ownership on page swaps
- dispose EventBus subscriptions, page-close listener, active timeout, page reference, and takeover state when the current page closes
- allow a disposed bridge to subscribe cleanly again on a later initialization
- replace an existing takeover timeout before scheduling another one so repeated takeover events cannot stack timers

## Why

`TakeoverBridge.initialize()` previously registered new `humanTakeoverRequested` and `agentResumed` EventBus listeners every time it ran. `reinitialize(page)` is explicitly used for page swaps, so listener counts grew with each swap. One takeover event could therefore run the same state transition multiple times, issue duplicate overlay commands, and create multiple timeout timers.

The bridge also had no page-lifecycle teardown, so its EventBus subscriptions and timeout could outlive the browser page that owned the overlay.

The new lifecycle treats EventBus and page-close handlers as bridge-owned resources. Reinitialize preserves one EventBus subscription pair while moving only the page-close handler. Closing the current page disposes the bridge, and a later initialize can safely subscribe again.

## Verification

- existing TakeoverBridge test page fake now models `page.on/off`
- `tests/unit/TakeoverBridgeListenerLifecycle.test.ts`
  - reinitialize keeps exactly one takeover and one resume EventBus listener
  - page-close ownership moves from the old page to the new page
  - closing the current page removes EventBus/page listeners and resets state
  - dispose clears an active takeover timeout
  - repeated takeover events leave only one timeout
  - a bridge can initialize and subscribe again after page-close disposal
- source diff is limited to TakeoverBridge lifecycle ownership plus tests
- full repository CI and Docker gates requested via this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved takeover handling during page reinitialization to prevent duplicate event subscriptions.
  * Cleaned up timers, listeners, and takeover state when pages close or the bridge is disposed.
  * Improved ownership transfer and timer replacement behavior across page lifecycle changes.

* **Tests**
  * Added coverage for listener cleanup, disposal, timeout handling, and resubscription scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->