### PR TITLE
fix: make NetworkMocker regex routes stateless

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -29,6 +29,7 @@ type RouteHandler = (route: Route, request: Request) => Promise<void>;
 
 interface MockRouteRegistration {
 	mock: MockResponse;
+	routePattern: string | RegExp;
 	handler: RouteHandler;
 }
 
@@ -56,6 +57,13 @@ export class NetworkMocker {
 
 	private generateId(): string {
 		return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+	}
+
+	private createStatelessRoutePattern(pattern: string | RegExp): string | RegExp {
+		if (typeof pattern === "string" || (!pattern.global && !pattern.sticky)) return pattern;
+		const flags = pattern.flags.replace(/[gy]/g, "");
+		const source = pattern.sticky ? `^(?:${pattern.source})` : pattern.source;
+		return new RegExp(source, flags);
 	}
 
 	private matchesPattern(url: string, pattern: string | RegExp): boolean {
@@ -209,8 +217,9 @@ export class NetworkMocker {
 	}
 
 	async addMock(mock: MockResponse): Promise<void> {
+		const routePattern = this.createStatelessRoutePattern(mock.urlPattern);
 		const handler: RouteHandler = async (route: Route, request: Request) => {
-			if (!this.matchesPattern(request.url(), mock.urlPattern)) {
+			if (!this.matchesPattern(request.url(), routePattern)) {
 				await route.continue();
 				return;
 			}
@@ -236,8 +245,8 @@ export class NetworkMocker {
 			await route.fulfill(fulfillOptions);
 		};
 
-		await this.page.route(mock.urlPattern, handler);
-		this.mockRoutes.push({ mock, handler });
+		await this.page.route(routePattern, handler);
+		this.mockRoutes.push({ mock, routePattern, handler });
 	}
 
 	async clearMocks(): Promise<void> {
@@ -245,7 +254,7 @@ export class NetworkMocker {
 		if (registrations.length === 0) return;
 
 		const results = await Promise.allSettled(
-			registrations.map(({ mock, handler }) => this.page.unroute(mock.urlPattern, handler)),
+			registrations.map(({ routePattern, handler }) => this.page.unroute(routePattern, handler)),
 		);
 		const removedHandlers = new Set<RouteHandler>();
 		let firstFailure: unknown;

--- a/tests/unit/NetworkMockerRegexPatternOwnership.test.ts
+++ b/tests/unit/NetworkMockerRegexPatternOwnership.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { NetworkMocker } from "../../src/core/NetworkMocker.js";
+
+type Handler = (route: any, request: any) => Promise<void>;
+
+function makePage() {
+	const registrations: Array<{ pattern: string | RegExp; handler: Handler }> = [];
+	return {
+		route: vi.fn(async (pattern: string | RegExp, handler: Handler) => {
+			registrations.push({ pattern, handler });
+		}),
+		unroute: vi.fn(async (pattern: string | RegExp, handler: Handler) => {
+			const index = registrations.findIndex((entry) => entry.pattern === pattern && entry.handler === handler);
+			if (index >= 0) registrations.splice(index, 1);
+		}),
+		_registrations: registrations,
+	};
+}
+
+function makeRoute() {
+	return {
+		continue: vi.fn(async () => {}),
+		fulfill: vi.fn(async () => {}),
+	};
+}
+
+function makeRequest(url: string) {
+	return { url: vi.fn(() => url) };
+}
+
+describe("NetworkMocker stateful RegExp ownership", () => {
+	it("normalizes a global RegExp so repeated identical requests match deterministically", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		const original = /api\.example\.com\/data/g;
+		await mocker.addMock({ urlPattern: original, body: "mocked" });
+
+		const registration = page._registrations[0]!;
+		expect(registration.pattern).toBeInstanceOf(RegExp);
+		expect(registration.pattern).not.toBe(original);
+		expect((registration.pattern as RegExp).global).toBe(false);
+		expect((registration.pattern as RegExp).source).toBe(original.source);
+
+		const firstRoute = makeRoute();
+		const secondRoute = makeRoute();
+		const request = makeRequest("https://api.example.com/data");
+		await registration.handler(firstRoute, request);
+		await registration.handler(secondRoute, request);
+
+		expect(firstRoute.fulfill).toHaveBeenCalledOnce();
+		expect(secondRoute.fulfill).toHaveBeenCalledOnce();
+		expect(firstRoute.continue).not.toHaveBeenCalled();
+		expect(secondRoute.continue).not.toHaveBeenCalled();
+		expect(original.lastIndex).toBe(0);
+	});
+
+	it("normalizes a sticky RegExp without losing its start-of-URL semantics", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		const original = /https:\/\/api\.example\.com\/data/y;
+		await mocker.addMock({ urlPattern: original, body: "mocked" });
+
+		const registration = page._registrations[0]!;
+		const routePattern = registration.pattern as RegExp;
+		expect(routePattern.sticky).toBe(false);
+		expect(routePattern.source.startsWith("^(?:")).toBe(true);
+
+		const matchingRoute = makeRoute();
+		const shiftedRoute = makeRoute();
+		await registration.handler(matchingRoute, makeRequest("https://api.example.com/data"));
+		await registration.handler(shiftedRoute, makeRequest("xhttps://api.example.com/data"));
+
+		expect(matchingRoute.fulfill).toHaveBeenCalledOnce();
+		expect(shiftedRoute.fulfill).not.toHaveBeenCalled();
+		expect(shiftedRoute.continue).toHaveBeenCalledOnce();
+		expect(original.lastIndex).toBe(0);
+	});
+
+	it("unroutes the exact normalized RegExp object that was registered", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		const original = /api\.example\.com/g;
+		await mocker.addMock({ urlPattern: original, body: "mocked" });
+		const registration = page._registrations[0]!;
+
+		await mocker.clearMocks();
+
+		expect(page.unroute).toHaveBeenCalledWith(registration.pattern, registration.handler);
+		expect(page._registrations).toHaveLength(0);
+		expect(mocker.getMocks()).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- normalize mock RegExp route patterns before registering them with Playwright
- remove the stateful `g` flag for boolean URL matching
- convert sticky `y` semantics into an explicit start-of-URL anchor before removing the flag
- use the normalized pattern for both Talox's match check and Playwright `page.route()`
- retain that exact registered pattern for targeted `unroute()` cleanup

## Why

JavaScript RegExp objects with `g` or `y` mutate `lastIndex` when `.test()` runs. `NetworkMocker` reused the caller's RegExp both for Playwright route registration and for its own `matchesPattern()` call, so repeated identical requests could become state-dependent and alternate between match/non-match behavior.

The route pattern is now stateless for the boolean matching contract while the public mock still retains the caller-provided pattern.

## Verification

`tests/unit/NetworkMockerRegexPatternOwnership.test.ts` covers:
- global RegExp matches repeated identical requests deterministically
- caller RegExp `lastIndex` remains untouched
- sticky RegExp retains start-of-URL semantics after normalization
- `clearMocks()` unroutes the exact normalized RegExp object originally registered

Source diff is limited to +13/-4 in `NetworkMocker.ts`.