### PR TITLE
fix: make inspect page reattach atomic

### DIFF
--- a/src/core/inspect/InspectServer.ts
+++ b/src/core/inspect/InspectServer.ts
@@ -89,22 +89,29 @@ export class InspectServer {
 		const detach = this.detachInFlight;
 		if (detach) await detach;
 
-		this.page = page;
 		await this.ensureServerStarted();
 
 		const previousSession = this.cdpSession;
-		this.cdpSession = null;
-		if (previousSession) {
-			this.unbindClientsFromSession(previousSession);
-			await previousSession.detach().catch(() => {}); // NOSONAR — previous page may already be closed
+		const previousPage = this.page;
+		let nextSession: import("playwright-core").CDPSession;
+		try {
+			nextSession = await page.context().newCDPSession(page);
+		} catch {
+			// Preserve a working attachment when a replacement page cannot provide CDP.
+			// On first attach, keep historical behavior and expose the requested page
+			// through /json even though CDP proxying is unavailable.
+			if (!previousSession) this.page = page;
+			else this.page = previousPage;
+			return;
 		}
 
-		try {
-			const nextSession = await page.context().newCDPSession(page);
-			this.cdpSession = nextSession;
-			this.bindClientsToSession(nextSession);
-		} catch {
-			// NOSONAR — CDP session creation may fail in some browsers
+		if (previousSession) this.unbindClientsFromSession(previousSession);
+		this.cdpSession = nextSession;
+		this.page = page;
+		this.bindClientsToSession(nextSession);
+
+		if (previousSession && previousSession !== nextSession) {
+			await previousSession.detach().catch(() => {}); // NOSONAR — previous page may already be closed
 		}
 	}
 

--- a/tests/unit/InspectServerAtomicReattach.test.ts
+++ b/tests/unit/InspectServerAtomicReattach.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockHttpServer, mockWss, mockCreateServer } = vi.hoisted(() => {
+	const mockHttpServer = {
+		listen: vi.fn(),
+		close: vi.fn(),
+		once: vi.fn(),
+		removeListener: vi.fn(),
+	};
+	const mockWss = {
+		on: vi.fn(),
+		close: vi.fn(),
+	};
+	const mockCreateServer = vi.fn(() => mockHttpServer);
+	return { mockHttpServer, mockWss, mockCreateServer };
+});
+
+vi.mock("node:http", () => ({ createServer: mockCreateServer }));
+vi.mock("node:crypto", () => ({ randomUUID: vi.fn(() => "inspect-atomic-id") }));
+vi.mock("ws", () => ({
+	WebSocketServer: vi.fn().mockImplementation(function (this: any) {
+		return mockWss;
+	}),
+	WebSocket: { OPEN: 1 },
+}));
+vi.mock("playwright-core", () => ({}));
+
+import { InspectServer } from "../../src/core/inspect/InspectServer.js";
+
+function createCdpSession() {
+	return {
+		on: vi.fn(),
+		off: vi.fn(),
+		send: vi.fn().mockResolvedValue({}),
+		detach: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+function createPage(url: string, newSession: () => Promise<any>) {
+	return {
+		url: vi.fn(() => url),
+		context: vi.fn(() => ({ newCDPSession: vi.fn(newSession) })),
+	};
+}
+
+function createClient() {
+	return {
+		OPEN: 1,
+		readyState: 1,
+		send: vi.fn(),
+		terminate: vi.fn(),
+		close: vi.fn(),
+		on: vi.fn().mockReturnThis(),
+	};
+}
+
+describe("InspectServer atomic reattach", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockHttpServer.once.mockReturnValue(mockHttpServer);
+		mockHttpServer.removeListener.mockReturnValue(mockHttpServer);
+		mockHttpServer.listen.mockImplementation((_port: number, _host: string, callback: () => void) => {
+			callback();
+			return mockHttpServer;
+		});
+		mockHttpServer.close.mockImplementation((callback?: () => void) => {
+			callback?.();
+			return mockHttpServer;
+		});
+		mockWss.on.mockReturnValue(mockWss);
+		mockWss.close.mockImplementation((callback?: () => void) => callback?.());
+	});
+
+	it("preserves the active session when a replacement session cannot be created", async () => {
+		const firstCdp = createCdpSession();
+		const server = new InspectServer({ port: 9222 });
+		await server.attach(createPage("https://first.example", async () => firstCdp) as any);
+
+		const connectionHandler = mockWss.on.mock.calls.find((call: any[]) => call[0] === "connection")?.[1];
+		const client = createClient();
+		connectionHandler(client as any);
+		const eventHandler = firstCdp.on.mock.calls.find((call: any[]) => call[0] === "event")?.[1];
+		expect(eventHandler).toBeDefined();
+
+		await expect(
+			server.attach(createPage("https://second.example", async () => { throw new Error("session unavailable"); }) as any),
+		).resolves.toBeUndefined();
+
+		expect(firstCdp.off).not.toHaveBeenCalledWith("event", eventHandler);
+		expect(firstCdp.detach).not.toHaveBeenCalled();
+
+		eventHandler({ method: "Page.loadEventFired", params: { timestamp: 1 } });
+		expect(client.send).toHaveBeenCalledTimes(1);
+
+		await server.detach();
+		expect(firstCdp.detach).toHaveBeenCalledTimes(1);
+	});
+});


### PR DESCRIPTION
## Summary
- acquire the replacement page CDP session before disturbing the active one
- preserve the current page/session/client subscriptions when replacement session creation fails
- swap client subscriptions synchronously once the replacement session exists
- detach the previous session only after the new session is active

## Why
InspectServer previously tore down the working CDP session before attempting to create the replacement. A transient `newCDPSession()` failure therefore broke an already-working DevTools connection even though the old page remained usable.

## Verification
Adds regression coverage proving a failed replacement attach keeps the existing CDP session alive, leaves the connected client's event subscription intact, and still cleans up normally on detach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CDP session reattachment reliability.
  - Failed replacement connections no longer interrupt an existing active session.
  - Existing client connections continue receiving events when reattachment fails.
  - Successful replacements now transition cleanly to the new session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->