### PR TITLE
fix: scope controller CAPTCHA solvers

### DIFF
--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -53,7 +53,7 @@ import type { TaloxSettings } from "../../types/settings.js";
 import { DEFAULT_SETTINGS, resolveLegacyMode } from "../../types/settings.js"; // NOSONAR
 import { formatAgentError } from "../AgentErrors.js";
 import type { BrowserType } from "../BrowserManager.js";
-import { type CaptchaSolver, registerSolver } from "../CaptchaSolver.js";
+import type { CaptchaSolver } from "../CaptchaSolver.js";
 import type { ChallengeState } from "../ChallengeDetector.js";
 import { ChallengeDetector } from "../ChallengeDetector.js";
 import type { ChallengeOutcome } from "../ChallengeResolver.js";
@@ -75,7 +75,7 @@ import type { SkillLoader } from "../skills/SkillLoader.js";
 import { AdaptationEngine } from "../smart/AdaptationEngine.js";
 import type { VideoRecorder as VideoRecorderType } from "../VideoRecorder.js";
 import { VideoRecorder as VideoRecorderClass } from "../VideoRecorder.js";
-import { resolveVisual, type ScreenshotFormat, type VisualReasoner } from "../VisualReasoner.js";
+import { getScopedVisualScope, resolveVisual, type ScreenshotFormat, type VisualReasoner } from "../VisualReasoner.js";
 import { ActionExecutor } from "./ActionExecutor.js";
 import type { EventHandler } from "./EventBus.js";
 import { EventBus } from "./EventBus.js";
