### PR TITLE
fix: enforce policy domain boundaries

### DIFF
--- a/src/core/PolicyEngine.ts
+++ b/src/core/PolicyEngine.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import * as yaml from "js-yaml";
+import { isIP } from "node:net";
 import type { ProfileClass } from "../types/index.js";
 import { createLogger } from "./Logger.js";
 
@@ -88,18 +89,17 @@ export class PolicyEngine {
 		const list = this.allowlists[profileClass];
 		if (!list) return false;
 		if (list.includes("*")) return true;
-		return list.some((domain) => url.includes(domain));
+		return list.some((domain) => this.urlMatchesDomain(url, domain));
 	}
 
 	private evaluateYAMLPolicy(profileClass: ProfileClass, url: string, action: string): boolean {
 		const policy = this.yamlPolicies[profileClass];
 		if (!policy) return false;
 
-		const domain = this.extractDomain(url);
 		const matchedRule = policy.rules.find((rule) => {
 			const actionMatch = rule.action === "*" || rule.action === action;
 			const domainMatch =
-				!rule.domains || rule.domains.length === 0 || rule.domains.some((d) => url.includes(d) || domain === d);
+				!rule.domains || rule.domains.length === 0 || rule.domains.some((domain) => this.urlMatchesDomain(url, domain));
 			return actionMatch && domainMatch;
 		});
 
@@ -159,10 +159,39 @@ export class PolicyEngine {
 						return false;
 					}
 				}
-				return false;
 			default:
 				return false;
 		}
+	}
+
+	private urlMatchesDomain(url: string, domainPattern: string): boolean {
+		const pattern = domainPattern.trim().toLowerCase();
+		if (!pattern) return false;
+		if (pattern === "*") return true;
+		if (pattern === "about:blank") return url === "about:blank";
+
+		let requestHost: string;
+		try {
+			requestHost = new URL(url).hostname.toLowerCase();
+		} catch {
+			return false;
+		}
+
+		let allowedHost: string;
+		try {
+			const normalizedPattern = pattern.startsWith("*.") ? pattern.slice(2) : pattern;
+			const candidate = /^[a-z][a-z\d+.-]*:\/\//i.test(normalizedPattern)
+				? normalizedPattern
+				: `http://${normalizedPattern}`;
+			allowedHost = new URL(candidate).hostname.toLowerCase();
+		} catch {
+			return false;
+		}
+
+		if (!allowedHost) return false;
+		if (requestHost === allowedHost) return true;
+		if (isIP(allowedHost)) return false;
+		return requestHost.endsWith(`.${allowedHost}`);
 	}
 
 	private extractDomain(url: string): string {

--- a/tests/unit/PolicyEngineDomainBoundary.test.ts
+++ b/tests/unit/PolicyEngineDomainBoundary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { PolicyEngine } from "../../src/core/PolicyEngine.js";
+
+describe("PolicyEngine domain boundaries", () => {
+	it("rejects lookalike, userinfo, and query-string bypasses for the default ops allowlist", () => {
+		const engine = new PolicyEngine();
+
+		expect(engine.isAllowed("ops", "https://github.com/org/repo")).toBe(true);
+		expect(engine.isAllowed("ops", "https://api.github.com/repos/org/repo")).toBe(true);
+		expect(engine.isAllowed("ops", "https://github.com.attacker.test/org/repo")).toBe(false);
+		expect(engine.isAllowed("ops", "https://github.com@attacker.test/org/repo")).toBe(false);
+		expect(engine.isAllowed("ops", "https://attacker.test/?next=github.com")).toBe(false);
+	});
+
+	it("keeps about:blank and localhost behavior without substring matching", () => {
+		const engine = new PolicyEngine();
+
+		expect(engine.isAllowed("ops", "about:blank")).toBe(true);
+		expect(engine.isAllowed("ops", "http://localhost:3000/app")).toBe(true);
+		expect(engine.isAllowed("ops", "https://notlocalhost.test/?q=localhost")).toBe(false);
+	});
+
+	it("applies the same hostname boundaries to YAML domain rules", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("qa", {
+			defaultEffect: "deny",
+			rules: [{ action: "navigate", effect: "allow", domains: ["trusted.example"] }],
+		});
+
+		expect(engine.isAllowed("qa", "https://trusted.example/page")).toBe(true);
+		expect(engine.isAllowed("qa", "https://api.trusted.example/page")).toBe(true);
+		expect(engine.isAllowed("qa", "https://trusted.example.attacker.test/page")).toBe(false);
+		expect(engine.isAllowed("qa", "https://attacker.test/?next=trusted.example")).toBe(false);
+	});
+
+	it("supports URL-shaped and wildcard-subdomain YAML domain patterns safely", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("qa", {
+			defaultEffect: "deny",
+			rules: [
+				{ action: "navigate", effect: "allow", domains: ["https://safe.example", "*.service.example"] },
+			],
+		});
+
+		expect(engine.isAllowed("qa", "https://safe.example/path")).toBe(true);
+		expect(engine.isAllowed("qa", "https://sub.service.example/path")).toBe(true);
+		expect(engine.isAllowed("qa", "https://safe.example.attacker.test/path")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- replace raw URL substring checks in the built-in ops allowlist with parsed hostname matching
- apply the same domain-boundary matcher to YAML policy `domains`
- preserve legitimate subdomains, localhost, URL-shaped policy entries, and wildcard-subdomain entries
- keep IP allowlists exact instead of treating them as suffix domains

## Security impact
The previous `url.includes(domain)` logic allowed navigation-policy bypasses such as `https://github.com.attacker.test`, `https://github.com@attacker.test`, or `https://attacker.test/?next=github.com`. YAML domain rules had the same issue.

## Verification
Adds regression coverage for lookalike hostnames, URL userinfo tricks, query-string tricks, legitimate subdomains, localhost/about:blank behavior, and YAML domain rules.