### PR TITLE
fix: clean observe session listener lifecycle

### DIFF
--- a/src/core/observe/ObserveSession.ts
+++ b/src/core/observe/ObserveSession.ts
@@ -32,7 +32,7 @@ import type {
 	SessionReportExtras,
 } from "../../types/session-report.js";
 import type { ArtifactBuilder } from "../ArtifactBuilder.js";
-import type { EventBus } from "../controller/EventBus.js";
+import type { EventBus, EventHandler } from "../controller/EventBus.js";
 import { createLogger } from "../Logger.js";
 import { AnnotationBuffer } from "./AnnotationBuffer.js";
 import { OverlayInjector } from "./OverlayInjector.js";
@@ -73,6 +73,7 @@ export class ObserveSession {
 	private readonly failureLog: FailureEntry[] = [];
 	private readonly diffLog: InteractionDiff[] = [];
 	private readonly bugSummaries: BugSummaryEntry[] = [];
+	private readonly listenerDisposers: Array<() => void> = [];
 	private lastUrl: string | null = null;
 	private readonly artifactBuilder: ArtifactBuilder;
 
@@ -135,7 +136,7 @@ export class ObserveSession {
 		}
 
 		// Track console errors
-		this.page.on("console", (msg: any) => {
+		const onConsole = (msg: any) => {
 			if (msg.type() === "error") {
 				const last = this.interactions.at(-1);
 				if (last) {
@@ -146,10 +147,14 @@ export class ObserveSession {
 					url: this.page.url?.() ?? "",
 				});
 			}
+		};
+		this.page.on("console", onConsole);
+		this.listenerDisposers.push(() => {
+			if (typeof this.page.off === "function") this.page.off("console", onConsole);
 		});
 
 		// Track network failures
-		this.page.on("requestfailed", (request: any) => {
+		const onRequestFailed = (request: any) => {
 			const failure = {
 				url: request.url(),
 				status: request.failure()?.errorText ? -1 : 0,
@@ -164,10 +169,14 @@ export class ObserveSession {
 				status: failure.status,
 				type: failure.type,
 			});
+		};
+		this.page.on("requestfailed", onRequestFailed);
+		this.listenerDisposers.push(() => {
+			if (typeof this.page.off === "function") this.page.off("requestfailed", onRequestFailed);
 		});
 
 		// Track page navigations
-		this.page.on("framenavigated", (frame: any) => {
+		const onFrameNavigated = (frame: any) => {
 			if (frame !== this.page.mainFrame?.()) return;
 			const url = frame.url();
 			if (!url || url === "about:blank") return;
@@ -182,6 +191,10 @@ export class ObserveSession {
 			};
 			this.interactions.push(interaction);
 			this.eventBus.emit("navigation", { url, title: "" });
+		};
+		this.page.on("framenavigated", onFrameNavigated);
+		this.listenerDisposers.push(() => {
+			if (typeof this.page.off === "function") this.page.off("framenavigated", onFrameNavigated);
 		});
 
 		const logEvent = <K extends keyof TaloxEventMap>(event: K, payload?: TaloxEventMap[K]) => {
@@ -192,8 +205,8 @@ export class ObserveSession {
 			});
 		};
 
-		this.eventBus.on("navigation", (payload) => logEvent("navigation", payload));
-		this.eventBus.on("consoleError", (payload) => {
+		this.subscribe("navigation", (payload) => logEvent("navigation", payload));
+		this.subscribe("consoleError", (payload) => {
 			logEvent("consoleError", payload);
 			this.recordFailure({
 				type: "console",
@@ -202,7 +215,7 @@ export class ObserveSession {
 				interactionIndex: this.interactions.length,
 			});
 		});
-		this.eventBus.on("networkError", (payload) => {
+		this.subscribe("networkError", (payload) => {
 			logEvent("networkError", payload);
 			this.recordFailure({
 				type: "network",
@@ -212,10 +225,10 @@ export class ObserveSession {
 				interactionIndex: this.interactions.length,
 			});
 		});
-		this.eventBus.on("annotationAdded", (payload) => logEvent("annotationAdded", payload));
-		this.eventBus.on("annotationUndone", (payload) => logEvent("annotationUndone", payload));
-		this.eventBus.on("stateChanged", (payload) => logEvent("stateChanged", payload));
-		this.eventBus.on("bugDetected", (payload) => {
+		this.subscribe("annotationAdded", (payload) => logEvent("annotationAdded", payload));
+		this.subscribe("annotationUndone", (payload) => logEvent("annotationUndone", payload));
+		this.subscribe("stateChanged", (payload) => logEvent("stateChanged", payload));
+		this.subscribe("bugDetected", (payload) => {
 			logEvent("bugDetected", payload);
 			this.bugSummaries.push({
 				id: payload.id,
@@ -226,13 +239,17 @@ export class ObserveSession {
 				evidence: payload.evidence?.screenshotRef,
 			});
 		});
-		this.eventBus.on("adapted", (payload) => logEvent("adapted", payload));
+		this.subscribe("adapted", (payload) => logEvent("adapted", payload));
 
 		// Auto-finalize on browser close
-		this.context.on("close", () => {
+		const onContextClose = () => {
 			this.finalize().catch((err: unknown) => {
 				this.log.error("Failed to finalize observe session:", err);
 			});
+		};
+		this.context.on("close", onContextClose);
+		this.listenerDisposers.push(() => {
+			if (typeof this.context.off === "function") this.context.off("close", onContextClose);
 		});
 
 		console.info(
@@ -327,13 +344,24 @@ export class ObserveSession {
 		});
 
 		this.eventBus.emit("sessionEnd", sessionEndPayload);
-
+		this.disposeListeners();
 		this.buffer.clear();
 
 		console.info(
 			`[Talox] Observe session ended · ${report.summary.totalInteractions} interactions · ` +
 				`${report.summary.totalAnnotations} annotations · ${Math.round(report.durationMs / 1000)}s`,
 		);
+	}
+
+	private subscribe<K extends keyof TaloxEventMap>(event: K, handler: EventHandler<TaloxEventMap[K]>): void {
+		this.eventBus.on(event, handler);
+		this.listenerDisposers.push(() => this.eventBus.off(event, handler));
+	}
+
+	private disposeListeners(): void {
+		for (const dispose of this.listenerDisposers.splice(0)) {
+			dispose();
+		}
 	}
 
 	private recordFailure(entry: FailureEntry): void {

--- a/tests/unit/ObserveSessionListenerLifecycle.test.ts
+++ b/tests/unit/ObserveSessionListenerLifecycle.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/controller/EventBus.js";
+import { ObserveSession } from "../../src/core/observe/ObserveSession.js";
+import type { TaloxEventMap } from "../../src/types/events.js";
+
+function makeEmitterTarget() {
+	const listeners = new Map<string, Set<(...args: any[]) => void>>();
+	const target = {
+		on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			const handlers = listeners.get(event) ?? new Set<(...args: any[]) => void>();
+			handlers.add(handler);
+			listeners.set(event, handlers);
+			return target;
+		}),
+		off: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			listeners.get(event)?.delete(handler);
+			return target;
+		}),
+		_emit(event: string, ...args: any[]) {
+			for (const handler of [...(listeners.get(event) ?? [])]) handler(...args);
+		},
+	};
+	return target;
+}
+
+function makePage() {
+	const emitter = makeEmitterTarget();
+	const mainFrame = { url: () => "https://example.com/next" };
+	return {
+		...emitter,
+		url: vi.fn(() => "https://example.com"),
+		mainFrame: vi.fn(() => mainFrame),
+		screenshot: vi.fn(async () => Buffer.from("frame")),
+	};
+}
+
+function makeContext() {
+	const emitter = makeEmitterTarget();
+	return {
+		...emitter,
+		close: vi.fn(async () => undefined),
+	};
+}
+
+const observedEvents: Array<keyof TaloxEventMap> = [
+	"navigation",
+	"consoleError",
+	"networkError",
+	"annotationAdded",
+	"annotationUndone",
+	"stateChanged",
+	"bugDetected",
+	"adapted",
+];
+
+describe("ObserveSession listener lifecycle", () => {
+	it("removes only session-owned listeners after successful finalization", async () => {
+		const eventBus = new EventBus<TaloxEventMap>();
+		const externalNavigationListener = vi.fn();
+		eventBus.on("navigation", externalNavigationListener);
+
+		const page = makePage();
+		const context = makeContext();
+		const session = new ObserveSession(
+			page as any,
+			context as any,
+			eventBus,
+			{ toActionFrames: vi.fn(() => []) } as any,
+			{ overlay: false, record: false },
+		);
+
+		await session.start();
+
+		expect(eventBus.listenerCount("navigation")).toBe(2);
+		for (const event of observedEvents.filter((event) => event !== "navigation")) {
+			expect(eventBus.listenerCount(event)).toBe(1);
+		}
+
+		await session.endSession();
+
+		expect(eventBus.listenerCount("navigation")).toBe(1);
+		for (const event of observedEvents.filter((event) => event !== "navigation")) {
+			expect(eventBus.listenerCount(event)).toBe(0);
+		}
+		expect(page.off).toHaveBeenCalledTimes(3);
+		expect(context.off).toHaveBeenCalledTimes(1);
+
+		eventBus.emit("navigation", { url: "https://external.example", title: "external" });
+		expect(externalNavigationListener).toHaveBeenCalledTimes(1);
+	});
+
+	it("stops page events from mutating a finalized session", async () => {
+		const eventBus = new EventBus<TaloxEventMap>();
+		const page = makePage();
+		const context = makeContext();
+		const session = new ObserveSession(
+			page as any,
+			context as any,
+			eventBus,
+			{ toActionFrames: vi.fn(() => []) } as any,
+			{ overlay: false, record: false },
+		);
+
+		await session.start();
+		await session.endSession();
+
+		page._emit("framenavigated", page.mainFrame());
+		page._emit("console", { type: () => "error", text: () => "late error" });
+		page._emit("requestfailed", {
+			url: () => "https://example.com/late.js",
+			failure: () => ({ errorText: "late failure" }),
+			resourceType: () => "script",
+		});
+
+		expect(session.buildReport().interactions).toEqual([]);
+		expect(eventBus.listenerCount("consoleError")).toBe(0);
+		expect(eventBus.listenerCount("networkError")).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- make ObserveSession own every EventBus/Page/BrowserContext listener it registers
- dispose only those session-owned listeners after successful finalization
- preserve external controller listeners
- prevent finalized sessions from continuing to mutate when their old page emits late events

## Why
ObserveSession subscribed to the controller-scoped EventBus on every start but never unsubscribed. Repeated observe sessions could therefore accumulate stale listeners, duplicate telemetry processing, and retain old session state.

## Verification
Adds focused regression coverage for listener counts, external-listener preservation, and late page events after finalization. CI should run the full repository gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup during finalization.
  * Prevented late page, context, and event notifications from affecting completed sessions.
  * Preserved unrelated navigation listeners while removing session-owned listeners.

* **Tests**
  * Added coverage for listener registration, cleanup, and finalized-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->