@@ -113,7 +113,8 @@ export class TaloxController {
 	readonly _adapt: AdaptationEngine;
 	readonly _takeover: TakeoverBridge;
 	readonly _challenge: ChallengeDetector;
-	private readonly _challengeResolver: ChallengeResolver = new ChallengeResolver();
+	private readonly _challengeResolver: ChallengeResolver;
+	private readonly captchaSolvers: CaptchaSolver[] = [];
 
 	skillLoader?: SkillLoader; // NOSONAR — optional, set externally before launch
 
@@ -191,6 +192,14 @@ export class TaloxController {
 		this._events = new EventBus<TaloxEventMap>();
 		this._challenge = new ChallengeDetector();
 		this._session = new SessionManager(this.settings, this._events, baseDir);
+		this._challengeResolver = new ChallengeResolver({
+			captchaSolvers: this.captchaSolvers,
+			getVisualReasoner: () => {
+				const collector = this._session.getActivePage();
+				if (!collector) return null;
+				return getScopedVisualScope(collector)?.reasoner ?? null;
+			},
+		});
 		this._takeover = new TakeoverBridge(this._events, this.settings.humanTakeoverTimeoutMs);
 		this.observing = Boolean(mergedConfig.observe);
 		this._adapt = new AdaptationEngine(
@@ -1394,7 +1403,7 @@ export class TaloxController {
 	}
 
 	useSolver(solver: CaptchaSolver): void {
-		registerSolver(solver);
+		this.captchaSolvers.push(solver);
 	}
 
 	/**

--- a/tests/unit/TaloxControllerCaptchaScopeOwnership.test.ts
+++ b/tests/unit/TaloxControllerCaptchaScopeOwnership.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	clearSolvers,
+	getSolvers,
+	registerSolver,
+	type CaptchaChallenge,
+	type CaptchaSolver,
+} from "../../src/core/CaptchaSolver.js";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+import { setVisualReasoner, type VisualReasoner } from "../../src/core/VisualReasoner.js";
+
+function makeCustomSolver(name: string, token: string): CaptchaSolver {
+	return {
+		name,
+		detect: vi.fn(async () => ({
+			type: "image-captcha",
+			sitekey: "image",
+			pageUrl: "https://example.test",
+		}) satisfies CaptchaChallenge),
+		solve: vi.fn(async () => ({ token, solver: name, durationMs: 1 })),
+	};
+}
+
+function makeCustomSolverPage() {
+	return {
+		evaluate: vi.fn().mockResolvedValue(undefined),
+	} as any;
+}
+
+function makeVlmCaptchaPage() {
+	const captchaElement = {
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("captcha-image")),
+	};
+	return {
+		on: vi.fn(),
+		url: vi.fn().mockReturnValue("https://example.test/captcha"),
+		$: vi.fn(async (selector: string) => {
+			if (selector === "[data-sitekey]") return null;
+			if (selector === ".h-captcha[data-sitekey]") return null;
+			if (selector === 'img[src*="captcha"], img[id*="captcha"], img[class*="captcha"]') return captchaElement;
+			if (selector === 'input[name*="captcha"], input[id*="captcha"]') return null;
+			if (selector.includes("[data-sitekey], .h-captcha")) return captchaElement;
+			return null;
+		}),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("page-image")),
+		evaluate: vi.fn().mockResolvedValue(undefined),
+	} as any;
+}
+
+function bindActivePage(controller: TaloxController, page: any): void {
+	const collector = (controller._session as any).createStateCollector(page);
+	controller._session.pages = [collector];
+	controller._session.activePageIndex = 0;
+}
+
+function makeReasoner(name: string, answer: string): VisualReasoner {
+	return {
+		name,
+		analyze: vi.fn().mockResolvedValue(answer),
+	};
+}
+
+afterEach(() => {
+	clearSolvers();
+	setVisualReasoner(null);
+});
+
+describe("TaloxController CAPTCHA solver ownership", () => {
+	it("keeps custom solvers local to their owning controller", async () => {
+		const standaloneSolver = makeCustomSolver("standalone", "global-token");
+		const solverA = makeCustomSolver("solver-a", "token-a");
+		const solverB = makeCustomSolver("solver-b", "token-b");
+		registerSolver(standaloneSolver);
+
+		const controllerA = new TaloxController();
+		const controllerB = new TaloxController();
+		controllerA.useSolver(solverA);
+		controllerB.useSolver(solverB);
+
+		expect(getSolvers()).toEqual([standaloneSolver]);
+
+		const outcomeA = await (controllerA as any)._challengeResolver.resolveCaptcha(makeCustomSolverPage());
+		const outcomeB = await (controllerB as any)._challengeResolver.resolveCaptcha(makeCustomSolverPage());
+
+		expect(outcomeA.resolved).toBe(true);
+		expect(outcomeB.resolved).toBe(true);
+		expect(solverA.detect).toHaveBeenCalledOnce();
+		expect(solverA.solve).toHaveBeenCalledOnce();
+		expect(solverB.detect).toHaveBeenCalledOnce();
+		expect(solverB.solve).toHaveBeenCalledOnce();
+		expect(standaloneSolver.detect).not.toHaveBeenCalled();
+	});
+
+	it("uses each controller's scoped VisualReasoner for the built-in CAPTCHA fallback", async () => {
+		const controllerA = new TaloxController();
+		const controllerB = new TaloxController();
+		const pageA = makeVlmCaptchaPage();
+		const pageB = makeVlmCaptchaPage();
+		const reasonerA = makeReasoner("reasoner-a", "alpha");
+		const reasonerB = makeReasoner("reasoner-b", "beta");
+		bindActivePage(controllerA, pageA);
+		bindActivePage(controllerB, pageB);
+		controllerA.useVision(reasonerA);
+		controllerB.useVision(reasonerB);
+
+		const outcomeA = await (controllerA as any)._challengeResolver.resolveCaptcha(pageA);
+		const outcomeB = await (controllerB as any)._challengeResolver.resolveCaptcha(pageB);
+
+		expect(outcomeA.resolved).toBe(true);
+		expect(outcomeB.resolved).toBe(true);
+		expect(reasonerA.analyze).toHaveBeenCalledOnce();
+		expect(reasonerB.analyze).toHaveBeenCalledOnce();
+		expect(outcomeA.attempts[0]?.detail).toContain("reasoner-a");
+		expect(outcomeB.attempts[0]?.detail).toContain("reasoner-b");
+	});
+
+	it("does not fall back to the standalone global VisualReasoner for controller CAPTCHA resolution", async () => {
+		const globalReasoner = makeReasoner("global-reasoner", "should-not-run");
+		setVisualReasoner(globalReasoner);
+
+		const controller = new TaloxController();
+		const page = makeVlmCaptchaPage();
+		bindActivePage(controller, page);
+
+		const outcome = await (controller as any)._challengeResolver.resolveCaptcha(page);
+
+		expect(outcome.resolved).toBe(false);
+		expect(outcome.requiresHuman).toBe(true);
+		expect(globalReasoner.analyze).not.toHaveBeenCalled();
+	});
+
+	it("useVision(null) disables a previously configured controller-local CAPTCHA reasoner", async () => {
+		const controller = new TaloxController();
+		const page = makeVlmCaptchaPage();
+		const reasoner = makeReasoner("local-reasoner", "answer");
+		bindActivePage(controller, page);
+		controller.useVision(reasoner);
+		controller.useVision(null);
+
+		const outcome = await (controller as any)._challengeResolver.resolveCaptcha(page);
+
+		expect(outcome.resolved).toBe(false);
+		expect(outcome.requiresHuman).toBe(true);
+		expect(reasoner.analyze).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- keep `TaloxController.useSolver()` registrations local to that controller
- construct each controller's `ChallengeResolver` with its own mutable solver list
- wire the built-in CAPTCHA VLM fallback to the controller/session-scoped VisualReasoner from #90
- preserve standalone `registerSolver()` and global VisualReasoner behavior for standalone callers

## Regression coverage
- separate controllers do not see each other's custom CAPTCHA solvers
- controller `useSolver()` does not mutate the standalone solver registry
- separate controllers use their own `useVision()` reasoners for CAPTCHA fallback
- standalone global VisualReasoner is ignored by controller-bound CAPTCHA resolution
- `useVision(null)` disables the controller-local CAPTCHA VLM fallback

Controller source diff is intentionally limited to +13/-4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAPTCHA solving now consistently uses the solvers and visual reasoning configured for the active controller.
  * Solver and vision settings remain isolated between controller instances.
  * Disabling a controller’s vision support now correctly prevents visual fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->