### PR TITLE
fix: preserve substring semantics for string network mocks

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -60,7 +60,11 @@ export class NetworkMocker {
 	}
 
 	private createStatelessRoutePattern(pattern: string | RegExp): string | RegExp {
-		if (typeof pattern === "string" || (!pattern.global && !pattern.sticky)) return pattern;
+		if (typeof pattern === "string") {
+			const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+			return new RegExp(escaped);
+		}
+		if (!pattern.global && !pattern.sticky) return pattern;
 		const flags = pattern.flags.replace(/[gy]/g, "");
 		const source = pattern.sticky ? `^(?:${pattern.source})` : pattern.source;
 		return new RegExp(source, flags);

--- a/tests/unit/NetworkMocker.test.ts
+++ b/tests/unit/NetworkMocker.test.ts
@@ -219,7 +219,7 @@ describe("NetworkMocker", () => {
 	});
 
 	describe("addMock / clearMocks / getMocks", () => {
-		it("adds a mock and registers route", async () => {
+		it("adds a mock and registers a substring route", async () => {
 			const mock: MockResponse = {
 				urlPattern: "api.example.com",
 				status: 200,
@@ -228,7 +228,9 @@ describe("NetworkMocker", () => {
 			await mocker.addMock(mock);
 
 			expect(mocker.getMocks()).toHaveLength(1);
-			expect(mockPage.route).toHaveBeenCalledWith("api.example.com", expect.any(Function));
+			const routePattern = mockPage.route.mock.calls[0]?.[0];
+			expect(routePattern).toBeInstanceOf(RegExp);
+			expect((routePattern as RegExp).test("https://api.example.com/data")).toBe(true);
 		});
 
 		it("clears all mocks", async () => {

--- a/tests/unit/NetworkMockerRouteOwnership.test.ts
+++ b/tests/unit/NetworkMockerRouteOwnership.test.ts
@@ -41,7 +41,11 @@ describe("NetworkMocker route ownership", () => {
 
 		expect(page._registrations).toHaveLength(2);
 		expect(page._registrations.some(({ handler }) => handler === externalHandler)).toBe(true);
-		expect(page._registrations.some(({ pattern }) => pattern === "api.example.com")).toBe(true);
+		expect(
+			page._registrations.some(
+				({ pattern }) => pattern instanceof RegExp && pattern.test("https://api.example.com/data"),
+			),
+		).toBe(true);
 		expect(page.unrouteAll).not.toHaveBeenCalled();
 	});
 

--- a/tests/unit/NetworkMockerStringPatternSemantics.test.ts
+++ b/tests/unit/NetworkMockerStringPatternSemantics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { NetworkMocker } from "../../src/core/NetworkMocker.js";
+
+type Handler = (route: any, request: any) => Promise<void>;
+
+function makePage() {
+	const registrations: Array<{ pattern: string | RegExp; handler: Handler }> = [];
+	return {
+		route: vi.fn(async (pattern: string | RegExp, handler: Handler) => {
+			registrations.push({ pattern, handler });
+		}),
+		unroute: vi.fn(async (pattern: string | RegExp, handler: Handler) => {
+			const index = registrations.findIndex((entry) => entry.pattern === pattern && entry.handler === handler);
+			if (index >= 0) registrations.splice(index, 1);
+		}),
+		_registrations: registrations,
+	};
+}
+
+function makeRoute() {
+	return {
+		continue: vi.fn(async () => {}),
+		fulfill: vi.fn(async () => {}),
+	};
+}
+
+function makeRequest(url: string) {
+	return { url: vi.fn(() => url) };
+}
+
+describe("NetworkMocker string pattern semantics", () => {
+	it("registers a Playwright matcher that preserves literal substring semantics", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		const literal = "api.example.com/data?filter=a*b(c)";
+		await mocker.addMock({ urlPattern: literal, body: "mocked" });
+
+		const registration = page._registrations[0]!;
+		expect(registration.pattern).toBeInstanceOf(RegExp);
+		const routePattern = registration.pattern as RegExp;
+		expect(routePattern.test(`https://${literal}&page=1`)).toBe(true);
+		expect(routePattern.test("https://apiXexampleXcom/dataZfilter=aZZbXcX")).toBe(false);
+
+		const matchingRoute = makeRoute();
+		const nonMatchingRoute = makeRoute();
+		await registration.handler(matchingRoute, makeRequest(`https://${literal}&page=1`));
+		await registration.handler(nonMatchingRoute, makeRequest("https://api.example.com/other"));
+
+		expect(matchingRoute.fulfill).toHaveBeenCalledOnce();
+		expect(matchingRoute.continue).not.toHaveBeenCalled();
+		expect(nonMatchingRoute.fulfill).not.toHaveBeenCalled();
+		expect(nonMatchingRoute.continue).toHaveBeenCalledOnce();
+	});
+
+	it("keeps the caller-visible mock pattern unchanged while owning the registered matcher", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		const mock = { urlPattern: "api.example.com", body: "mocked" };
+		await mocker.addMock(mock);
+		const registration = page._registrations[0]!;
+
+		expect(mocker.getMocks()).toEqual([mock]);
+		expect(registration.pattern).not.toBe(mock.urlPattern);
+
+		await mocker.clearMocks();
+		expect(page.unroute).toHaveBeenCalledWith(registration.pattern, registration.handler);
+		expect(page._registrations).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

- convert string `urlPattern` values into escaped RegExp route matchers before registering with Playwright
- preserve Talox's existing literal substring semantics instead of accidentally delegating strings to Playwright glob semantics
- keep caller-visible mocks unchanged
- retain exact matcher ownership for targeted `unroute()` cleanup

## Why

Talox's own matcher treats string patterns as `url.includes(pattern)`, but `page.route(string, ...)` treats strings as Playwright glob patterns. Playwright documents that glob patterns must match the entire URL. A pattern such as `"api.example.com"` therefore expressed substring intent inside Talox but could fail to invoke the route handler in a real browser.

Using an escaped RegExp makes Playwright registration follow the same literal substring contract, including strings containing regex/glob metacharacters.

## Verification

- updated existing NetworkMocker tests to assert substring matcher behavior rather than raw string registration
- `NetworkMockerStringPatternSemantics.test.ts` covers literal `.`, `?`, `*`, and parentheses, matching/non-matching URLs, caller-visible pattern preservation, and targeted cleanup ownership
- source diff is limited to +5/-1 in `NetworkMocker.ts`

Reference: Playwright network docs specify string route patterns are globs and must match the entire URL.