### PR TITLE
fix: support scoped captcha solver dependencies

### DIFF
--- a/src/core/CaptchaSolver.ts
+++ b/src/core/CaptchaSolver.ts
@@ -25,7 +25,7 @@
 
 import type { Page } from "playwright-core";
 import { createLogger } from "./Logger.js";
-import { getVisualReasoner } from "./VisualReasoner.js";
+import { getVisualReasoner, type VisualReasoner } from "./VisualReasoner.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -67,22 +67,27 @@ export interface CaptchaSolver {
 	solve(page: Page, challenge: CaptchaChallenge): Promise<CaptchaSolution | null>;
 }
 
+/** Dependencies for one CAPTCHA solve attempt. Omit them for standalone global behavior. */
+export interface CaptchaSolverRunOptions {
+	/** Custom solvers to try before the built-in VLM solver. */
+	solvers?: readonly CaptchaSolver[];
+	/** Provider for the VLM fallback. Defaults to the standalone global VisualReasoner. */
+	getVisualReasoner?: () => VisualReasoner | null;
+}
+
 // ─── Built-in: VLM-based Solver ───────────────────────────────────────────────
 
 const log = createLogger("Solver");
 
 /**
- * Creates a CAPTCHA solver backed by the registered VisualReasoner (VLM).
+ * Creates a CAPTCHA solver backed by a VisualReasoner (VLM).
  *
- * When a captcha is detected, this solver:
- * 1. Screenshots the captcha element (or full page as fallback)
- * 2. Asks the VLM: "Read the text in this CAPTCHA image. Reply with ONLY the characters."
- * 3. Returns the VLM's answer as the token
- *
- * Requires a VisualReasoner to be registered via `setVisualReasoner()`.
- * If no VLM is registered, this solver returns null and falls through.
+ * The optional provider makes controller/session ownership explicit. Standalone
+ * callers that omit it retain the historical global VisualReasoner behavior.
  */
