### PR TITLE
fix: isolate EventBus listener failures

### DIFF
--- a/src/core/controller/EventBus.ts
+++ b/src/core/controller/EventBus.ts
@@ -74,22 +74,38 @@ export class EventBus<TMap extends object> {
 	 * Emit an event with its typed payload.
 	 * All listeners are called synchronously. Errors thrown by listeners are
 	 * caught and re-emitted as `'error'` events (if any listener is registered),
-	 * or logged to stderr — they never propagate to the caller.
+	 * or logged to stderr — they never propagate to the caller or block later listeners.
 	 */
 	emit<K extends keyof TMap>(event: K, ...[data]: TMap[K] extends undefined ? [] : [TMap[K]]): void {
-		try {
-			this.emitter.emit(event as string, data);
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			const stack = err instanceof Error ? err.stack : undefined;
+		this.emitSafely(event as string, data);
+	}
 
-			// Avoid infinite loop: only re-emit 'error' if this isn't already 'error'
-			if (event !== "error" && this.emitter.listenerCount("error") > 0) {
-				this.emitter.emit("error", { message, stack });
-			} else {
-				this.log.error(`Unhandled error in '${String(event)}' listener:`, err);
+	private emitSafely(event: string, data: unknown): void {
+		const listeners = this.emitter.rawListeners(event);
+		if (event === "error" && listeners.length === 0) {
+			this.log.error("Unhandled 'error' event:", data);
+			return;
+		}
+
+		for (const listener of listeners) {
+			try {
+				(listener as (...args: unknown[]) => void).call(this.emitter, data);
+			} catch (error) {
+				this.handleListenerError(event, error);
 			}
 		}
+	}
+
+	private handleListenerError(event: string, error: unknown): void {
+		const message = error instanceof Error ? error.message : String(error);
+		const stack = error instanceof Error ? error.stack : undefined;
+
+		if (event !== "error" && this.emitter.listenerCount("error") > 0) {
+			this.emitSafely("error", { message, stack });
+			return;
+		}
+
+		this.log.error(`Unhandled error in '${event}' listener:`, error);
 	}
 
 	// ─── One-time Subscription ─────────────────────────────────────────────────

--- a/tests/unit/EventBusListenerIsolation.test.ts
+++ b/tests/unit/EventBusListenerIsolation.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+
+interface TestEvents {
+	work: { id: number };
+	error: { message: string; stack?: string };
+}
+
+describe("EventBus listener failure isolation", () => {
+	it("continues to later listeners when an earlier listener throws", () => {
+		const bus = new EventBus<TestEvents>();
+		const later = vi.fn();
+		bus.on("error", vi.fn());
+		bus.on("work", () => {
+			throw new Error("first listener failed");
+		});
+		bus.on("work", later);
+
+		expect(() => bus.emit("work", { id: 1 })).not.toThrow();
+		expect(later).toHaveBeenCalledOnce();
+		expect(later).toHaveBeenCalledWith({ id: 1 });
+	});
+
+	it("reports a listener failure to error listeners without blocking the original event", () => {
+		const bus = new EventBus<TestEvents>();
+		const errorListener = vi.fn();
+		const later = vi.fn();
+		bus.on("error", errorListener);
+		bus.on("work", () => {
+			throw new Error("synthetic work failure");
+		});
+		bus.on("work", later);
+
+		bus.emit("work", { id: 2 });
+
+		expect(errorListener).toHaveBeenCalledOnce();
+		expect(errorListener).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "synthetic work failure" }),
+		);
+		expect(later).toHaveBeenCalledOnce();
+	});
+
+	it("isolates failures between error listeners too", () => {
+		const bus = new EventBus<TestEvents>();
+		const survivingErrorListener = vi.fn();
+		const laterWorkListener = vi.fn();
+		bus.on("error", () => {
+			throw new Error("broken error observer");
+		});
+		bus.on("error", survivingErrorListener);
+		bus.on("work", () => {
+			throw new Error("original failure");
+		});
+		bus.on("work", laterWorkListener);
+
+		expect(() => bus.emit("work", { id: 3 })).not.toThrow();
+		expect(survivingErrorListener).toHaveBeenCalledOnce();
+		expect(survivingErrorListener).toHaveBeenCalledWith(
+			expect.objectContaining({ message: "original failure" }),
+		);
+		expect(laterWorkListener).toHaveBeenCalledOnce();
+	});
+
+	it("preserves once semantics and listener counts when a once listener throws", () => {
+		const bus = new EventBus<TestEvents>();
+		const onceListener = vi.fn(() => {
+			throw new Error("one-shot failure");
+		});
+		const persistent = vi.fn();
+		bus.on("error", vi.fn());
+		bus.once("work", onceListener);
+		bus.on("work", persistent);
+
+		bus.emit("work", { id: 4 });
+		bus.emit("work", { id: 5 });
+
+		expect(onceListener).toHaveBeenCalledOnce();
+		expect(persistent).toHaveBeenCalledTimes(2);
+		expect(bus.listenerCount("work")).toBe(1);
+		expect(bus.getListenerCounts().get("work")).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

- dispatch EventBus listeners from a stable `rawListeners()` snapshot
- catch failures per listener instead of around the entire Node EventEmitter dispatch
- continue delivering the original event to later listeners after one listener throws
- safely dispatch error notifications listener-by-listener as well
- preserve Node `once()` wrappers and existing Talox listener-count semantics

## Why

The previous `emit()` wrapped one call to `EventEmitter.emit()` in a try/catch. Node stops invoking later listeners when one listener throws, so Talox avoided a process-level throw but still allowed one faulty observer to block unrelated lifecycle/event consumers. A throwing `error` listener could also escape from the catch path.

The new dispatch isolates each listener while keeping synchronous ordering and snapshot behavior.

## Verification

`tests/unit/EventBusListenerIsolation.test.ts` covers:
- later listeners still run after an earlier listener throws
- failures are delivered to `error` listeners while original-event delivery continues
- a throwing `error` listener does not block subsequent error listeners or escape `emit()`
- a throwing `once()` listener remains one-shot and listener counts stay correct

Source diff is limited to EventBus dispatch/error handling.