### PR TITLE
fix: keep EventBus listener counts truthful

### DIFF
--- a/src/core/controller/EventBus.ts
+++ b/src/core/controller/EventBus.ts
@@ -62,9 +62,10 @@ export class EventBus<TMap extends object> {
 	 * Unsubscribe a specific handler from an event.
 	 */
 	off<K extends keyof TMap>(event: K, handler: EventHandler<TMap[K]>): void {
+		const before = this.emitter.listenerCount(event as string);
 		this.emitter.off(event as string, handler as (...args: unknown[]) => void);
-		const current = this.counts.get(event) ?? 0;
-		if (current > 0) this.counts.set(event, current - 1);
+		const after = this.emitter.listenerCount(event as string);
+		if (after < before) this.counts.set(event, after);
 	}
 
 	// ─── Emit ──────────────────────────────────────────────────────────────────

--- a/tests/unit/EventBusOffCountOwnership.test.ts
+++ b/tests/unit/EventBusOffCountOwnership.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+
+interface TestEvents {
+	ping: { value: number };
+}
+
+describe("EventBus off() count ownership", () => {
+	it("does not decrement the count when the handler was never registered", () => {
+		const bus = new EventBus<TestEvents>();
+		const registered = vi.fn();
+		const stranger = vi.fn();
+		bus.on("ping", registered);
+
+		bus.off("ping", stranger);
+		bus.emit("ping", { value: 1 });
+
+		expect(bus.listenerCount("ping")).toBe(1);
+		expect(bus.getListenerCounts().get("ping")).toBe(1);
+		expect(registered).toHaveBeenCalledOnce();
+		expect(stranger).not.toHaveBeenCalled();
+	});
+
+	it("still decrements exactly once when a registered handler is removed", () => {
+		const bus = new EventBus<TestEvents>();
+		const first = vi.fn();
+		const second = vi.fn();
+		bus.on("ping", first);
+		bus.on("ping", second);
+
+		bus.off("ping", first);
+		bus.emit("ping", { value: 2 });
+
+		expect(bus.listenerCount("ping")).toBe(1);
+		expect(bus.getListenerCounts().get("ping")).toBe(1);
+		expect(first).not.toHaveBeenCalled();
+		expect(second).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary

- compare the underlying Node EventEmitter listener count before and after `off()`
- update Talox's tracked count only when Node actually removed a listener
- preserve existing behavior for valid removals while preventing count drift for unknown handlers

## Why

`EventBus.off(event, handler)` previously decremented Talox's tracked listener count whenever the count was above zero, even if the supplied handler was never registered. Node's EventEmitter correctly left the real listener installed, but Talox then reported a lower count than the number of listeners that would actually fire.

That makes lifecycle diagnostics and leak assertions unreliable.

## Verification

`tests/unit/EventBusOffCountOwnership.test.ts` covers:
- removing an unknown handler leaves both the real listener and reported count intact
- removing a real handler decrements exactly once and leaves the remaining listener active

Source diff is limited to +3/-2 in `EventBus.off()`.