### PR TITLE
fix: let unmatched policy conditions fall through

### DIFF
--- a/src/core/PolicyEngine.ts
+++ b/src/core/PolicyEngine.ts
@@ -96,21 +96,19 @@ export class PolicyEngine {
 		const policy = this.yamlPolicies[profileClass];
 		if (!policy) return false;
 
-		const matchedRule = policy.rules.find((rule) => {
+		for (const rule of policy.rules) {
 			const actionMatch = rule.action === "*" || rule.action === action;
+			if (!actionMatch) continue;
+
 			const domainMatch =
 				!rule.domains || rule.domains.length === 0 || rule.domains.some((domain) => this.urlMatchesDomain(url, domain));
-			return actionMatch && domainMatch;
-		});
+			if (!domainMatch) continue;
 
-		if (matchedRule) {
-			if (matchedRule.conditions) {
-				const conditionsMet = matchedRule.conditions.every((condition) =>
-					this.evaluateCondition(condition, url, action),
-				);
-				return matchedRule.effect === "allow" ? conditionsMet : !conditionsMet;
-			}
-			return matchedRule.effect === "allow";
+			const conditionsMet =
+				!rule.conditions || rule.conditions.every((condition) => this.evaluateCondition(condition, url, action));
+			if (!conditionsMet) continue;
+
+			return rule.effect === "allow";
 		}
 
 		return policy.defaultEffect === "allow";

--- a/tests/unit/PolicyEngineConditionFallthrough.test.ts
+++ b/tests/unit/PolicyEngineConditionFallthrough.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { PolicyEngine } from "../../src/core/PolicyEngine.js";
+
+describe("PolicyEngine conditional rule fallthrough", () => {
+	it("does not turn an unmatched deny rule into allow under a deny-by-default policy", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("ops", {
+			defaultEffect: "deny",
+			rules: [
+				{
+					action: "purchase",
+					effect: "deny",
+					conditions: [{ field: "amount", operator: ">", value: 100 }],
+				},
+			],
+		});
+
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 50 })).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 500 })).toBe(false);
+	});
+
+	it("falls through an unmet allow rule to the policy default", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("qa", {
+			defaultEffect: "allow",
+			rules: [
+				{
+					action: "navigate",
+					effect: "allow",
+					conditions: [{ field: "url", operator: "contains", value: "/admin" }],
+				},
+			],
+		});
+
+		expect(engine.isAllowed("qa", "https://example.com/public")).toBe(true);
+	});
+
+	it("continues to later rules when an earlier rule's conditions do not match", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("ops", {
+			defaultEffect: "deny",
+			rules: [
+				{
+					action: "transfer",
+					effect: "allow",
+					conditions: [{ field: "amount", operator: "<=", value: 100 }],
+				},
+				{
+					action: "transfer",
+					effect: "allow",
+					conditions: [{ field: "amount", operator: ">=", value: 500 }],
+				},
+			],
+		});
+
+		expect(engine.isActionAllowed("ops", "transfer", { amount: 50 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "transfer", { amount: 600 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "transfer", { amount: 250 })).toBe(false);
+	});
+
+	it("still applies a conditional deny rule when its conditions match", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("qa", {
+			defaultEffect: "allow",
+			rules: [
+				{
+					action: "navigate",
+					effect: "deny",
+					conditions: [{ field: "url", operator: "contains", value: "/blocked" }],
+				},
+			],
+		});
+
+		expect(engine.isAllowed("qa", "https://example.com/blocked")).toBe(false);
+		expect(engine.isAllowed("qa", "https://example.com/allowed")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- treat unmet policy conditions as a non-matching rule instead of flipping the rule effect
- continue evaluating later rules after an unmet condition
- use `defaultEffect` only when no complete rule matches

## Impact
A conditional `deny` rule currently returns `allow` when its condition is false. Under `defaultEffect: deny`, that can grant an action solely because a deny condition did not apply. Conditional `allow` rules also stop later rules prematurely.

## Verification
Adds regression coverage for deny-by-default policies, allow-by-default fallthrough, later matching rules, and conditional deny rules that do match.