### PR TITLE
fix: scope visual question resolution per session

### DIFF
--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -87,6 +87,7 @@ const log = createLogger("Vision");
 interface PendingQuestion {
 	resolve: (answer: string | null) => void;
 	timer: ReturnType<typeof setTimeout>;
+	owner: object | undefined;
 }
 
 const pending = new Map<string, PendingQuestion>();
@@ -137,6 +138,7 @@ export async function askVisual(
 		emitter: emitter ?? emitVisual ?? undefined,
 		screenshotFormat,
 		reasoner: currentReasoner,
+		pendingOwner: undefined,
 	});
 }
 
@@ -152,6 +154,7 @@ export async function askVisualScoped(
 		emitter: scope?.emitter ?? emitVisual ?? undefined,
 		screenshotFormat: scope?.screenshotFormat ?? screenshotFormat,
 		reasoner: scopedReasoner,
+		pendingOwner: scope,
 	});
 }
 
@@ -159,6 +162,7 @@ interface ActiveVisualScope {
 	emitter: VisualEmitter | undefined;
 	screenshotFormat: ScreenshotFormat;
 	reasoner: VisualReasoner | null;
+	pendingOwner: object | undefined;
 }
 
 async function askVisualInternal(
@@ -186,7 +190,7 @@ async function askVisualInternal(
 			resolve(null);
 		}, timeoutMs);
 
