### PR TITLE
fix: cancel pending visual questions on page close

### DIFF
--- a/src/core/PerceptionStack.ts
+++ b/src/core/PerceptionStack.ts
@@ -44,7 +44,7 @@
 import type { TaloxPageState } from "../types/index.js";
 import type { ChallengeDetector, ChallengeState } from "./ChallengeDetector.js";
 import type { PageStateCollector } from "./PageStateCollector.js";
-import { askVisualScoped } from "./VisualReasoner.js";
+import { askVisualScoped, cancelScopedVisualQuestions } from "./VisualReasoner.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,7 +53,7 @@ export type PerceptionPreset = "cheap" | "medium" | "heavy";
 export interface PerceptionLayerFlags {
 	/** Collect AX tree + interactive elements. Always true — required for all presets. */
 	structural: boolean;
-	/** Collect console errors + failed network requests. */
+	/** Collect console errors + failed HTTP requests. */
 	network: boolean;
 	/** Run RulesEngine structural diff + layout bug analysis. */
 	bugs: boolean;
@@ -117,6 +117,8 @@ export const PERCEPTION_PRESETS: Record<PerceptionPreset, PerceptionLayerFlags> 
 
 // ─── PerceptionStack ──────────────────────────────────────────────────────────
 
+const visualCloseBoundCollectors = new WeakSet<PageStateCollector>();
+
 /**
  * Composable wrapper around `PageStateCollector` that assembles perception
  * into presets and caches results within a single agent action cycle.
@@ -136,7 +138,17 @@ export class PerceptionStack {
 	constructor(
 		private readonly collector: PageStateCollector,
 		private readonly challengeDetector: ChallengeDetector | null = null,
-	) {}
+	) {
+		if (!visualCloseBoundCollectors.has(collector)) {
+			const page = collector.getPage();
+			if (page && typeof page.on === "function") {
+				visualCloseBoundCollectors.add(collector);
+				page.on("close", () => {
+					cancelScopedVisualQuestions(collector);
+				});
+			}
+		}
+	}
 
 	// ─── Public API ─────────────────────────────────────────────────────────────
 

--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -83,11 +83,14 @@ export function getScreenshotFormat(): ScreenshotFormat {
 // ─── Event-based Resolution ──────────────────────────────────────────────────
 
 const log = createLogger("Vision");
+const VISUAL_CANCELLED = Symbol("visual-cancelled");
+type VisualQuestionResolution = string | null | typeof VISUAL_CANCELLED;
 
 interface PendingQuestion {
-	resolve: (answer: string | null) => void;
+	resolve: (answer: VisualQuestionResolution) => void;
 	timer: ReturnType<typeof setTimeout>;
-	owner: object | undefined;
+	resolutionOwner: object | undefined;
+	sourceOwner: object | undefined;
 }
 
 const pending = new Map<string, PendingQuestion>();
@@ -138,7 +141,8 @@ export async function askVisual(
 		emitter: emitter ?? emitVisual ?? undefined,
 		screenshotFormat,
 		reasoner: currentReasoner,
-		pendingOwner: undefined,
+		resolutionOwner: undefined,
+		sourceOwner: undefined,
 	});
 }
 
@@ -154,7 +158,8 @@ export async function askVisualScoped(
 		emitter: scope?.emitter ?? emitVisual ?? undefined,
 		screenshotFormat: scope?.screenshotFormat ?? screenshotFormat,
 		reasoner: scopedReasoner,
-		pendingOwner: scope,
+		resolutionOwner: scope,
+		sourceOwner: owner,
 	});
 }
 
@@ -162,7 +167,8 @@ interface ActiveVisualScope {
 	emitter: VisualEmitter | undefined;
 	screenshotFormat: ScreenshotFormat;
 	reasoner: VisualReasoner | null;
-	pendingOwner: object | undefined;
+	resolutionOwner: object | undefined;
+	sourceOwner: object | undefined;
 }
 
 async function askVisualInternal(
@@ -184,13 +190,18 @@ async function askVisualInternal(
 		imageData = `data:image/png;base64,${screenshot.toString("base64")}`;
 	}
 
-	const promise = new Promise<string | null>((resolve) => {
+	const promise = new Promise<VisualQuestionResolution>((resolve) => {
 		const timer = setTimeout(() => {
 			pending.delete(id);
 			resolve(null);
 		}, timeoutMs);
 
-		pending.set(id, { resolve, timer, owner: scope.pendingOwner });
+		pending.set(id, {
+			resolve,
+			timer,
+			resolutionOwner: scope.resolutionOwner,
+			sourceOwner: scope.sourceOwner,
+		});
 	});
 
 	if (scope.emitter) {
@@ -199,6 +210,11 @@ async function askVisualInternal(
 	}
 
 	const agentAnswer = await promise;
+
+	if (agentAnswer === VISUAL_CANCELLED) {
+		log.info(`Visual question cancelled because its source page closed`);
+		return null;
+	}
 
 	if (agentAnswer !== null) {
 		log.info(`Agent resolved visual question in time`);
@@ -209,10 +225,24 @@ async function askVisualInternal(
 	return askVisualFallback(screenshot, question, scope.reasoner);
 }
 
-function settlePendingVisual(id: string, entry: PendingQuestion, answer: string): void {
+function settlePendingVisual(id: string, entry: PendingQuestion, answer: VisualQuestionResolution): void {
 	clearTimeout(entry.timer);
 	pending.delete(id);
 	entry.resolve(answer);
+}
+
+/**
+ * Cancel pending scoped visual questions that originated from one perception owner.
+ * Cancellation resolves callers with `null` and never invokes the VLM timeout fallback.
+ */
+export function cancelScopedVisualQuestions(owner: object): number {
+	let cancelled = 0;
+	for (const [id, entry] of pending) {
+		if (entry.sourceOwner !== owner) continue;
+		settlePendingVisual(id, entry, VISUAL_CANCELLED);
+		cancelled++;
+	}
+	return cancelled;
 }
 
 /**
@@ -242,7 +272,7 @@ export function resolveVisualScoped(owner: object, id: string, answer: string): 
 		log.warn(`resolveVisualScoped called for unknown id: ${id}`);
 		return false;
 	}
-	if (entry.owner !== scope) {
+	if (entry.resolutionOwner !== scope) {
 		log.warn(`resolveVisualScoped rejected ownership mismatch for id: ${id}`);
 		return false;
 	}

--- a/tests/unit/VisualQuestionCancellationOwnership.test.ts
+++ b/tests/unit/VisualQuestionCancellationOwnership.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PerceptionStack } from "../../src/core/PerceptionStack.js";
+import * as VisualReasoner from "../../src/core/VisualReasoner.js";
+
+function makeReasoner(name: string) {
+	return {
+		name,
+		analyze: vi.fn(async () => `${name}-fallback`),
+	} satisfies VisualReasoner.VisualReasoner;
+}
+
+function makeCollector() {
+	const closeHandlers: Array<() => void> = [];
+	const page = {
+		on: vi.fn((event: string, handler: () => void) => {
+			if (event === "close") closeHandlers.push(handler);
+		}),
+		screenshot: vi.fn().mockResolvedValue(Buffer.from("image")),
+	};
+	const collector = {
+		getPage: () => page,
+		collect: vi.fn(),
+	} as any;
+	return { collector, page, closeHandlers };
+}
+
+afterEach(() => {
+	VisualReasoner.setVisualEmitter(null);
+	VisualReasoner.setVisualReasoner(null);
+});
+
+describe("visual question cancellation ownership", () => {
+	it("cancels an owner's pending question without invoking its fallback reasoner", async () => {
+		const owner = {};
+		const reasoner = makeReasoner("owned");
+		VisualReasoner.setScopedVisualScope(owner, {
+			emitter: vi.fn(),
+			reasoner,
+		});
+
+		const answerPromise = VisualReasoner.askVisualScoped(owner, Buffer.from("image"), "pending", 10_000);
+
+		expect(VisualReasoner.cancelScopedVisualQuestions(owner)).toBe(1);
+		await expect(answerPromise).resolves.toBeNull();
+		expect(reasoner.analyze).not.toHaveBeenCalled();
+		expect(VisualReasoner.cancelScopedVisualQuestions(owner)).toBe(0);
+	});
+
+	it("cancels only the source tab while preserving same-session resolution for sibling tabs", async () => {
+		const ownerA = {};
+		const ownerB = {};
+		const ids = new Map<string, string>();
+		const reasoner = makeReasoner("shared");
+		const sharedScope: VisualReasoner.VisualScope = {
+			emitter: (payload) => ids.set(payload.question, payload.id),
+			reasoner,
+		};
+		VisualReasoner.setScopedVisualScope(ownerA, sharedScope);
+		VisualReasoner.setScopedVisualScope(ownerB, sharedScope);
+
+		const answerA = VisualReasoner.askVisualScoped(ownerA, Buffer.from("a"), "question-a", 10_000);
+		const answerB = VisualReasoner.askVisualScoped(ownerB, Buffer.from("b"), "question-b", 10_000);
+		const idB = ids.get("question-b");
+		expect(idB).toBeTruthy();
+
+		expect(VisualReasoner.cancelScopedVisualQuestions(ownerA)).toBe(1);
+		expect(VisualReasoner.resolveVisualScoped(ownerB, idB!, "answer-b")).toBe(true);
+
+		await expect(answerA).resolves.toBeNull();
+		await expect(answerB).resolves.toBe("answer-b");
+		expect(reasoner.analyze).not.toHaveBeenCalled();
+	});
+
+	it("binds one page-close cancellation handler per perception collector", async () => {
+		const { collector, page, closeHandlers } = makeCollector();
+		const reasoner = makeReasoner("page");
+		VisualReasoner.setScopedVisualScope(collector, {
+			emitter: vi.fn(),
+			reasoner,
+		});
+
+		const stackA = new PerceptionStack(collector);
+		new PerceptionStack(collector);
+		expect(page.on).toHaveBeenCalledTimes(1);
+		expect(closeHandlers).toHaveLength(1);
+
+		const answerPromise = stackA.askVisual("will-close");
+		await Promise.resolve();
+		closeHandlers[0]!();
+
+		await expect(answerPromise).resolves.toBeNull();
+		expect(reasoner.analyze).not.toHaveBeenCalled();
+	});
+
+	it("does not let scoped cancellation affect standalone pending questions", async () => {
+		const owner = {};
+		let questionId = "";
+		VisualReasoner.setVisualEmitter((payload) => {
+			questionId = payload.id;
+		});
+
+		const answerPromise = VisualReasoner.askVisual(Buffer.from("image"), "standalone", 10_000);
+		expect(questionId).not.toBe("");
+		expect(VisualReasoner.cancelScopedVisualQuestions(owner)).toBe(0);
+		VisualReasoner.resolveVisual(questionId, "standalone-answer");
+
+		await expect(answerPromise).resolves.toBe("standalone-answer");
+	});
+});


### PR DESCRIPTION
## Summary
- track both session resolution ownership and concrete source-collector ownership for pending visual questions
- add scoped cancellation that resolves pending callers with `null` without triggering the VLM timeout fallback
- bind one page-close cancellation handler per `PerceptionStack` collector
- preserve same-session cross-tab resolution and standalone visual-question behavior

## Regression coverage
- cancelling a source owner skips its fallback reasoner
- closing one tab does not cancel a sibling tab in the same visual session
- only one close handler is installed per collector even with multiple PerceptionStack instances
- scoped cancellation cannot affect standalone pending questions
