### PR TITLE
fix: scope visual configuration per session

### DIFF
--- a/src/core/PerceptionStack.ts
+++ b/src/core/PerceptionStack.ts
@@ -44,7 +44,7 @@
 import type { TaloxPageState } from "../types/index.js";
 import type { ChallengeDetector, ChallengeState } from "./ChallengeDetector.js";
 import type { PageStateCollector } from "./PageStateCollector.js";
-import { askVisual, getScopedVisualEmitter } from "./VisualReasoner.js";
+import { askVisualScoped } from "./VisualReasoner.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -189,7 +189,7 @@ export class PerceptionStack {
 			const page = this.collector.getPage();
 			if (!page) return null;
 			const screenshot = await page.screenshot({ type: "png", fullPage: false });
-			return await askVisual(screenshot, question, 15_000, getScopedVisualEmitter(this.collector));
+			return await askVisualScoped(this.collector, screenshot, question, 15_000);
 		} catch {
 			return null;
 		}

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -156,7 +156,7 @@ export async function askVisualScoped(
 }
 
 interface ActiveVisualScope {
-	emitter?: VisualEmitter;
+	emitter: VisualEmitter | undefined;
 	screenshotFormat: ScreenshotFormat;
 	reasoner: VisualReasoner | null;
 }

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -64,6 +64,12 @@ export interface VisualQuestionPayload {
 
 export type VisualEmitter = (payload: VisualQuestionPayload) => void;
 
+export interface VisualScope {
+	emitter?: VisualEmitter;
+	screenshotFormat?: ScreenshotFormat;
+	reasoner?: VisualReasoner | null;
+}
+
 let screenshotFormat: ScreenshotFormat = "base64";
 
 export function setScreenshotFormat(format: ScreenshotFormat): void {
@@ -87,19 +93,29 @@ const pending = new Map<string, PendingQuestion>();
 
 /** Standalone emit function. Controller-bound perception uses a scoped emitter. */
 let emitVisual: VisualEmitter | null = null;
-/** Weak ownership keeps controller/session routing isolated without retaining dead collectors. */
-const scopedVisualEmitters = new WeakMap<object, VisualEmitter>();
+/** Weak ownership keeps controller/session visual settings isolated without retaining dead collectors. */
+const scopedVisualScopes = new WeakMap<object, VisualScope>();
 
 export function setVisualEmitter(fn: VisualEmitter | null): void {
 	emitVisual = fn;
 }
 
+export function setScopedVisualScope(owner: object, scope: VisualScope): void {
+	scopedVisualScopes.set(owner, scope);
+}
+
+export function getScopedVisualScope(owner: object): VisualScope | undefined {
+	return scopedVisualScopes.get(owner);
+}
+
 export function setScopedVisualEmitter(owner: object, emitter: VisualEmitter): void {
-	scopedVisualEmitters.set(owner, emitter);
+	const scope = scopedVisualScopes.get(owner) ?? {};
+	scope.emitter = emitter;
+	scopedVisualScopes.set(owner, scope);
 }
 
 export function getScopedVisualEmitter(owner: object): VisualEmitter | undefined {
-	return scopedVisualEmitters.get(owner);
+	return scopedVisualScopes.get(owner)?.emitter;
 }
 
 /**
@@ -117,37 +133,67 @@ export async function askVisual(
 	timeoutMs = 15_000,
 	emitter?: VisualEmitter,
 ): Promise<string | null> {
-	const id = `vis-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	return askVisualInternal(screenshot, question, timeoutMs, {
+		emitter: emitter ?? emitVisual ?? undefined,
+		screenshotFormat,
+		reasoner: currentReasoner,
+	});
+}
 
-	// Format the image
+export async function askVisualScoped(
+	owner: object,
+	screenshot: Buffer,
+	question: string,
+	timeoutMs = 15_000,
+): Promise<string | null> {
+	const scope = scopedVisualScopes.get(owner);
+	const scopedReasoner = scope && Object.hasOwn(scope, "reasoner") ? (scope.reasoner ?? null) : currentReasoner;
+	return askVisualInternal(screenshot, question, timeoutMs, {
+		emitter: scope?.emitter ?? emitVisual ?? undefined,
+		screenshotFormat: scope?.screenshotFormat ?? screenshotFormat,
+		reasoner: scopedReasoner,
+	});
+}
+
+private interface ActiveVisualScope {
+	emitter?: VisualEmitter;
+	screenshotFormat: ScreenshotFormat;
+	reasoner: VisualReasoner | null;
+}
+
+async function askVisualInternal(
+	screenshot: Buffer,
+	question: string,
+	timeoutMs: number,
+	scope: ActiveVisualScope,
+): Promise<string | null> {
+	const id = `vis-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+	const activeFormat = scope.screenshotFormat;
+
 	let imageData: string;
-	if (screenshotFormat === "base64") {
+	if (activeFormat === "base64") {
 		imageData = `data:image/png;base64,${screenshot.toString("base64")}`;
-	} else if (screenshotFormat === "buffer") {
+	} else if (activeFormat === "buffer") {
 		imageData = screenshot.toString("base64");
 	} else {
 		// file format — not implemented yet, fall back to base64
 		imageData = `data:image/png;base64,${screenshot.toString("base64")}`;
 	}
 
-	// Create a promise that resolves when resolveVisual() is called
 	const promise = new Promise<string | null>((resolve) => {
 		const timer = setTimeout(() => {
 			pending.delete(id);
-			resolve(null); // Timeout — will trigger fallback
+			resolve(null);
 		}, timeoutMs);
 
 		pending.set(id, { resolve, timer });
 	});
 
-	// Prefer a session-scoped emitter; retain the global emitter for standalone API use.
-	const activeEmitter = emitter ?? emitVisual;
-	if (activeEmitter) {
-		activeEmitter({ id, question, image: { format: screenshotFormat, data: imageData } });
+	if (scope.emitter) {
+		scope.emitter({ id, question, image: { format: activeFormat, data: imageData } });
 		log.info(`Visual question emitted: "${question.slice(0, 60)}..." (timeout: ${timeoutMs}ms)`);
 	}
 
-	// Wait for agent response
 	const agentAnswer = await promise;
 
 	if (agentAnswer !== null) {
@@ -155,9 +201,8 @@ export async function askVisual(
 		return agentAnswer;
 	}
 
-	// Fallback: try registered VisualReasoner
 	log.info("Agent did not respond — trying registered VisualReasoner fallback");
-	return askVisualFallback(screenshot, question);
+	return askVisualFallback(screenshot, question, scope.reasoner);
 }
 
 /**
@@ -193,14 +238,18 @@ export function getVisualReasoner(): VisualReasoner | null {
 	return currentReasoner;
 }
 
-async function askVisualFallback(screenshot: Buffer, question: string): Promise<string | null> {
-	if (!currentReasoner) return null;
+async function askVisualFallback(
+	screenshot: Buffer,
+	question: string,
+	reasoner: VisualReasoner | null = currentReasoner,
+): Promise<string | null> {
+	if (!reasoner) return null;
 
 	try {
 		const start = Date.now();
-		const answer = await currentReasoner.analyze(screenshot, question);
+		const answer = await reasoner.analyze(screenshot, question);
 		if (answer !== null) {
-			log.info(`${currentReasoner.name} answered in ${Date.now() - start}ms`);
+			log.info(`${reasoner.name} answered in ${Date.now() - start}ms`);
 		}
 		return answer;
 	} catch (err) {

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -155,7 +155,7 @@ export async function askVisualScoped(
 	});
 }
 
-private interface ActiveVisualScope {
+interface ActiveVisualScope {
 	emitter?: VisualEmitter;
 	screenshotFormat: ScreenshotFormat;
 	reasoner: VisualReasoner | null;

--- a/src/core/controller/SessionManager.ts
+++ b/src/core/controller/SessionManager.ts
@@ -31,7 +31,12 @@ import { PolicyEngine } from "../PolicyEngine.js";
 import { ProfileVault } from "../ProfileVault.js";
 import { RulesEngine } from "../RulesEngine.js";
 import { captureSessionSnapshot, restoreSessionSnapshot, type SessionSnapshot } from "../SessionSnapshot.js";
-import { setScopedVisualEmitter } from "../VisualReasoner.js";
+import {
+	type ScreenshotFormat,
+	setScopedVisualScope,
+	type VisualReasoner,
+	type VisualScope,
+} from "../VisualReasoner.js";
 import { VisionGate } from "../VisionGate.js";
 import type { EventBus } from "./EventBus.js";
 
@@ -77,6 +82,7 @@ export class SessionManager {
 	private fingerprint: FingerprintProfile | null = null;
 	private readonly fingerprintGen = new FingerprintGenerator();
 	private _networkGuard: NetworkGuard | null = null;
+	private readonly visualScope: VisualScope;
 
 	constructor(
 		private readonly settings: TaloxSettings,
@@ -90,6 +96,7 @@ export class SessionManager {
 		this.visionGate = new VisionGate();
 		this.policyEngine = new PolicyEngine();
 		this.dialogHandler = new AutoDialogHandler(events, settings.verbosity);
+		this.visualScope = { emitter: (payload) => this.events.emit("visualQuestion", payload) };
 	}
 
 	// ─── Launch ──────────────────────────────────────────────────────────────────
@@ -375,6 +382,14 @@ export class SessionManager {
 	}
 
 	// ─── Visual Verification ─────────────────────────────────────────────────────
+
+	setScreenshotFormat(format: ScreenshotFormat): void {
+		this.visualScope.screenshotFormat = format;
+	}
+
+	setVisualReasoner(reasoner: VisualReasoner | null): void {
+		this.visualScope.reasoner = reasoner;
+	}
 
 	async verifyVisual(baselineKey: string, autoSave: boolean = false): Promise<any> {
 		const page = this.getPage();
@@ -759,7 +774,7 @@ export class SessionManager {
 
 	private createStateCollector(page: Page): PageStateCollector {
 		const collector = new PageStateCollector(page);
-		setScopedVisualEmitter(collector, (payload) => this.events.emit("visualQuestion", payload));
+		setScopedVisualScope(collector, this.visualScope);
 		return collector;
 	}
 

--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -75,13 +75,7 @@ import type { SkillLoader } from "../skills/SkillLoader.js";
 import { AdaptationEngine } from "../smart/AdaptationEngine.js";
 import type { VideoRecorder as VideoRecorderType } from "../VideoRecorder.js";
 import { VideoRecorder as VideoRecorderClass } from "../VideoRecorder.js";
-import {
-	resolveVisual,
-	type ScreenshotFormat,
-	setScreenshotFormat,
-	setVisualReasoner,
-	type VisualReasoner,
-} from "../VisualReasoner.js";
+import { resolveVisual, type ScreenshotFormat, type VisualReasoner } from "../VisualReasoner.js";
 import { ActionExecutor } from "./ActionExecutor.js";
 import type { EventHandler } from "./EventBus.js";
 import { EventBus } from "./EventBus.js";
@@ -1392,11 +1386,11 @@ export class TaloxController {
 	 * - `"buffer"` — raw base64 (for in-process SDK usage)
 	 */
 	setScreenshotFormat(format: ScreenshotFormat): void {
-		setScreenshotFormat(format);
+		this._session.setScreenshotFormat(format);
 	}
 
 	useVision(reasoner: VisualReasoner | null): void {
-		setVisualReasoner(reasoner);
+		this._session.setVisualReasoner(reasoner);
 	}
 
 	useSolver(solver: CaptchaSolver): void {

--- a/tests/unit/VisualConfigurationScopeOwnership.test.ts
+++ b/tests/unit/VisualConfigurationScopeOwnership.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+import { SessionManager } from "../../src/core/controller/SessionManager.js";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+import * as VisualReasoner from "../../src/core/VisualReasoner.js";
+import type { TaloxEventMap } from "../../src/types/events.js";
+import { DEFAULT_SETTINGS } from "../../src/types/settings.js";
+
+function makePage() {
+	return {
+		on: vi.fn(),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("fake-png")),
+	} as any;
+}
+
+function createCollector(manager: SessionManager) {
+	return (manager as any).createStateCollector(makePage());
+}
+
+function makeReasoner(name: string, answer: string): VisualReasoner.VisualReasoner {
+	return {
+		name,
+		analyze: vi.fn().mockResolvedValue(answer),
+	};
+}
+
+afterEach(() => {
+	VisualReasoner.setVisualEmitter(null);
+	VisualReasoner.setVisualReasoner(null);
+	VisualReasoner.setScreenshotFormat("base64");
+});
+
+describe("visual configuration scope ownership", () => {
+	it("shares one mutable visual scope across collectors in the same session only", () => {
+		const managerA = new SessionManager(
+			{ ...DEFAULT_SETTINGS },
+			new EventBus<TaloxEventMap>(),
+			".",
+		);
+		const managerB = new SessionManager(
+			{ ...DEFAULT_SETTINGS },
+			new EventBus<TaloxEventMap>(),
+			".",
+		);
+
+		const collectorA1 = createCollector(managerA);
+		const collectorA2 = createCollector(managerA);
+		const collectorB = createCollector(managerB);
+		const scopeA1 = VisualReasoner.getScopedVisualScope(collectorA1);
+		const scopeA2 = VisualReasoner.getScopedVisualScope(collectorA2);
+		const scopeB = VisualReasoner.getScopedVisualScope(collectorB);
+
+		expect(scopeA1).toBe(scopeA2);
+		expect(scopeA1).not.toBe(scopeB);
+
+		managerA.setScreenshotFormat("buffer");
+		const reasonerA = makeReasoner("reasoner-a", "answer-a");
+		managerA.setVisualReasoner(reasonerA);
+
+		expect(scopeA1?.screenshotFormat).toBe("buffer");
+		expect(scopeA2?.screenshotFormat).toBe("buffer");
+		expect(scopeA1?.reasoner).toBe(reasonerA);
+		expect(scopeA2?.reasoner).toBe(reasonerA);
+		expect(scopeB?.screenshotFormat).toBeUndefined();
+		expect(scopeB?.reasoner).toBeUndefined();
+	});
+
+	it("keeps controller visual reasoners isolated and preserves standalone globals", async () => {
+		const controllerA = new TaloxController();
+		const controllerB = new TaloxController();
+		const collectorA = createCollector(controllerA._session);
+		const collectorB = createCollector(controllerB._session);
+		const reasonerA = makeReasoner("reasoner-a", "answer-a");
+		const reasonerB = makeReasoner("reasoner-b", "answer-b");
+		const globalReasoner = makeReasoner("global", "global-answer");
+
+		VisualReasoner.setVisualReasoner(globalReasoner);
+		controllerA.useVision(reasonerA);
+		controllerB.useVision(reasonerB);
+
+		const [answerA, answerB, globalAnswer] = await Promise.all([
+			VisualReasoner.askVisualScoped(collectorA, Buffer.from("a"), "question-a", 0),
+			VisualReasoner.askVisualScoped(collectorB, Buffer.from("b"), "question-b", 0),
+			VisualReasoner.askVisual(Buffer.from("global"), "global-question", 0),
+		]);
+
+		expect(answerA).toBe("answer-a");
+		expect(answerB).toBe("answer-b");
+		expect(globalAnswer).toBe("global-answer");
+		expect(reasonerA.analyze).toHaveBeenCalledOnce();
+		expect(reasonerB.analyze).toHaveBeenCalledOnce();
+		expect(globalReasoner.analyze).toHaveBeenCalledOnce();
+	});
+
+	it("keeps screenshot formats isolated across controllers", async () => {
+		const controllerA = new TaloxController();
+		const controllerB = new TaloxController();
+		const collectorA = createCollector(controllerA._session);
+		const collectorB = createCollector(controllerB._session);
+		const formatsA: VisualReasoner.ScreenshotFormat[] = [];
+		const formatsB: VisualReasoner.ScreenshotFormat[] = [];
+
+		controllerA.on("visualQuestion", (payload) => {
+			formatsA.push(payload.image.format);
+			controllerA.resolveVisual(payload.id, "a");
+		});
+		controllerB.on("visualQuestion", (payload) => {
+			formatsB.push(payload.image.format);
+			controllerB.resolveVisual(payload.id, "b");
+		});
+		controllerA.setScreenshotFormat("buffer");
+		controllerB.setScreenshotFormat("base64");
+
+		const [answerA, answerB] = await Promise.all([
+			VisualReasoner.askVisualScoped(collectorA, Buffer.from("a"), "question-a", 100),
+			VisualReasoner.askVisualScoped(collectorB, Buffer.from("b"), "question-b", 100),
+		]);
+
+		expect(answerA).toBe("a");
+		expect(answerB).toBe("b");
+		expect(formatsA).toEqual(["buffer"]);
+		expect(formatsB).toEqual(["base64"]);
+		expect(VisualReasoner.getScreenshotFormat()).toBe("base64");
+	});
+
+	it("allows a session to explicitly disable a global fallback reasoner", async () => {
+		const manager = new SessionManager(
+			{ ...DEFAULT_SETTINGS },
+			new EventBus<TaloxEventMap>(),
+			".",
+		);
+		const inheritedCollector = createCollector(manager);
+		const globalReasoner = makeReasoner("global", "global-answer");
+		VisualReasoner.setVisualReasoner(globalReasoner);
+
+		expect(
+			await VisualReasoner.askVisualScoped(inheritedCollector, Buffer.from("first"), "inherits-global", 0),
+		).toBe("global-answer");
+
+		manager.setVisualReasoner(null);
+		const disabledCollector = createCollector(manager);
+		expect(
+			await VisualReasoner.askVisualScoped(disabledCollector, Buffer.from("second"), "local-disabled", 0),
+		).toBeNull();
+		expect(globalReasoner.analyze).toHaveBeenCalledOnce();
+	});
+});


### PR DESCRIPTION
## Summary
- scope visual question emitter, screenshot format, and fallback reasoner to each SessionManager
- share one mutable visual scope across all collectors/tabs owned by the same session
- keep standalone global VisualReasoner APIs as backwards-compatible fallbacks
- route TaloxController visual configuration through its own SessionManager

## Regression coverage
- same-session collectors share visual config while separate sessions stay isolated
- concurrent controllers use independent fallback reasoners and screenshot formats
- standalone global reasoner remains independent
- explicit session-local `null` disables a global fallback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Visual reasoning settings can now be configured independently for each session and controller.
  * Sessions support custom screenshot formats and visual reasoning services.
  * Visual configuration changes remain isolated between sessions while preserving standalone behavior.

* **Bug Fixes**
  * Prevented visual settings from unintentionally carrying over between sessions or controllers.

* **Tests**
  * Added coverage for configuration isolation, inheritance, overrides, and explicit disabling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->