### PR TITLE
fix: make takeover timeout ownership single-source

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -135,7 +135,7 @@ export class TaloxController {
 	private behavioralDNA: any = null;
 
 	private takeoverState: "AGENT_RUNNING" | "WAITING_FOR_HUMAN" = "AGENT_RUNNING";
-	private autoResumeTimer: NodeJS.Timeout | null = null;
+	private pendingTakeoverResolve: (() => void) | null = null;
 	private readonly takeoverHistory: TakeoverSummary[] = [];
 	private readonly observing: boolean;
 	private originHeaders: OriginHeaders | null = null;
@@ -409,6 +409,9 @@ export class TaloxController {
 			this.log.error(`Error during stop(): ${e instanceof Error ? e.message : String(e)}`);
 			throw e;
 		}
+
+		this.finishPendingTakeover();
+		this._takeover.dispose();
 
 		if (evidenceFailed) throw evidenceFailure;
 	}
@@ -757,20 +760,13 @@ export class TaloxController {
 	async requestHumanTakeover(reason?: string): Promise<void> {
 		if (this.takeoverState === "WAITING_FOR_HUMAN") return;
 
+		this.takeoverState = "WAITING_FOR_HUMAN";
 		return new Promise<void>((resolve) => {
-			this._events.once("agentResumed", (_e) => resolve());
-
-			this.takeoverState = "WAITING_FOR_HUMAN";
-			// TakeoverBridge listens to this event to update the overlay
+			this.pendingTakeoverResolve = resolve;
+			// TakeoverBridge owns timeout policy and emits agentResumed on completion.
 			this._takeover.requestTakeover(reason).catch((e) => {
 				this.log.error(`Takeover request failed: ${e instanceof Error ? e.message : String(e)}`);
 			});
-
-			if (this.settings.humanTakeoverTimeoutMs > 0) {
-				this.autoResumeTimer = setTimeout(() => {
-					this.resumeAgent();
-				}, this.settings.humanTakeoverTimeoutMs);
-			}
 		});
 	}
 
@@ -780,14 +776,6 @@ export class TaloxController {
 	 */
 	resumeAgent(): void {
 		if (this.takeoverState !== "WAITING_FOR_HUMAN") return;
-
-		if (this.autoResumeTimer) {
-			clearTimeout(this.autoResumeTimer);
-			this.autoResumeTimer = null;
-		}
-
-		this.takeoverState = "AGENT_RUNNING";
-		// TakeoverBridge listens to this event to restore the overlay
 		this._takeover.resumeAgent();
 	}
 
@@ -809,12 +797,20 @@ export class TaloxController {
 	}
 
 	private recordTakeoverResume(payload: TaloxEventMap["agentResumed"]): void {
+		this.finishPendingTakeover();
 		if (payload.summary) {
 			this.takeoverHistory.push(payload.summary);
 			this._session.artifactBuilder.addAction("takeoverResumed", payload.summary);
 		} else {
 			this._session.artifactBuilder.addAction("takeoverResumed", payload);
 		}
+	}
+
+	private finishPendingTakeover(): void {
+		this.takeoverState = "AGENT_RUNNING";
+		const resolve = this.pendingTakeoverResolve;
+		this.pendingTakeoverResolve = null;
+		resolve?.();
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════════

--- a/tests/unit/TaloxControllerTakeoverTimeoutOwnership.test.ts
+++ b/tests/unit/TaloxControllerTakeoverTimeoutOwnership.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+
+function makePage() {
+	const listeners = new Map<string, Set<(...args: any[]) => void>>();
+	const page = {
+		addInitScript: vi.fn().mockResolvedValue(undefined),
+		exposeFunction: vi.fn().mockResolvedValue(undefined),
+		evaluate: vi.fn().mockResolvedValue(undefined),
+		url: vi.fn().mockReturnValue("https://example.com"),
+		on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			const handlers = listeners.get(event) ?? new Set<(...args: any[]) => void>();
+			handlers.add(handler);
+			listeners.set(event, handlers);
+			return page;
+		}),
+		off: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			listeners.get(event)?.delete(handler);
+			return page;
+		}),
+		emit: (event: string, ...args: any[]) => {
+			for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
+		},
+	};
+	return page;
+}
+
+async function makeController(timeoutMs = 500) {
+	const controller = new TaloxController(".", { humanTakeover: { timeoutMs } });
+	const page = makePage();
+	await controller._takeover.initialize(page as any, true);
+	return { controller, page };
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("TaloxController takeover timeout ownership", () => {
+	it("uses the bridge as the sole timeout owner and emits one timeout resume", async () => {
+		vi.useFakeTimers();
+		const { controller } = await makeController();
+		const resumed = vi.fn();
+		controller.on("agentResumed", resumed);
+
+		const pending = controller.requestHumanTakeover("manual");
+		expect(controller.getTakeoverState()).toBe("WAITING_FOR_HUMAN");
+		expect(vi.getTimerCount()).toBe(1);
+
+		await vi.advanceTimersByTimeAsync(500);
+		await pending;
+
+		expect(controller.getTakeoverState()).toBe("AGENT_RUNNING");
+		expect(resumed).toHaveBeenCalledTimes(1);
+		expect(resumed).toHaveBeenCalledWith(expect.objectContaining({ reason: "timeout" }));
+		expect(vi.getTimerCount()).toBe(0);
+
+		await vi.advanceTimersByTimeAsync(500);
+		expect(resumed).toHaveBeenCalledTimes(1);
+	});
+
+	it("manual resume settles the pending takeover and clears the bridge timeout", async () => {
+		vi.useFakeTimers();
+		const { controller } = await makeController();
+		const resumed = vi.fn();
+		controller.on("agentResumed", resumed);
+
+		const pending = controller.requestHumanTakeover("manual");
+		expect(vi.getTimerCount()).toBe(1);
+
+		controller.resumeAgent();
+		await pending;
+
+		expect(controller.getTakeoverState()).toBe("AGENT_RUNNING");
+		expect(resumed).toHaveBeenCalledTimes(1);
+		expect(resumed).toHaveBeenCalledWith(expect.objectContaining({ reason: "manual" }));
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("successful stop settles a pending takeover without a delayed resume event", async () => {
+		vi.useFakeTimers();
+		const { controller } = await makeController();
+		vi.spyOn(controller._session, "stop").mockResolvedValue(undefined);
+		const resumed = vi.fn();
+		controller.on("agentResumed", resumed);
+
+		const pending = controller.requestHumanTakeover("manual");
+		expect(vi.getTimerCount()).toBe(1);
+
+		await controller.stop();
+		await pending;
+
+		expect(controller.getTakeoverState()).toBe("AGENT_RUNNING");
+		expect(vi.getTimerCount()).toBe(0);
+		expect(resumed).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(resumed).not.toHaveBeenCalled();
+	});
+
+	it("keeps takeover state alive when session shutdown fails and cleans it on retry", async () => {
+		vi.useFakeTimers();
+		const { controller } = await makeController(5_000);
+		const shutdownFailure = new Error("browser still open");
+		vi.spyOn(controller._session, "stop").mockRejectedValueOnce(shutdownFailure).mockResolvedValueOnce(undefined);
+
+		let settled = false;
+		const pending = controller.requestHumanTakeover("manual").then(() => {
+			settled = true;
+		});
+		expect(vi.getTimerCount()).toBe(1);
+
+		await expect(controller.stop()).rejects.toBe(shutdownFailure);
+		expect(controller.getTakeoverState()).toBe("WAITING_FOR_HUMAN");
+		expect(vi.getTimerCount()).toBe(1);
+		expect(settled).toBe(false);
+
+		await controller.stop();
+		await pending;
+
+		expect(controller.getTakeoverState()).toBe("AGENT_RUNNING");
+		expect(vi.getTimerCount()).toBe(0);
+		expect(settled).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

- remove TaloxController's duplicate human-takeover timeout
- make TakeoverBridge the sole owner of timeout policy
- keep one controller-side pending takeover resolver instead of an untracked one-shot EventBus listener
- synchronize controller takeover state from the existing `agentResumed` event for both manual resume and timeout resume
- settle and clear any pending takeover only after browser/session shutdown succeeds
- dispose TakeoverBridge after successful session shutdown so its timer/listeners cannot fire after close
- preserve takeover state and timer when SessionManager shutdown fails, allowing the existing stop retry path to recover cleanly

## Why

TaloxController and TakeoverBridge both scheduled a timeout for the same human takeover. At timeout, the bridge emitted `agentResumed(reason=timeout)`, resolving the caller, but the controller remained in `WAITING_FOR_HUMAN` until its own timer fired and called `resumeAgent()` again. That second path emitted another resume event as `manual`, which could duplicate history/artifacts and made controller state temporarily inconsistent with the completed takeover.

The controller timer could also outlive a successful browser shutdown and later fire against a closed/disposed bridge.

The new lifecycle gives timeout ownership to TakeoverBridge only. Controller state/promise completion follows the synchronous `agentResumed` event, while successful shutdown explicitly settles any pending takeover and disposes the bridge. Failed session shutdown keeps the takeover alive for a real retry.

## Verification

- `tests/unit/TaloxControllerTakeoverTimeoutOwnership.test.ts`
  - bridge is the sole timeout owner and timeout emits exactly one resume event
  - manual resume settles the takeover and clears the bridge timer
  - successful stop settles a pending takeover with no delayed resume event
  - failed SessionManager stop preserves takeover state/timer; retry succeeds and cleans both
- controller diff is limited to +16/-20 around takeover state and successful shutdown cleanup
- full repository CI and Docker gates requested via this PR
