### PR TITLE
fix: scope visual question routing per session

### DIFF
--- a/src/core/PerceptionStack.ts
+++ b/src/core/PerceptionStack.ts
@@ -53,13 +53,13 @@ export type PerceptionPreset = "cheap" | "medium" | "heavy";
 export interface PerceptionLayerFlags {
 	/** Collect AX tree + interactive elements. Always true — required for all presets. */
 	structural: boolean;
-	/** Collect console errors + failed HTTP requests. */
+	/** Collect console errors + failed network requests. */
 	network: boolean;
 	/** Run RulesEngine structural diff + layout bug analysis. */
 	bugs: boolean;
 	/** Run ChallengeDetector scan. */
 	challenge: boolean;
-	/** Capture full-page PNG capture. */
+	/** Capture full-page screenshot PNG. */
 	screenshot: boolean;
 }
 

--- a/src/core/PerceptionStack.ts
+++ b/src/core/PerceptionStack.ts
@@ -44,7 +44,7 @@
 import type { TaloxPageState } from "../types/index.js";
 import type { ChallengeDetector, ChallengeState } from "./ChallengeDetector.js";
 import type { PageStateCollector } from "./PageStateCollector.js";
-import { askVisual } from "./VisualReasoner.js";
+import { askVisual, getScopedVisualEmitter } from "./VisualReasoner.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,13 +53,13 @@ export type PerceptionPreset = "cheap" | "medium" | "heavy";
 export interface PerceptionLayerFlags {
 	/** Collect AX tree + interactive elements. Always true — required for all presets. */
 	structural: boolean;
-	/** Collect console errors + failed network requests. */
+	/** Collect console errors + failed HTTP requests. */
 	network: boolean;
 	/** Run RulesEngine structural diff + layout bug analysis. */
 	bugs: boolean;
 	/** Run ChallengeDetector scan. */
 	challenge: boolean;
-	/** Capture full-page screenshot PNG. */
+	/** Capture full-page PNG capture. */
 	screenshot: boolean;
 }
 
@@ -189,7 +189,7 @@ export class PerceptionStack {
 			const page = this.collector.getPage();
 			if (!page) return null;
 			const screenshot = await page.screenshot({ type: "png", fullPage: false });
-			return await askVisual(screenshot, question);
+			return await askVisual(screenshot, question, 15_000, getScopedVisualEmitter(this.collector));
 		} catch {
 			return null;
 		}

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -87,9 +87,19 @@ const pending = new Map<string, PendingQuestion>();
 
 /** Standalone emit function. Controller-bound perception uses a scoped emitter. */
 let emitVisual: VisualEmitter | null = null;
+/** Weak ownership keeps controller/session routing isolated without retaining dead collectors. */
+const scopedVisualEmitters = new WeakMap<object, VisualEmitter>();
 
 export function setVisualEmitter(fn: VisualEmitter | null): void {
 	emitVisual = fn;
+}
+
+export function setScopedVisualEmitter(owner: object, emitter: VisualEmitter): void {
+	scopedVisualEmitters.set(owner, emitter);
+}
+
+export function getScopedVisualEmitter(owner: object): VisualEmitter | undefined {
+	return scopedVisualEmitters.get(owner);
 }
 
 /**

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -56,6 +56,14 @@ export interface OpenAIVisionConfig {
 
 export type ScreenshotFormat = "base64" | "file" | "buffer";
 
+export interface VisualQuestionPayload {
+	id: string;
+	question: string;
+	image: { format: ScreenshotFormat; data: string };
+}
+
+export type VisualEmitter = (payload: VisualQuestionPayload) => void;
+
 let screenshotFormat: ScreenshotFormat = "base64";
 
 export function setScreenshotFormat(format: ScreenshotFormat): void {
@@ -77,12 +85,10 @@ interface PendingQuestion {
 
 const pending = new Map<string, PendingQuestion>();
 
-/** Emit function — set by TaloxController when EventBus is ready. */
-let emitVisual:
-	| ((payload: { id: string; question: string; image: { format: ScreenshotFormat; data: string } }) => void)
-	| null = null;
+/** Standalone emit function. Controller-bound perception uses a scoped emitter. */
+let emitVisual: VisualEmitter | null = null;
 