-		pending.set(id, { resolve, timer });
+		pending.set(id, { resolve, timer, owner: scope.pendingOwner });
 	});
 
 	if (scope.emitter) {
@@ -205,9 +209,15 @@ async function askVisualInternal(
 	return askVisualFallback(screenshot, question, scope.reasoner);
 }
 
+function settlePendingVisual(id: string, entry: PendingQuestion, answer: string): void {
+	clearTimeout(entry.timer);
+	pending.delete(id);
+	entry.resolve(answer);
+}
+
 /**
  * Resolve a pending visual question.
- * Called by the hosting agent after it processes the screenshot.
+ * Called by standalone hosts and retained as the backwards-compatible unrestricted resolver.
  */
 export function resolveVisual(id: string, answer: string): void {
 	const entry = pending.get(id);
@@ -216,9 +226,29 @@ export function resolveVisual(id: string, answer: string): void {
 		return;
 	}
 
-	clearTimeout(entry.timer);
-	pending.delete(id);
-	entry.resolve(answer);
+	settlePendingVisual(id, entry, answer);
+}
+
+/** Resolve a visual question only when it belongs to the caller's scoped visual session. */
+export function resolveVisualScoped(owner: object, id: string, answer: string): boolean {
+	const scope = scopedVisualScopes.get(owner);
+	if (!scope) {
+		log.warn(`resolveVisualScoped called without a visual scope for id: ${id}`);
+		return false;
+	}
+
+	const entry = pending.get(id);
+	if (!entry) {
+		log.warn(`resolveVisualScoped called for unknown id: ${id}`);
+		return false;
+	}
+	if (entry.owner !== scope) {
+		log.warn(`resolveVisualScoped rejected ownership mismatch for id: ${id}`);
+		return false;
+	}
+
+	settlePendingVisual(id, entry, answer);
+	return true;
 }
 
 // ─── VisualReasoner Fallback ─────────────────────────────────────────────────

--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -75,7 +75,12 @@ import type { SkillLoader } from "../skills/SkillLoader.js";
 import { AdaptationEngine } from "../smart/AdaptationEngine.js";
 import type { VideoRecorder as VideoRecorderType } from "../VideoRecorder.js";
 import { VideoRecorder as VideoRecorderClass } from "../VideoRecorder.js";
-import { getScopedVisualScope, resolveVisual, type ScreenshotFormat, type VisualReasoner } from "../VisualReasoner.js";
+import {
+	getScopedVisualScope,
+	resolveVisualScoped,
+	type ScreenshotFormat,
+	type VisualReasoner,
+} from "../VisualReasoner.js";
 import { ActionExecutor } from "./ActionExecutor.js";
 import type { EventHandler } from "./EventBus.js";
 import { EventBus } from "./EventBus.js";
@@ -1384,7 +1389,12 @@ export class TaloxController {
 	 * @param answer The answer to the visual question
 	 */
 	resolveVisual(id: string, answer: string): void {
-		resolveVisual(id, answer);
+		const collector = this._session.getActivePage();
+		if (!collector) {
+			this.log.warn(`Cannot resolve visual question without an active page: ${id}`);
+			return;
+		}
+		resolveVisualScoped(collector, id, answer);
 	}
 
 	/**

--- a/tests/unit/VisualConfigurationScopeOwnership.test.ts
+++ b/tests/unit/VisualConfigurationScopeOwnership.test.ts
@@ -97,6 +97,10 @@ describe("visual configuration scope ownership", () => {
 		const controllerB = new TaloxController();
 		const collectorA = createCollector(controllerA._session);
 		const collectorB = createCollector(controllerB._session);
+		controllerA._session.pages = [collectorA];
+		controllerA._session.activePageIndex = 0;
+		controllerB._session.pages = [collectorB];
+		controllerB._session.activePageIndex = 0;
 		const formatsA: VisualReasoner.ScreenshotFormat[] = [];
 		const formatsB: VisualReasoner.ScreenshotFormat[] = [];
 

--- a/tests/unit/VisualQuestionResolutionOwnership.test.ts
+++ b/tests/unit/VisualQuestionResolutionOwnership.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TaloxController } from "../../src/core/controller/TaloxController.js";
+import * as VisualReasoner from "../../src/core/VisualReasoner.js";
+
+function makePage() {
+	return {
+		on: vi.fn(),
+	} as any;
+}
+
+function bindCollectors(controller: TaloxController, count = 1) {
+	const collectors = Array.from({ length: count }, () => (controller._session as any).createStateCollector(makePage()));
+	controller._session.pages = collectors;
+	controller._session.activePageIndex = collectors.length - 1;
+	return collectors;
+}
+
+afterEach(() => {
+	VisualReasoner.setVisualEmitter(null);
+	VisualReasoner.setVisualReasoner(null);
+});
+
+describe("visual question response ownership", () => {
+	it("rejects another controller resolving a pending question", async () => {
+		const controllerA = new TaloxController();
+		const controllerB = new TaloxController();
+		const [collectorA] = bindCollectors(controllerA);
+		bindCollectors(controllerB);
+		let questionId = "";
+		controllerA.on("visualQuestion", (payload) => {
+			questionId = payload.id;
+		});
+
+		const answerPromise = VisualReasoner.askVisualScoped(collectorA!, Buffer.from("image"), "owned by a", 1_000);
+		expect(questionId).not.toBe("");
+
+		controllerB.resolveVisual(questionId, "wrong-controller");
+		let settled = false;
+		void answerPromise.then(() => {
+			settled = true;
+		});
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		controllerA.resolveVisual(questionId, "right-controller");
+		await expect(answerPromise).resolves.toBe("right-controller");
+	});
+
+	it("allows another tab from the same session to resolve the question", async () => {
+		const controller = new TaloxController();
+		const [originCollector] = bindCollectors(controller, 2);
+		let questionId = "";
+		controller.on("visualQuestion", (payload) => {
+			questionId = payload.id;
+		});
+
+		const answerPromise = VisualReasoner.askVisualScoped(originCollector!, Buffer.from("image"), "cross-tab", 1_000);
+		expect(questionId).not.toBe("");
+		// activePageIndex points at collector #2, which shares the same session VisualScope.
+		controller.resolveVisual(questionId, "same-session");
+
+		await expect(answerPromise).resolves.toBe("same-session");
+	});
+
+	it("keeps the standalone unrestricted resolver backwards compatible", async () => {
+		const owner = {};
+		let questionId = "";
+		VisualReasoner.setScopedVisualScope(owner, {
+			emitter: (payload) => {
+				questionId = payload.id;
+			},
+		});
+
+		const answerPromise = VisualReasoner.askVisualScoped(owner, Buffer.from("image"), "standalone", 1_000);
+		expect(questionId).not.toBe("");
+		VisualReasoner.resolveVisual(questionId, "legacy-global-resolver");
+
+		await expect(answerPromise).resolves.toBe("legacy-global-resolver");
+	});
+});


### PR DESCRIPTION
## Summary
- attach session ownership to pending scoped visual questions
- add `resolveVisualScoped()` that rejects responses from a different VisualScope
- route `TaloxController.resolveVisual()` through its active session scope
- keep standalone `resolveVisual()` unrestricted for backwards compatibility
- preserve cross-tab resolution because all collectors in one SessionManager share the same VisualScope

## Regression coverage
- controller B cannot resolve controller A's pending visual question
- the owning controller can still resolve after a foreign attempt
- another tab in the same session can resolve the question
- the standalone global resolver remains backwards compatible

Controller diff is intentionally limited to +12/-2.