### PR TITLE
fix: clean pending visual state when emitters throw

### DIFF
--- a/src/core/VisualReasoner.ts
+++ b/src/core/VisualReasoner.ts
@@ -205,7 +205,13 @@ async function askVisualInternal(
 	});
 
 	if (scope.emitter) {
-		scope.emitter({ id, question, image: { format: activeFormat, data: imageData } });
+		try {
+			scope.emitter({ id, question, image: { format: activeFormat, data: imageData } });
+		} catch (error) {
+			const entry = pending.get(id);
+			if (entry) settlePendingVisual(id, entry, VISUAL_CANCELLED);
+			throw error;
+		}
 		log.info(`Visual question emitted: "${question.slice(0, 60)}..." (timeout: ${timeoutMs}ms)`);
 	}
 

--- a/tests/unit/VisualEmitterThrowCleanup.test.ts
+++ b/tests/unit/VisualEmitterThrowCleanup.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as VisualReasoner from "../../src/core/VisualReasoner.js";
+
+afterEach(() => {
+	vi.useRealTimers();
+	VisualReasoner.setVisualEmitter(null);
+	VisualReasoner.setVisualReasoner(null);
+});
+
+describe("visual emitter failure cleanup", () => {
+	it("removes scoped pending state before rethrowing an emitter error", async () => {
+		const owner = {};
+		const error = new Error("emitter boom");
+		VisualReasoner.setScopedVisualScope(owner, {
+			emitter: () => {
+				throw error;
+			},
+		});
+
+		await expect(VisualReasoner.askVisualScoped(owner, Buffer.from("image"), "question", 10_000)).rejects.toBe(error);
+		expect(VisualReasoner.cancelScopedVisualQuestions(owner)).toBe(0);
+	});
+
+	it("does not invoke the fallback later after emitter failure cleanup", async () => {
+		vi.useFakeTimers();
+		const owner = {};
+		const reasoner = {
+			name: "should-not-run",
+			analyze: vi.fn(async () => "late-fallback"),
+		};
+		VisualReasoner.setScopedVisualScope(owner, {
+			emitter: () => {
+				throw new Error("dispatch failed");
+			},
+			reasoner,
+		});
+
+		await expect(VisualReasoner.askVisualScoped(owner, Buffer.from("image"), "question", 10_000)).rejects.toThrow(
+			"dispatch failed",
+		);
+		await vi.advanceTimersByTimeAsync(10_000);
+
+		expect(reasoner.analyze).not.toHaveBeenCalled();
+		expect(VisualReasoner.cancelScopedVisualQuestions(owner)).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- preserve synchronous visual-emitter errors while cleaning the pending timer/map entry before rethrow
- prevent failed dispatch from leaving an orphaned visual question until timeout
- prevent a fallback reasoner from running later after dispatch already failed

## Regression coverage
- scoped emitter throw propagates the original error and leaves no cancellable pending state
- advancing past the original timeout after dispatch failure never invokes the fallback reasoner
