### PR TITLE
fix: make origin header installation lifecycle-safe

### DIFF
--- a/src/core/OriginHeaders.ts
+++ b/src/core/OriginHeaders.ts
@@ -12,6 +12,8 @@ export interface OriginHeaderConfig {
 	[origin: string]: Record<string, string>;
 }
 
+type RouteHandler = (route: Route) => Promise<void>;
+
 /**
  * Manages per-origin HTTP headers and installs request interception on a Playwright page.
  *
@@ -20,14 +22,15 @@ export interface OriginHeaderConfig {
  * const headers = new OriginHeaders({
  *   'https://api.example.com': { 'Authorization': 'Bearer token123' },
  * });
- * headers.install(page);
+ * await headers.install(page);
  * // All requests to https://api.example.com now include the Authorization header.
  * ```
  */
 export class OriginHeaders {
 	private readonly config: Map<string, Record<string, string>> = new Map();
 	private installedPage: Page | null = null;
-	private routeHandler: ((route: Route) => Promise<void>) | null = null;
+	private routeHandler: RouteHandler | null = null;
+	private rollbackRoutes: Array<{ page: Page; handler: RouteHandler }> = [];
 
 	constructor(config?: OriginHeaderConfig) {
 		if (config) {
@@ -61,14 +64,34 @@ export class OriginHeaders {
 		return {};
 	}
 
-	install(page: Page): void {
-		this.installedPage = page;
-		this.routeHandler = this.createRouteHandler();
+	async install(page: Page): Promise<void> {
+		if (this.installedPage === page && this.routeHandler) return;
 
-		void page.route("**/*", this.routeHandler);
+		const nextHandler = this.createRouteHandler();
+		const routePromise = page.route("**/*", nextHandler);
+		if (routePromise) await routePromise;
+
+		const previousPage = this.installedPage;
+		const previousHandler = this.routeHandler;
+		if (previousPage && previousHandler) {
+			try {
+				await previousPage.unroute("**/*", previousHandler);
+			} catch (error) {
+				try {
+					await page.unroute("**/*", nextHandler);
+				} catch {
+					// Preserve ownership so dispose() can retry removing the rollback route.
+					this.rollbackRoutes.push({ page, handler: nextHandler });
+				}
+				throw error;
+			}
+		}
+
+		this.installedPage = page;
+		this.routeHandler = nextHandler;
 	}
 
-	private createRouteHandler(): (route: Route) => Promise<void> {
+	private createRouteHandler(): RouteHandler {
 		return async (route: Route) => {
 			const request = route.request();
 			const url = request.url();
@@ -117,6 +140,17 @@ export class OriginHeaders {
 			this.installedPage = null;
 			this.routeHandler = null;
 		}
+
+		const rollbackRoutes = this.rollbackRoutes;
+		this.rollbackRoutes = [];
+		for (const { page, handler } of rollbackRoutes) {
+			try {
+				await page.unroute("**/*", handler);
+			} catch {
+				// NOSONAR — page may already be closed
+			}
+		}
+
 		this.config.clear();
 	}
 }

--- a/src/core/controller/TaloxController.ts
+++ b/src/core/controller/TaloxController.ts
@@ -297,7 +297,7 @@ export class TaloxController {
 				throw new Error(`Takeover initialization failed: ${error instanceof Error ? error.message : String(error)}`);
 			}
 
-			this.setupOriginHeaders(page);
+			await this.setupOriginHeaders(page);
 			this.setupHarRecording(page);
 			this.setupCrossOriginManager(page);
 			await this.setupInspectServer(page);
@@ -315,10 +315,11 @@ export class TaloxController {
 	}
 
 	/** Install per-origin headers if configured. */
-	private setupOriginHeaders(page: import("playwright-core").Page): void {
+	private async setupOriginHeaders(page: import("playwright-core").Page): Promise<void> {
 		if (!this.originHeaderConfig) return;
-		this.originHeaders = new OriginHeaders(this.originHeaderConfig);
-		this.originHeaders.install(page);
+		const headers = new OriginHeaders(this.originHeaderConfig);
+		this.originHeaders = headers;
+		await headers.install(page);
 	}
 
 	/** Start HAR recording if configured. */

--- a/tests/unit/OriginHeadersInstallLifecycle.test.ts
+++ b/tests/unit/OriginHeadersInstallLifecycle.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { OriginHeaders } from "../../src/core/OriginHeaders.js";
+
+function createPage() {
+	return {
+		route: vi.fn().mockResolvedValue(undefined),
+		unroute: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe("OriginHeaders install lifecycle", () => {
+	it("waits for Playwright route registration before resolving install", async () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+		const page = createPage();
+		let releaseRegistration!: () => void;
+		const registration = new Promise<void>((resolve) => {
+			releaseRegistration = resolve;
+		});
+		page.route.mockReturnValue(registration);
+
+		let settled = false;
+		const installing = headers.install(page as any).then(() => {
+			settled = true;
+		});
+
+		await Promise.resolve();
+		expect(settled).toBe(false);
+
+		releaseRegistration();
+		await installing;
+		expect(settled).toBe(true);
+		await headers.dispose();
+	});
+
+	it("rejects a failed route installation without claiming ownership", async () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+		const page = createPage();
+		const failure = new Error("route install failed");
+		page.route.mockRejectedValue(failure);
+
+		await expect(headers.install(page as any)).rejects.toBe(failure);
+		await headers.dispose();
+
+		expect(page.unroute).not.toHaveBeenCalled();
+	});
+
+	it("does not install duplicate handlers on the same page", async () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+		const page = createPage();
+
+		await headers.install(page as any);
+		await headers.install(page as any);
+
+		expect(page.route).toHaveBeenCalledTimes(1);
+		await headers.dispose();
+		expect(page.unroute).toHaveBeenCalledTimes(1);
+	});
+
+	it("keeps the current page installed when replacement route acquisition fails", async () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+		const currentPage = createPage();
+		const replacementPage = createPage();
+		replacementPage.route.mockRejectedValue(new Error("replacement unavailable"));
+
+		await headers.install(currentPage as any);
+		await expect(headers.install(replacementPage as any)).rejects.toThrow("replacement unavailable");
+		await headers.dispose();
+
+		expect(currentPage.unroute).toHaveBeenCalledTimes(1);
+		expect(replacementPage.unroute).not.toHaveBeenCalled();
+	});
+
+	it("rolls back the replacement route if old-page cleanup fails", async () => {
+		const headers = new OriginHeaders({
+			"https://api.example.com": { Authorization: "Bearer secret" },
+		});
+		const currentPage = createPage();
+		const replacementPage = createPage();
+		currentPage.unroute.mockRejectedValueOnce(new Error("old route cleanup failed")).mockResolvedValue(undefined);
+
+		await headers.install(currentPage as any);
+		await expect(headers.install(replacementPage as any)).rejects.toThrow("old route cleanup failed");
+
+		expect(replacementPage.unroute).toHaveBeenCalledTimes(1);
+
+		await headers.dispose();
+		expect(currentPage.unroute).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
## Summary
- make `OriginHeaders.install()` await Playwright route registration
- preserve the currently working route when replacement route acquisition fails
- avoid duplicate handlers when installing repeatedly on the same page
- roll back a newly acquired replacement route if old-page cleanup fails
- retain failed rollback ownership so `dispose()` can retry cleanup

## Impact
`page.route()` is asynchronous. The previous implementation discarded that promise and marked the page/handler as installed immediately, so route registration failures could be invisible and lifecycle state could claim ownership that never existed.

## Verification
Adds regression coverage for rejected route installs, same-page idempotence, failed replacement acquisition, and rollback when old-page cleanup fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation reliability when setting up page routes.
  * Prevented duplicate installations on the same page.
  * Added safer rollback and cleanup when installation or page replacement fails.
  * Ensured failed setup state is cleaned up during disposal.

* **Tests**
  * Added coverage for duplicate installations, failed setup, page replacement failures, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->