### PR TITLE
fix: enforce origin boundaries for injected headers

### DIFF
--- a/src/core/OriginHeaders.ts
+++ b/src/core/OriginHeaders.ts
@@ -46,10 +46,16 @@ export class OriginHeaders {
 	}
 
 	getHeadersForUrl(url: string): Record<string, string> {
-		const origins = Array.from(this.config.keys());
-		for (const origin of origins) {
-			if (url.startsWith(origin)) {
-				return { ...this.config.get(origin)! };
+		let requestUrl: URL;
+		try {
+			requestUrl = new URL(url);
+		} catch {
+			return {};
+		}
+
+		for (const [configuredTarget, headers] of this.config) {
+			if (this.matchesTarget(requestUrl, configuredTarget)) {
+				return { ...headers };
 			}
 		}
 		return {};
@@ -81,6 +87,24 @@ export class OriginHeaders {
 
 			await route.continue({ headers: mergedHeaders });
 		};
+	}
+
+	private matchesTarget(requestUrl: URL, configuredTarget: string): boolean {
+		let targetUrl: URL;
+		try {
+			targetUrl = new URL(configuredTarget);
+		} catch {
+			return false;
+		}
+
+		if (requestUrl.origin !== targetUrl.origin) return false;
+
+		const targetPath = targetUrl.pathname;
+		if (targetPath === "/" || targetPath === "") return true;
+		if (requestUrl.pathname === targetPath) return true;
+
+		const pathPrefix = targetPath.endsWith("/") ? targetPath : `${targetPath}/`;
+		return requestUrl.pathname.startsWith(pathPrefix);
 	}
 
 	async dispose(): Promise<void> {

--- a/tests/unit/OriginHeadersBoundary.test.ts
+++ b/tests/unit/OriginHeadersBoundary.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { OriginHeaders } from "../../src/core/OriginHeaders.js";
+
+describe("OriginHeaders security boundaries", () => {
+	it("does not send same-prefix origin headers to a lookalike hostname", () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+
+		expect(headers.getHeadersForUrl("https://api.example.com.attacker.test/collect")).toEqual({});
+		expect(headers.getHeadersForUrl("https://api.example.com/v1/data")).toEqual({
+			Authorization: "Bearer secret",
+		});
+	});
+
+	it("requires protocol and port to match the configured origin", () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { "X-Api-Key": "secret" },
+		});
+
+		expect(headers.getHeadersForUrl("http://api.example.com/v1")).toEqual({});
+		expect(headers.getHeadersForUrl("https://api.example.com:8443/v1")).toEqual({});
+		expect(headers.getHeadersForUrl("https://api.example.com/v1")).toEqual({ "X-Api-Key": "secret" });
+	});
+
+	it("keeps path-scoped rules inside a segment boundary", () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com/v2": { "X-Version": "2" },
+		});
+
+		expect(headers.getHeadersForUrl("https://api.example.com/v2")).toEqual({ "X-Version": "2" });
+		expect(headers.getHeadersForUrl("https://api.example.com/v2/users")).toEqual({ "X-Version": "2" });
+		expect(headers.getHeadersForUrl("https://api.example.com/v20/users")).toEqual({});
+	});
+
+	it("fails closed for malformed request or configured URLs", () => {
+		const malformedConfig = new OriginHeaders({
+			"not a url": { Authorization: "Bearer secret" },
+		});
+		const validConfig = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+
+		expect(malformedConfig.getHeadersForUrl("https://not-a-url.test")).toEqual({});
+		expect(validConfig.getHeadersForUrl("not a request url")).toEqual({});
+	});
+});


### PR DESCRIPTION
## Summary
- parse request/config targets as URLs instead of using raw string prefixes
- require exact scheme + hostname + port origin equality before injecting headers
- preserve path-scoped header rules with segment boundaries
- fail closed for malformed request or configured URLs

## Security impact
The previous `url.startsWith(origin)` check allowed a configuration for `https://api.example.com` to match a lookalike host such as `https://api.example.com.attacker.test`. Authorization tokens, API keys, or other configured headers could therefore be attached to a foreign origin.

## Verification
Adds regression coverage for lookalike hostnames, scheme mismatches, port mismatches, path-boundary behavior, and malformed URLs. Full CI and Docker gates should validate repository-wide compatibility.