-export function createVLMCaptchaSolver(): CaptchaSolver {
+export function createVLMCaptchaSolver(
+	reasonerProvider: () => VisualReasoner | null = getVisualReasoner,
+): CaptchaSolver {
 	return {
 		name: "Talox VLM",
 
@@ -123,7 +128,7 @@ export function createVLMCaptchaSolver(): CaptchaSolver {
 		},
 
 		async solve(page, challenge) {
-			const reasoner = getVisualReasoner();
+			const reasoner = reasonerProvider();
 			if (!reasoner) {
 				log.info("No VisualReasoner registered — captcha solving unavailable");
 				return null;
@@ -188,7 +193,7 @@ export function createVLMCaptchaSolver(): CaptchaSolver {
 
 let registeredSolvers: CaptchaSolver[] = [];
 
-/** Register a solver. Solver is appended — solvers are tried in registration order. */
+/** Register a standalone solver. Solver is appended — solvers are tried in registration order. */
 export function registerSolver(solver: CaptchaSolver): void {
 	registeredSolvers.push(solver);
 	log.info(`Registered solver: ${solver.name}`);
@@ -203,13 +208,16 @@ export function getSolvers(): readonly CaptchaSolver[] {
 }
 
 /**
- * Try all registered solvers in sequence.
- * The built-in VLM solver is always tried LAST (after custom solvers).
- * Returns the first successful solution, or null if all fail.
+ * Try custom solvers in sequence and then the built-in VLM solver.
+ *
+ * When `options` are omitted, this preserves the historical standalone global
+ * registry + global VisualReasoner behavior. Controller-bound callers can pass
+ * their own solver list and reasoner provider to avoid cross-session leakage.
  */
-export async function trySolve(page: Page): Promise<CaptchaSolution | null> {
-	// Always include the VLM solver as fallback
-	const allSolvers = [...registeredSolvers, createVLMCaptchaSolver()];
+export async function trySolve(page: Page, options: CaptchaSolverRunOptions = {}): Promise<CaptchaSolution | null> {
+	const customSolvers = options.solvers ?? registeredSolvers;
+	const reasonerProvider = options.getVisualReasoner ?? getVisualReasoner;
+	const allSolvers = [...customSolvers, createVLMCaptchaSolver(reasonerProvider)];
 
 	for (const solver of allSolvers) {
 		log.info(`Attempting solver: ${solver.name}`);

--- a/src/core/ChallengeResolver.ts
+++ b/src/core/ChallengeResolver.ts
@@ -39,8 +39,9 @@ import type { Page } from "playwright-core";
  */
 
 import type { TakeoverReason } from "../types/events.js";
-import { trySolve } from "./CaptchaSolver.js";
+import { type CaptchaSolver, type CaptchaSolverRunOptions, trySolve } from "./CaptchaSolver.js";
 import type { ChallengeType, DetectedChallenge } from "./ChallengeDetector.js";
+import type { VisualReasoner } from "./VisualReasoner.js";
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type ResolutionStrategy =
@@ -95,6 +96,10 @@ export interface ChallengeResolverOptions {
 	 * @default 8000
 	 */
 	spaHydrationTimeoutMs?: number;
+	/** Controller/session-owned custom CAPTCHA solvers. Omit for the standalone global registry. */
+	captchaSolvers?: readonly CaptchaSolver[];
+	/** Controller/session-owned VisualReasoner provider for the built-in CAPTCHA fallback. */
+	getVisualReasoner?: () => VisualReasoner | null;
 }
 
 // ─── Consent/Age-Gate dismiss selectors ─────────────────────────────────────
@@ -134,12 +139,18 @@ export class ChallengeResolver {
 	private readonly baseDelayMs: number;
 	private readonly maxDelayMs: number;
 	private readonly spaHydrationTimeoutMs: number;
+	private readonly captchaSolveOptions: CaptchaSolverRunOptions;
 
 	constructor(options: ChallengeResolverOptions = {}) {
 		this.maxRetries = options.maxRetries ?? 3;
 		this.baseDelayMs = options.baseDelayMs ?? 1500;
 		this.maxDelayMs = options.maxDelayMs ?? 15_000;
 		this.spaHydrationTimeoutMs = options.spaHydrationTimeoutMs ?? 8_000;
+		this.captchaSolveOptions = {};
+		if (options.captchaSolvers !== undefined) this.captchaSolveOptions.solvers = options.captchaSolvers;
+		if (options.getVisualReasoner !== undefined) {
+			this.captchaSolveOptions.getVisualReasoner = options.getVisualReasoner;
+		}
 	}
 
 	// ─── Public API ─────────────────────────────────────────────────────────────
@@ -207,7 +218,7 @@ export class ChallengeResolver {
 
 		// Try external solvers (VLM-based or custom)
 		try {
-			const solution = await trySolve(page);
+			const solution = await trySolve(page, this.captchaSolveOptions);
 			if (solution) {
 				// Inject the token — handles reCAPTCHA/hCaptcha callbacks + form submits
 				try {

--- a/tests/unit/CaptchaSolverScopeOwnership.test.ts
+++ b/tests/unit/CaptchaSolverScopeOwnership.test.ts
@@ -132,8 +132,9 @@ describe("captcha solver scope ownership", () => {
 
 		expect(outcomeA.resolved).toBe(true);
 		expect(outcomeB.resolved).toBe(true);
+		expect(outcomeA.attempts[0]?.detail).toContain("reasoner-a");
+		expect(outcomeB.attempts[0]?.detail).toContain("reasoner-b");
 		expect(reasonerA.analyze).toHaveBeenCalledOnce();
 		expect(reasonerB.analyze).toHaveBeenCalledOnce();
-		expect(reasonerA.analyze).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining("answer-b"));
 	});
 });

--- a/tests/unit/CaptchaSolverScopeOwnership.test.ts
+++ b/tests/unit/CaptchaSolverScopeOwnership.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	type CaptchaSolver,
+	clearSolvers,
+	registerSolver,
+	trySolve,
+} from "../../src/core/CaptchaSolver.js";
+import { ChallengeResolver } from "../../src/core/ChallengeResolver.js";
+import { setVisualReasoner, type VisualReasoner } from "../../src/core/VisualReasoner.js";
+
+function makeSolver(name: string, token: string): CaptchaSolver {
+	return {
+		name,
+		detect: vi.fn().mockResolvedValue({
+			type: "recaptcha-v2",
+			sitekey: `${name}-sitekey`,
+			pageUrl: "https://example.com",
+		}),
+		solve: vi.fn().mockResolvedValue({ token, solver: name, durationMs: 1 }),
+	};
+}
+
+function makeReasoner(name: string, answer: string): VisualReasoner {
+	return {
+		name,
+		analyze: vi.fn().mockResolvedValue(answer),
+	};
+}
+
+function makePlainPage() {
+	return {
+		url: () => "https://example.com",
+		$: vi.fn().mockResolvedValue(null),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("page")),
+		evaluate: vi.fn().mockResolvedValue(undefined),
+	} as any;
+}
+
+function makeCaptchaPage() {
+	const captchaElement = {
+		getAttribute: vi.fn().mockResolvedValue("site-key"),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("captcha")),
+	};
+	return {
+		url: () => "https://example.com/captcha",
+		$: vi.fn(async (selector: string) => {
+			if (selector.includes("data-sitekey")) return captchaElement;
+			return null;
+		}),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("page")),
+		evaluate: vi.fn().mockResolvedValue(undefined),
+	} as any;
+}
+
+afterEach(() => {
+	clearSolvers();
+	setVisualReasoner(null);
+});
+
+describe("captcha solver scope ownership", () => {
+	it("uses an explicitly scoped solver list instead of the standalone registry", async () => {
+		const globalSolver = makeSolver("global", "global-token");
+		const scopedSolver = makeSolver("scoped", "scoped-token");
+		registerSolver(globalSolver);
+
+		const result = await trySolve(makePlainPage(), {
+			solvers: [scopedSolver],
+			getVisualReasoner: () => null,
+		});
+
+		expect(result?.token).toBe("scoped-token");
+		expect(scopedSolver.detect).toHaveBeenCalledOnce();
+		expect(globalSolver.detect).not.toHaveBeenCalled();
+	});
+
+	it("uses a scoped VLM provider instead of the standalone global reasoner", async () => {
+		const globalReasoner = makeReasoner("global", "global-answer");
+		const scopedReasoner = makeReasoner("scoped", "scoped-answer");
+		setVisualReasoner(globalReasoner);
+
+		const result = await trySolve(makeCaptchaPage(), {
+			solvers: [],
+			getVisualReasoner: () => scopedReasoner,
+		});
+
+		expect(result?.token).toBe("scoped-answer");
+		expect(scopedReasoner.analyze).toHaveBeenCalledOnce();
+		expect(globalReasoner.analyze).not.toHaveBeenCalled();
+	});
+
+	it("keeps custom solver ownership isolated across ChallengeResolver instances", async () => {
+		const solverA = makeSolver("solver-a", "token-a");
+		const solverB = makeSolver("solver-b", "token-b");
+		const resolverA = new ChallengeResolver({
+			captchaSolvers: [solverA],
+			getVisualReasoner: () => null,
+		});
+		const resolverB = new ChallengeResolver({
+			captchaSolvers: [solverB],
+			getVisualReasoner: () => null,
+		});
+
+		const [outcomeA, outcomeB] = await Promise.all([
+			resolverA.resolveCaptcha(makePlainPage()),
+			resolverB.resolveCaptcha(makePlainPage()),
+		]);
+
+		expect(outcomeA.resolved).toBe(true);
+		expect(outcomeB.resolved).toBe(true);
+		expect(outcomeA.attempts[0]?.detail).toContain("solver-a");
+		expect(outcomeB.attempts[0]?.detail).toContain("solver-b");
+		expect(solverA.solve).toHaveBeenCalledOnce();
+		expect(solverB.solve).toHaveBeenCalledOnce();
+	});
+
+	it("keeps VLM fallback ownership isolated across ChallengeResolver instances", async () => {
+		const reasonerA = makeReasoner("reasoner-a", "answer-a");
+		const reasonerB = makeReasoner("reasoner-b", "answer-b");
+		const resolverA = new ChallengeResolver({
+			captchaSolvers: [],
+			getVisualReasoner: () => reasonerA,
+		});
+		const resolverB = new ChallengeResolver({
+			captchaSolvers: [],
+			getVisualReasoner: () => reasonerB,
+		});
+
+		const [outcomeA, outcomeB] = await Promise.all([
+			resolverA.resolveCaptcha(makeCaptchaPage()),
+			resolverB.resolveCaptcha(makeCaptchaPage()),
+		]);
+
+		expect(outcomeA.resolved).toBe(true);
+		expect(outcomeB.resolved).toBe(true);
+		expect(reasonerA.analyze).toHaveBeenCalledOnce();
+		expect(reasonerB.analyze).toHaveBeenCalledOnce();
+		expect(reasonerA.analyze).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining("answer-b"));
+	});
+});


### PR DESCRIPTION
## Summary
- allow `trySolve()` to receive a scoped custom-solver list and VisualReasoner provider
- keep the historical global solver registry and global VisualReasoner as standalone defaults
- let each `ChallengeResolver` own CAPTCHA solver dependencies

## Regression coverage
- scoped solver lists ignore the standalone global registry
- scoped VLM providers ignore the standalone global reasoner
- separate ChallengeResolver instances keep custom solvers isolated
- separate ChallengeResolver instances keep VLM fallbacks isolated

This is the dependency boundary needed to wire `TaloxController.useSolver()` to controller-owned state without breaking standalone APIs.