### PR TITLE
fix: isolate built-in warmup defaults per registry

### DIFF
--- a/src/core/SiteWarmup.ts
+++ b/src/core/SiteWarmup.ts
@@ -125,25 +125,30 @@ export const genericVerificationWarmup: WarmupStrategy = {
  */
 export type WarmupMap = Map<string, WarmupStrategy>;
 
-/** Internal immutable-by-convention snapshots so exported defaults cannot become constructor state. */
-const BUILT_IN_WARMUP_DEFINITIONS: ReadonlyArray<readonly [string, WarmupStrategy]> = [
-	["reddit.com", { ...redditWarmup }],
-	["cloudflare.com", { ...cloudflareWarmup }],
-	["*", { ...cloudflareWarmup }],
-];
+/** Private snapshots keep default registry construction independent from exported mutable objects. */
+const DEFAULT_REDDIT_WARMUP: WarmupStrategy = { ...redditWarmup };
+const DEFAULT_CLOUDFLARE_WARMUP: WarmupStrategy = { ...cloudflareWarmup };
 
 function createBuiltInWarmups(): WarmupMap {
-	return new Map(BUILT_IN_WARMUP_DEFINITIONS.map(([hostname, strategy]) => [hostname, { ...strategy }]));
+	return new Map([
+		["reddit.com", { ...DEFAULT_REDDIT_WARMUP }],
+		["cloudflare.com", { ...DEFAULT_CLOUDFLARE_WARMUP }],
+		["*", { ...DEFAULT_CLOUDFLARE_WARMUP }],
+	]);
 }
 
 /**
  * Pre-registered built-in warmups for known sites.
  *
- * This exported map remains mutable for backwards compatibility, but default
- * `SiteWarmupRegistry` instances are created from private snapshots instead of
- * using this object as shared constructor state.
+ * This exported map retains its historical strategy identities for backwards
+ * compatibility, while default `SiteWarmupRegistry` instances are created from
+ * private snapshots instead of using this object as shared constructor state.
  */
-export const BUILT_IN_WARMUPS: WarmupMap = createBuiltInWarmups();
+export const BUILT_IN_WARMUPS: WarmupMap = new Map([
+	["reddit.com", redditWarmup],
+	["cloudflare.com", cloudflareWarmup],
+	["*", cloudflareWarmup],
+]);
 
 /**
  * Registry that maps hostname suffixes to {@link WarmupStrategy} instances.
@@ -153,15 +158,15 @@ export class SiteWarmupRegistry {
 	private readonly warmups: WarmupMap;
 
 	constructor(builtins?: WarmupMap) {
-		// Preserve caller-provided map reference semantics while giving every
-		// default registry fresh built-in strategy objects of its own.
+		// Preserve caller-provided strategy identity while giving every default
+		// registry fresh built-in strategy objects of its own.
 		this.warmups = builtins ? new Map(builtins) : createBuiltInWarmups();
 	}
 
 	/**
 	 * Register a warmup strategy for a hostname suffix.
 	 *
-	 * @param hostname - Hostname suffix to match (e.g., `"reddit.com").
+	 * @param hostname - Hostname suffix to match (e.g., `"reddit.com"`).
 	 *                   Use `"*"` to register a catch-all fallback.
 	 * @param strategy - The warmup strategy.
 	 */

--- a/src/core/SiteWarmup.ts
+++ b/src/core/SiteWarmup.ts
@@ -125,16 +125,25 @@ export const genericVerificationWarmup: WarmupStrategy = {
  */
 export type WarmupMap = Map<string, WarmupStrategy>;
 
+/** Internal immutable-by-convention snapshots so exported defaults cannot become constructor state. */
+const BUILT_IN_WARMUP_DEFINITIONS: ReadonlyArray<readonly [string, WarmupStrategy]> = [
+	["reddit.com", { ...redditWarmup }],
+	["cloudflare.com", { ...cloudflareWarmup }],
+	["*", { ...cloudflareWarmup }],
+];
+
+function createBuiltInWarmups(): WarmupMap {
+	return new Map(BUILT_IN_WARMUP_DEFINITIONS.map(([hostname, strategy]) => [hostname, { ...strategy }]));
+}
+
 /**
  * Pre-registered built-in warmups for known sites.
+ *
+ * This exported map remains mutable for backwards compatibility, but default
+ * `SiteWarmupRegistry` instances are created from private snapshots instead of
+ * using this object as shared constructor state.
  */
-export const BUILT_IN_WARMUPS: WarmupMap = new Map([
-	["reddit.com", redditWarmup],
-	["cloudflare.com", cloudflareWarmup],
-	// The cloudflare warmup is also the default for any site that triggers it.
-	// It is registered as a fallback via the '*' key.
-	["*", cloudflareWarmup],
-]);
+export const BUILT_IN_WARMUPS: WarmupMap = createBuiltInWarmups();
 
 /**
  * Registry that maps hostname suffixes to {@link WarmupStrategy} instances.
@@ -143,14 +152,16 @@ export const BUILT_IN_WARMUPS: WarmupMap = new Map([
 export class SiteWarmupRegistry {
 	private readonly warmups: WarmupMap;
 
-	constructor(builtins: WarmupMap = BUILT_IN_WARMUPS) {
-		this.warmups = new Map(builtins);
+	constructor(builtins?: WarmupMap) {
+		// Preserve caller-provided map reference semantics while giving every
+		// default registry fresh built-in strategy objects of its own.
+		this.warmups = builtins ? new Map(builtins) : createBuiltInWarmups();
 	}
 
 	/**
 	 * Register a warmup strategy for a hostname suffix.
 	 *
-	 * @param hostname - Hostname suffix to match (e.g., `"reddit.com"`).
+	 * @param hostname - Hostname suffix to match (e.g., `"reddit.com").
 	 *                   Use `"*"` to register a catch-all fallback.
 	 * @param strategy - The warmup strategy.
 	 */

--- a/tests/unit/SiteWarmupDefaultIsolation.test.ts
+++ b/tests/unit/SiteWarmupDefaultIsolation.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	BUILT_IN_WARMUPS,
+	SiteWarmupRegistry,
+	type WarmupStrategy,
+} from "../../src/core/SiteWarmup.js";
+
+const originalExportedEntries = Array.from(BUILT_IN_WARMUPS.entries());
+
+afterEach(() => {
+	BUILT_IN_WARMUPS.clear();
+	for (const [hostname, strategy] of originalExportedEntries) {
+		BUILT_IN_WARMUPS.set(hostname, strategy);
+	}
+});
+
+describe("SiteWarmupRegistry default isolation", () => {
+	it("does not let mutations of the exported built-in map alter future default registries", () => {
+		BUILT_IN_WARMUPS.clear();
+		BUILT_IN_WARMUPS.set("poisoned.example", {
+			name: "poisoned",
+			detect: () => true,
+			warmup: async () => {},
+		});
+
+		const registry = new SiteWarmupRegistry();
+
+		expect(registry.getWarmup("reddit.com")?.name).toBe("reddit-humanity-challenge");
+		expect(registry.getWarmup("unknown.example")?.name).toBe("cloudflare-challenge");
+		expect(registry.getWarmup("poisoned.example")?.name).toBe("cloudflare-challenge");
+	});
+
+	it("gives each default registry independent built-in strategy objects", () => {
+		const registryA = new SiteWarmupRegistry();
+		const registryB = new SiteWarmupRegistry();
+		const redditA = registryA.getWarmup("reddit.com")!;
+		const redditB = registryB.getWarmup("reddit.com")!;
+
+		expect(redditA).not.toBe(redditB);
+		redditA.name = "mutated-in-a";
+
+		expect(registryA.getWarmup("reddit.com")?.name).toBe("mutated-in-a");
+		expect(registryB.getWarmup("reddit.com")?.name).toBe("reddit-humanity-challenge");
+		expect(new SiteWarmupRegistry().getWarmup("reddit.com")?.name).toBe("reddit-humanity-challenge");
+	});
+
+	it("preserves caller-provided custom strategy identity", () => {
+		const custom: WarmupStrategy = {
+			name: "custom",
+			detect: () => false,
+			warmup: async () => {},
+		};
+		const registry = new SiteWarmupRegistry(new Map([["custom.example", custom]]));
+
+		expect(registry.getWarmup("custom.example")).toBe(custom);
+	});
+});


### PR DESCRIPTION
## Summary
- stop using the exported mutable `BUILT_IN_WARMUPS` map as default constructor state
- snapshot built-in strategies privately and create fresh strategy objects for every default `SiteWarmupRegistry`
- preserve the exported map for backwards compatibility
- preserve caller-provided custom strategy identity

## Regression coverage
- mutating/clearing the exported built-in map cannot poison future default registries
- mutating a built-in strategy returned by registry A cannot affect registry B or future registries
- explicitly provided custom map strategies retain reference identity
