### PR TITLE
fix: rebind inspect clients across page attach

### DIFF
--- a/src/core/inspect/InspectServer.ts
+++ b/src/core/inspect/InspectServer.ts
@@ -28,6 +28,8 @@ interface DevToolsTarget {
 	webSocketDebuggerUrl: string;
 }
 
+type CdpEventHandler = (event: { method: string; params?: unknown }) => void;
+
 // ─── Implementation ─────────────────────────────────────────────────────────
 
 /**
@@ -47,6 +49,7 @@ export class InspectServer {
 	private page: Page | null = null;
 	private cdpSession: import("playwright-core").CDPSession | null = null;
 	private readonly devtoolsClients: Set<WebSocket> = new Set();
+	private readonly clientEventHandlers = new Map<WebSocket, CdpEventHandler>();
 	private running = false;
 	private attachInFlight: Promise<void> | null = null;
 	private detachInFlight: Promise<void> | null = null;
@@ -92,11 +95,14 @@ export class InspectServer {
 		const previousSession = this.cdpSession;
 		this.cdpSession = null;
 		if (previousSession) {
+			this.unbindClientsFromSession(previousSession);
 			await previousSession.detach().catch(() => {}); // NOSONAR — previous page may already be closed
 		}
 
 		try {
-			this.cdpSession = await page.context().newCDPSession(page);
+			const nextSession = await page.context().newCDPSession(page);
+			this.cdpSession = nextSession;
+			this.bindClientsToSession(nextSession);
 		} catch {
 			// NOSONAR — CDP session creation may fail in some browsers
 		}
@@ -145,6 +151,10 @@ export class InspectServer {
 		const attach = this.attachInFlight;
 		if (attach) await attach.catch(() => {});
 
+		const cdpSession = this.cdpSession;
+		this.cdpSession = null;
+		if (cdpSession) this.unbindClientsFromSession(cdpSession);
+
 		const clients = Array.from(this.devtoolsClients);
 		for (const ws of clients) {
 			try {
@@ -158,9 +168,8 @@ export class InspectServer {
 			}
 		}
 		this.devtoolsClients.clear();
+		this.clientEventHandlers.clear();
 
-		const cdpSession = this.cdpSession;
-		this.cdpSession = null;
 		const cdpDetach = cdpSession ? cdpSession.detach().catch(() => {}) : Promise.resolve();
 
 		this.page = null;
@@ -252,12 +261,13 @@ export class InspectServer {
 	private handleDevToolsConnection(ws: WebSocket): void {
 		this.devtoolsClients.add(ws);
 
-		const onCdpEvent = ({ method, params }: { method: string; params?: unknown }) => {
+		const onCdpEvent: CdpEventHandler = ({ method, params }) => {
 			const msg = JSON.stringify({ method, params });
 			if (ws.readyState === ws.OPEN) {
 				ws.send(msg);
 			}
 		};
+		this.clientEventHandlers.set(ws, onCdpEvent);
 
 		if (this.cdpSession) {
 			this.cdpSession.on("event", onCdpEvent);
@@ -271,10 +281,23 @@ export class InspectServer {
 
 		ws.on("close", () => {
 			this.devtoolsClients.delete(ws);
+			this.clientEventHandlers.delete(ws);
 			if (this.cdpSession) {
 				this.cdpSession.off("event", onCdpEvent);
 			}
 		});
+	}
+
+	private bindClientsToSession(session: import("playwright-core").CDPSession): void {
+		for (const handler of this.clientEventHandlers.values()) {
+			session.on("event", handler);
+		}
+	}
+
+	private unbindClientsFromSession(session: import("playwright-core").CDPSession): void {
+		for (const handler of this.clientEventHandlers.values()) {
+			session.off("event", handler);
+		}
 	}
 
 	private async forwardToCdp(raw: RawData): Promise<void> {

--- a/tests/unit/InspectServerClientReattach.test.ts
+++ b/tests/unit/InspectServerClientReattach.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHttpServer, mockWss, mockCreateServer } = vi.hoisted(() => {
+	const mockHttpServer = {
+		listen: vi.fn(),
+		close: vi.fn(),
+		once: vi.fn(),
+		removeListener: vi.fn(),
+	};
+	const mockWss = {
+		on: vi.fn(),
+		close: vi.fn(),
+	};
+	const mockCreateServer = vi.fn(() => mockHttpServer);
+	return { mockHttpServer, mockWss, mockCreateServer };
+});
+
+vi.mock("node:http", () => ({ createServer: mockCreateServer }));
+vi.mock("node:crypto", () => ({ randomUUID: vi.fn(() => "inspect-reattach-id") }));
+vi.mock("ws", () => ({
+	WebSocketServer: vi.fn().mockImplementation(function (this: any) {
+		return mockWss;
+	}),
+	WebSocket: { OPEN: 1 },
+}));
+vi.mock("playwright-core", () => ({}));
+
+import { InspectServer } from "../../src/core/inspect/InspectServer.js";
+
+function createCdpSession() {
+	return {
+		on: vi.fn(),
+		off: vi.fn(),
+		send: vi.fn().mockResolvedValue({}),
+		detach: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function createPage(cdpSession: ReturnType<typeof createCdpSession>, url: string) {
+	return {
+		url: vi.fn(() => url),
+		context: vi.fn(() => ({ newCDPSession: vi.fn().mockResolvedValue(cdpSession) })),
+	};
+}
+
+function createClient() {
+	const handlers = new Map<string, (...args: any[]) => void>();
+	const client = {
+		OPEN: 1,
+		readyState: 1,
+		send: vi.fn(),
+		terminate: vi.fn(),
+		close: vi.fn(),
+		on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+			handlers.set(event, handler);
+			return client;
+		}),
+		_emit: (event: string, ...args: any[]) => handlers.get(event)?.(...args),
+	};
+	return client;
+}
+
+describe("InspectServer connected client reattach", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHttpServer.once.mockReturnValue(mockHttpServer);
+		mockHttpServer.removeListener.mockReturnValue(mockHttpServer);
+		mockHttpServer.listen.mockImplementation((_port: number, _host: string, callback: () => void) => {
+			callback();
+			return mockHttpServer;
+		});
+		mockHttpServer.close.mockImplementation((callback?: () => void) => {
+			callback?.();
+			return mockHttpServer;
+		});
+		mockWss.on.mockReturnValue(mockWss);
+		mockWss.close.mockImplementation((callback?: () => void) => callback?.());
+	});
+
+	it("moves connected DevTools event subscriptions to the replacement CDP session", async () => {
+		const firstCdp = createCdpSession();
+		const secondCdp = createCdpSession();
+		const server = new InspectServer({ port: 9222 });
+		await server.attach(createPage(firstCdp, "https://first.example") as any);
+
+		const connectionHandler = mockWss.on.mock.calls.find((call: any[]) => call[0] === "connection")?.[1];
+		expect(connectionHandler).toBeDefined();
+		const client = createClient();
+		connectionHandler(client as any);
+
+		const eventHandler = firstCdp.on.mock.calls.find((call: any[]) => call[0] === "event")?.[1];
+		expect(eventHandler).toBeDefined();
+
+		await server.attach(createPage(secondCdp, "https://second.example") as any);
+
+		expect(firstCdp.off).toHaveBeenCalledWith("event", eventHandler);
+		expect(firstCdp.detach).toHaveBeenCalledTimes(1);
+		expect(secondCdp.on).toHaveBeenCalledWith("event", eventHandler);
+
+		eventHandler({ method: "Page.loadEventFired", params: { timestamp: 1 } });
+		expect(client.send).toHaveBeenCalledWith(
+			JSON.stringify({ method: "Page.loadEventFired", params: { timestamp: 1 } }),
+		);
+
+		client._emit("close");
+		expect(secondCdp.off).toHaveBeenCalledWith("event", eventHandler);
+		await server.detach();
+	});
+
+	it("unbinds connected client handlers before detaching the active CDP session", async () => {
+		const cdp = createCdpSession();
+		const server = new InspectServer({ port: 9222 });
+		await server.attach(createPage(cdp, "https://example.com") as any);
+
+		const connectionHandler = mockWss.on.mock.calls.find((call: any[]) => call[0] === "connection")?.[1];
+		const client = createClient();
+		connectionHandler(client as any);
+		const eventHandler = cdp.on.mock.calls.find((call: any[]) => call[0] === "event")?.[1];
+
+		await server.detach();
+
+		expect(cdp.off).toHaveBeenCalledWith("event", eventHandler);
+		expect(cdp.detach).toHaveBeenCalledTimes(1);
+		expect(client.terminate).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- track each connected DevTools client's CDP event handler
- unbind client handlers from the old CDP session before page reattach
- bind existing clients to the replacement CDP session
- remove active client handlers before server detach

## Why
InspectServer could reattach to a new page while DevTools remained connected, but existing clients stayed subscribed to the old CDP session. They therefore missed browser events from the replacement page, and close cleanup could target the wrong session.

## Verification
Adds regression coverage for live client migration across attach calls, event forwarding from the replacement session, client close cleanup, and detach cleanup.