### PR TITLE
fix: own cross-origin page listener lifecycle

### DIFF
--- a/src/core/CrossOriginManager.ts
+++ b/src/core/CrossOriginManager.ts
@@ -61,6 +61,9 @@ export class CrossOriginManager {
 	private nextFrameId = 1;
 	private page: Page | null = null;
 	private mainCdpSession: CDPSession | null = null;
+	private readonly frameAttachedListener = (frame: Frame): Promise<void> => this.handleFrameAttached(frame);
+	private readonly frameNavigatedListener = (frame: Frame): Promise<void> => this.handleFrameNavigated(frame);
+	private readonly frameDetachedListener = (frame: Frame): void => this.handleFrameDetached(frame);
 
 	constructor(options: CrossOriginManagerOptions = {}) {
 		const configured = [...(options.trustedDomains ?? []), ...(options.trustedOrigins ?? [])];
@@ -70,13 +73,20 @@ export class CrossOriginManager {
 	/**
 	 * Install frame listeners on the given page.
 	 * Call after the page has been created (e.g. after `launch()`).
+	 * Reinstalling on the same page is idempotent; moving the manager to a new
+	 * page detaches listeners and frame sessions owned by the previous page.
 	 */
 	install(page: Page): void {
-		this.page = page;
+		if (this.page === page) return;
+		if (this.page) {
+			this.removePageListeners();
+			this.clearSessions();
+		}
 
-		page.on("frameattached", (frame: Frame) => this.handleFrameAttached(frame));
-		page.on("framenavigated", (frame: Frame) => this.handleFrameNavigated(frame));
-		page.on("framedetached", (frame: Frame) => this.handleFrameDetached(frame));
+		this.page = page;
+		page.on("frameattached", this.frameAttachedListener);
+		page.on("framenavigated", this.frameNavigatedListener);
+		page.on("framedetached", this.frameDetachedListener);
 	}
 
 	/** Look up the CDP session for a given stable frame ID. */
@@ -176,12 +186,10 @@ export class CrossOriginManager {
 		return session.cdpSession.send(command as any, params);
 	}
 
-	/** Clean up all CDP sessions and remove manager state. */
+	/** Clean up all CDP sessions, page listeners, and manager state. */
 	dispose(): void {
-		for (const [, session] of Array.from(this.sessions.entries())) {
-			session.cdpSession.detach().catch(() => {}); // NOSONAR — best-effort cleanup
-		}
-		this.sessions.clear();
+		this.removePageListeners();
+		this.clearSessions();
 		this.assignedFrameIds.clear();
 		this.mainCdpSession = null;
 		this.page = null;
@@ -242,6 +250,24 @@ export class CrossOriginManager {
 		if (existing) {
 			existing.cdpSession.detach().catch(() => {}); // NOSONAR — best-effort cleanup
 			this.sessions.delete(frameId);
+		}
+	}
+
+	private clearSessions(): void {
+		for (const session of this.sessions.values()) {
+			session.cdpSession.detach().catch(() => {}); // NOSONAR — best-effort cleanup
+		}
+		this.sessions.clear();
+	}
+
+	private removePageListeners(): void {
+		if (!this.page) return;
+		try {
+			this.page.off("frameattached", this.frameAttachedListener);
+			this.page.off("framenavigated", this.frameNavigatedListener);
+			this.page.off("framedetached", this.frameDetachedListener);
+		} catch {
+			// NOSONAR — page may already be closed
 		}
 	}
 

--- a/tests/unit/CrossOriginManagerListenerLifecycle.test.ts
+++ b/tests/unit/CrossOriginManagerListenerLifecycle.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { CrossOriginManager } from "../../src/core/CrossOriginManager.js";
+
+function createPage() {
+	const listeners = new Map<string, Set<(value: any) => unknown>>();
+	const cdp = {
+		send: vi.fn(async () => ({})),
+		detach: vi.fn(async () => undefined),
+	};
+	const page = {
+		on: vi.fn((event: string, handler: (value: any) => unknown) => {
+			const handlers = listeners.get(event) ?? new Set<(value: any) => unknown>();
+			handlers.add(handler);
+			listeners.set(event, handlers);
+			return page;
+		}),
+		off: vi.fn((event: string, handler: (value: any) => unknown) => {
+			listeners.get(event)?.delete(handler);
+			return page;
+		}),
+		context: vi.fn(() => ({ newCDPSession: vi.fn(async () => cdp) })),
+		_emit: async (event: string, value: any) => {
+			await Promise.all([...(listeners.get(event) ?? [])].map((handler) => handler(value)));
+		},
+		_listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+	};
+	return { page, cdp };
+}
+
+function createCrossOriginFrame(name = "child") {
+	const parent = {
+		name: vi.fn(() => "parent"),
+		url: vi.fn(() => "https://parent.example/page"),
+		parentFrame: vi.fn(() => null),
+	};
+	return {
+		name: vi.fn(() => name),
+		url: vi.fn(() => "https://child.example/embed"),
+		parentFrame: vi.fn(() => parent),
+	};
+}
+
+describe("CrossOriginManager page listener lifecycle", () => {
+	it("installs one listener set per page and treats repeated install as idempotent", () => {
+		const manager = new CrossOriginManager();
+		const { page } = createPage();
+
+		manager.install(page as any);
+		manager.install(page as any);
+
+		expect(page.on).toHaveBeenCalledTimes(3);
+		expect(page._listenerCount("frameattached")).toBe(1);
+		expect(page._listenerCount("framenavigated")).toBe(1);
+		expect(page._listenerCount("framedetached")).toBe(1);
+	});
+
+	it("removes all page listeners on dispose and ignores later frame events", async () => {
+		const manager = new CrossOriginManager();
+		const { page } = createPage();
+		manager.install(page as any);
+		manager.dispose();
+
+		expect(page.off).toHaveBeenCalledTimes(3);
+		expect(page._listenerCount("frameattached")).toBe(0);
+		expect(page._listenerCount("framenavigated")).toBe(0);
+		expect(page._listenerCount("framedetached")).toBe(0);
+
+		await page._emit("frameattached", createCrossOriginFrame());
+		expect(manager.getAllSessions()).toEqual([]);
+	});
+
+	it("detaches old sessions and listeners when moved to a new page", async () => {
+		const manager = new CrossOriginManager();
+		const first = createPage();
+		const second = createPage();
+		manager.install(first.page as any);
+		await first.page._emit("frameattached", createCrossOriginFrame("old-child"));
+		expect(manager.getSession("old-child")).toBeDefined();
+
+		manager.install(second.page as any);
+
+		expect(first.cdp.detach).toHaveBeenCalledTimes(1);
+		expect(manager.getSession("old-child")).toBeUndefined();
+		expect(first.page.off).toHaveBeenCalledTimes(3);
+		expect(second.page.on).toHaveBeenCalledTimes(3);
+	});
+});


### PR DESCRIPTION
## Summary
- make CrossOriginManager keep stable references to its frame listeners
- make repeated install on the same page idempotent
- detach old page listeners and CDP sessions when moving the manager to another page
- remove owned listeners during dispose

## Why
CrossOriginManager previously registered anonymous page listeners that `dispose()` could not remove. Direct reuse/reinstall could stack frame handlers despite the class claiming to clean up its state.

## Verification
Adds focused regression coverage for idempotent install, dispose cleanup, late frame events, and moving the manager between pages.