-export function setVisualEmitter(fn: typeof emitVisual): void {
+export function setVisualEmitter(fn: VisualEmitter | null): void {
 	emitVisual = fn;
 }
 
@@ -93,8 +99,14 @@ export function setVisualEmitter(fn: typeof emitVisual): void {
  * @param screenshot PNG screenshot buffer
  * @param question  Natural language question
  * @param timeoutMs Max wait for agent response (default: 15000)
+ * @param emitter   Optional scoped emitter. Falls back to the standalone emitter.
  */
-export async function askVisual(screenshot: Buffer, question: string, timeoutMs = 15_000): Promise<string | null> {
+export async function askVisual(
+	screenshot: Buffer,
+	question: string,
+	timeoutMs = 15_000,
+	emitter?: VisualEmitter,
+): Promise<string | null> {
 	const id = `vis-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
 	// Format the image
@@ -118,9 +130,10 @@ export async function askVisual(screenshot: Buffer, question: string, timeoutMs 
 		pending.set(id, { resolve, timer });
 	});
 
-	// Emit the event for the hosting agent
-	if (emitVisual) {
-		emitVisual({ id, question, image: { format: screenshotFormat, data: imageData } });
+	// Prefer a session-scoped emitter; retain the global emitter for standalone API use.
+	const activeEmitter = emitter ?? emitVisual;
+	if (activeEmitter) {
+		activeEmitter({ id, question, image: { format: screenshotFormat, data: imageData } });
 		log.info(`Visual question emitted: "${question.slice(0, 60)}..." (timeout: ${timeoutMs}ms)`);
 	}
 

--- a/src/core/controller/SessionManager.ts
+++ b/src/core/controller/SessionManager.ts
@@ -31,6 +31,7 @@ import { PolicyEngine } from "../PolicyEngine.js";
 import { ProfileVault } from "../ProfileVault.js";
 import { RulesEngine } from "../RulesEngine.js";
 import { captureSessionSnapshot, restoreSessionSnapshot, type SessionSnapshot } from "../SessionSnapshot.js";
+import { setScopedVisualEmitter } from "../VisualReasoner.js";
 import { VisionGate } from "../VisionGate.js";
 import type { EventBus } from "./EventBus.js";
 
@@ -142,7 +143,7 @@ export class SessionManager {
 			this.dialogHandler.install(page);
 		}
 
-		const stateCollector = new PageStateCollector(page);
+		const stateCollector = this.createStateCollector(page);
 		this.activePageIndex = 0;
 		this.pages = [stateCollector];
 		this.pageMousePositions.set(0, { x: 0, y: 0 });
@@ -236,7 +237,7 @@ export class SessionManager {
 			this.dialogHandler.install(newPage);
 		}
 
-		const stateCollector = new PageStateCollector(newPage);
+		const stateCollector = this.createStateCollector(newPage);
 		this.activePageIndex = 0;
 		this.pages = [stateCollector];
 		this.pageMousePositions.set(0, { x: 0, y: 0 });
@@ -291,7 +292,7 @@ export class SessionManager {
 			this.dialogHandler.install(page);
 		}
 
-		const stateCollector = new PageStateCollector(page);
+		const stateCollector = this.createStateCollector(page);
 		this.activePageIndex = this.pages.length;
 		this.pages.push(stateCollector);
 		this.pageMousePositions.set(this.activePageIndex, { x: 0, y: 0 });
@@ -755,6 +756,12 @@ export class SessionManager {
 	}
 
 	// ─── Internal Helpers ─────────────────────────────────────────────────────────
+
+	private createStateCollector(page: Page): PageStateCollector {
+		const collector = new PageStateCollector(page);
+		setScopedVisualEmitter(collector, (payload) => this.events.emit("visualQuestion", payload));
+		return collector;
+	}
 
 	/** Returns the current mouse position for the active page (used by auto-thinking interval). */
 	private getCurrentMousePos(): Point {

--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -79,7 +79,6 @@ import {
 	resolveVisual,
 	type ScreenshotFormat,
 	setScreenshotFormat,
-	setVisualEmitter,
 	setVisualReasoner,
 	type VisualReasoner,
 } from "../VisualReasoner.js";
@@ -196,7 +195,6 @@ export class TaloxController {
 		}
 
 		this._events = new EventBus<TaloxEventMap>();
-		setVisualEmitter((payload) => this._events.emit("visualQuestion", payload));
 		this._challenge = new ChallengeDetector();
 		this._session = new SessionManager(this.settings, this._events, baseDir);
 		this._takeover = new TakeoverBridge(this._events, this.settings.humanTakeoverTimeoutMs);

--- a/tests/unit/VisualQuestionRoutingOwnership.test.ts
+++ b/tests/unit/VisualQuestionRoutingOwnership.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PerceptionStack } from "../../src/core/PerceptionStack.js";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+import { SessionManager } from "../../src/core/controller/SessionManager.js";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+import {
+	askVisual,
+	getScopedVisualEmitter,
+	resolveVisual,
+	setScopedVisualEmitter,
+	setVisualEmitter,
+	setVisualReasoner,
+	type VisualQuestionPayload,
+} from "../../src/core/VisualReasoner.js";
+import type { TaloxEventMap } from "../../src/types/events.js";
+import { DEFAULT_SETTINGS } from "../../src/types/settings.js";
+
+function makeCollector() {
+	const page = {
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("fake-png")),
+	};
+	return {
+		collect: vi.fn(),
+		getPage: () => page,
+	} as any;
+}
+
+function makePage() {
+	return {
+		on: vi.fn(),
+	} as any;
+}
+
+afterEach(() => {
+	setVisualEmitter(null);
+	setVisualReasoner(null);
+});
+
+describe("visual question routing ownership", () => {
+	it("routes concurrent perception questions only to their owning collectors", async () => {
+		const collectorA = makeCollector();
+		const collectorB = makeCollector();
+		const emitterA = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "answer-a"));
+		const emitterB = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "answer-b"));
+		const globalEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "wrong-global-answer"));
+
+		setVisualEmitter(globalEmitter);
+		setScopedVisualEmitter(collectorA, emitterA);
+		setScopedVisualEmitter(collectorB, emitterB);
+
+		const [answerA, answerB] = await Promise.all([
+			new PerceptionStack(collectorA).askVisual("question-a"),
+			new PerceptionStack(collectorB).askVisual("question-b"),
+		]);
+
+		expect(answerA).toBe("answer-a");
+		expect(answerB).toBe("answer-b");
+		expect(emitterA).toHaveBeenCalledOnce();
+		expect(emitterB).toHaveBeenCalledOnce();
+		expect(emitterA.mock.calls[0]?.[0].question).toBe("question-a");
+		expect(emitterB.mock.calls[0]?.[0].question).toBe("question-b");
+		expect(globalEmitter).not.toHaveBeenCalled();
+	});
+
+	it("keeps the global emitter as the standalone fallback", async () => {
+		const globalEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "standalone-answer"));
+		setVisualEmitter(globalEmitter);
+
+		const answer = await askVisual(Buffer.from("fake-png"), "standalone-question", 100);
+
+		expect(answer).toBe("standalone-answer");
+		expect(globalEmitter).toHaveBeenCalledOnce();
+		expect(globalEmitter.mock.calls[0]?.[0].question).toBe("standalone-question");
+	});
+
+	it("binds each SessionManager collector to that manager's EventBus", () => {
+		const eventsA = new EventBus<TaloxEventMap>();
+		const eventsB = new EventBus<TaloxEventMap>();
+		const managerA = new SessionManager({ ...DEFAULT_SETTINGS }, eventsA, ".");
+		const managerB = new SessionManager({ ...DEFAULT_SETTINGS }, eventsB, ".");
+		const seenA = vi.fn();
+		const seenB = vi.fn();
+		eventsA.on("visualQuestion", seenA);
+		eventsB.on("visualQuestion", seenB);
+
+		const collectorA = (managerA as any).createStateCollector(makePage());
+		const collectorB = (managerB as any).createStateCollector(makePage());
+		const payloadA: VisualQuestionPayload = {
+			id: "a",
+			question: "owned-by-a",
+			image: { format: "base64", data: "a" },
+		};
+		const payloadB: VisualQuestionPayload = {
+			id: "b",
+			question: "owned-by-b",
+			image: { format: "base64", data: "b" },
+		};
+
+		getScopedVisualEmitter(collectorA)?.(payloadA);
+		getScopedVisualEmitter(collectorB)?.(payloadB);
+
+		expect(seenA).toHaveBeenCalledOnce();
+		expect(seenA).toHaveBeenCalledWith(payloadA);
+		expect(seenB).toHaveBeenCalledOnce();
+		expect(seenB).toHaveBeenCalledWith(payloadB);
+	});
+
+	it("constructing controllers does not overwrite the standalone emitter", async () => {
+		const standaloneEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "still-standalone"));
+		setVisualEmitter(standaloneEmitter);
+
+		new TaloxController();
+		new TaloxController();
+		const answer = await askVisual(Buffer.from("fake-png"), "after-controller-construction", 100);
+
+		expect(answer).toBe("still-standalone");
+		expect(standaloneEmitter).toHaveBeenCalledOnce();
+	});
+});

--- a/tests/unit/VisualQuestionRoutingOwnership.test.ts
+++ b/tests/unit/VisualQuestionRoutingOwnership.test.ts
@@ -3,15 +3,7 @@ import { PerceptionStack } from "../../src/core/PerceptionStack.js";
 import { EventBus } from "../../src/core/controller/EventBus.js";
 import { SessionManager } from "../../src/core/controller/SessionManager.js";
 import { TaloxController } from "../../src/core/controller/TaloxController.js";
-import {
-	askVisual,
-	getScopedVisualEmitter,
-	resolveVisual,
-	setScopedVisualEmitter,
-	setVisualEmitter,
-	setVisualReasoner,
-	type VisualQuestionPayload,
-} from "../../src/core/VisualReasoner.js";
+import * as VisualReasoner from "../../src/core/VisualReasoner.js";
 import type { TaloxEventMap } from "../../src/types/events.js";
 import { DEFAULT_SETTINGS } from "../../src/types/settings.js";
 
@@ -32,21 +24,27 @@ function makePage() {
 }
 
 afterEach(() => {
-	setVisualEmitter(null);
-	setVisualReasoner(null);
+	VisualReasoner.setVisualEmitter(null);
+	VisualReasoner.setVisualReasoner(null);
 });
 
 describe("visual question routing ownership", () => {
 	it("routes concurrent perception questions only to their owning collectors", async () => {
 		const collectorA = makeCollector();
 		const collectorB = makeCollector();
-		const emitterA = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "answer-a"));
-		const emitterB = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "answer-b"));
-		const globalEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "wrong-global-answer"));
+		const emitterA = vi.fn((payload: VisualReasoner.VisualQuestionPayload) =>
+			VisualReasoner.resolveVisual(payload.id, "answer-a"),
+		);
+		const emitterB = vi.fn((payload: VisualReasoner.VisualQuestionPayload) =>
+			VisualReasoner.resolveVisual(payload.id, "answer-b"),
+		);
+		const globalEmitter = vi.fn((payload: VisualReasoner.VisualQuestionPayload) =>
+			VisualReasoner.resolveVisual(payload.id, "wrong-global-answer"),
+		);
 
-		setVisualEmitter(globalEmitter);
-		setScopedVisualEmitter(collectorA, emitterA);
-		setScopedVisualEmitter(collectorB, emitterB);
+		VisualReasoner.setVisualEmitter(globalEmitter);
+		VisualReasoner.setScopedVisualEmitter(collectorA, emitterA);
+		VisualReasoner.setScopedVisualEmitter(collectorB, emitterB);
 
 		const [answerA, answerB] = await Promise.all([
 			new PerceptionStack(collectorA).askVisual("question-a"),
@@ -63,10 +61,12 @@ describe("visual question routing ownership", () => {
 	});
 
 	it("keeps the global emitter as the standalone fallback", async () => {
-		const globalEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "standalone-answer"));
-		setVisualEmitter(globalEmitter);
+		const globalEmitter = vi.fn((payload: VisualReasoner.VisualQuestionPayload) =>
+			VisualReasoner.resolveVisual(payload.id, "standalone-answer"),
+		);
+		VisualReasoner.setVisualEmitter(globalEmitter);
 
-		const answer = await askVisual(Buffer.from("fake-png"), "standalone-question", 100);
+		const answer = await VisualReasoner.askVisual(Buffer.from("fake-png"), "standalone-question", 100);
 
 		expect(answer).toBe("standalone-answer");
 		expect(globalEmitter).toHaveBeenCalledOnce();
@@ -85,19 +85,19 @@ describe("visual question routing ownership", () => {
 
 		const collectorA = (managerA as any).createStateCollector(makePage());
 		const collectorB = (managerB as any).createStateCollector(makePage());
-		const payloadA: VisualQuestionPayload = {
+		const payloadA: VisualReasoner.VisualQuestionPayload = {
 			id: "a",
 			question: "owned-by-a",
 			image: { format: "base64", data: "a" },
 		};
-		const payloadB: VisualQuestionPayload = {
+		const payloadB: VisualReasoner.VisualQuestionPayload = {
 			id: "b",
 			question: "owned-by-b",
 			image: { format: "base64", data: "b" },
 		};
 
-		getScopedVisualEmitter(collectorA)?.(payloadA);
-		getScopedVisualEmitter(collectorB)?.(payloadB);
+		VisualReasoner.getScopedVisualEmitter(collectorA)?.(payloadA);
+		VisualReasoner.getScopedVisualEmitter(collectorB)?.(payloadB);
 
 		expect(seenA).toHaveBeenCalledOnce();
 		expect(seenA).toHaveBeenCalledWith(payloadA);
@@ -106,12 +106,14 @@ describe("visual question routing ownership", () => {
 	});
 
 	it("constructing controllers does not overwrite the standalone emitter", async () => {
-		const standaloneEmitter = vi.fn((payload: VisualQuestionPayload) => resolveVisual(payload.id, "still-standalone"));
-		setVisualEmitter(standaloneEmitter);
+		const standaloneEmitter = vi.fn((payload: VisualReasoner.VisualQuestionPayload) =>
+			VisualReasoner.resolveVisual(payload.id, "still-standalone"),
+		);
+		VisualReasoner.setVisualEmitter(standaloneEmitter);
 
 		new TaloxController();
 		new TaloxController();
-		const answer = await askVisual(Buffer.from("fake-png"), "after-controller-construction", 100);
+		const answer = await VisualReasoner.askVisual(Buffer.from("fake-png"), "after-controller-construction", 100);
 
 		expect(answer).toBe("still-standalone");
 		expect(standaloneEmitter).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

- stop `TaloxController` construction from overwriting the process-global visual question emitter
- add scoped visual emitters keyed weakly by collector ownership
- make `PerceptionStack.askVisual()` prefer the emitter belonging to its own collector
- bind every `SessionManager` collector creation path (initial launch, headed restart, new tab) to that manager's EventBus
- preserve the existing global emitter as an explicit standalone fallback

## Why

`VisualReasoner` previously exposed one global emitter slot, and every new `TaloxController` replaced it in its constructor. In multi-controller / daemon / coordinator use, whichever controller was created last could receive visual questions originating from another session.

The new routing keeps controller-bound perception local to the collector/session that owns it while retaining backwards-compatible standalone `askVisual()` behavior.

## Verification

`tests/unit/VisualQuestionRoutingOwnership.test.ts` covers:
- concurrent PerceptionStacks route only to their own scoped emitters
- scoped routing wins over the global fallback
- standalone global emitter still works
- separate SessionManagers bind collectors to separate EventBuses
- constructing additional TaloxControllers no longer replaces the standalone emitter

Diff guards confirm the large SessionManager/Controller files only contain the intended narrow changes.