### PR TITLE
fix: harden practical site search generation

### DIFF
--- a/src/tools/practical-tools.ts
+++ b/src/tools/practical-tools.ts
@@ -100,7 +100,7 @@ export async function searchOnSite(talox: TaloxController, query: string, limit:
           const selector =
             el.tagName.toLowerCase()
             + (el.id ? '#' + el.id : '')
-            + (el.className ? '.' + el.className.toString().trim().split(/\s+/).filter(Boolean).join('.') : '');
+            + (el.className ? '.' + el.className.toString().trim().split(/\\s+/).filter(Boolean).join('.') : '');
           matches.push({
             selector,
             snippet: snippet.slice(0, 160),

--- a/src/tools/practical-tools.ts
+++ b/src/tools/practical-tools.ts
@@ -87,6 +87,7 @@ export async function exportMarkdownSnapshot(talox: TaloxController, destPath: s
 }
 
 export async function searchOnSite(talox: TaloxController, query: string, limit: number = 5): Promise<SearchResult[]> {
+	const safeLimit = Number.isFinite(limit) ? Math.max(1, Math.min(100, Math.floor(limit))) : 5;
 	const results = await talox.evaluate<SearchResult[]>(`( () => {
       const matches: Array<{ selector: string; snippet: string; tag: string }> = [];
       const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT, { acceptNode: () => NodeFilter.FILTER_ACCEPT }, false);
@@ -99,16 +100,16 @@ export async function searchOnSite(talox: TaloxController, query: string, limit:
           const selector =
             el.tagName.toLowerCase()
             + (el.id ? '#' + el.id : '')
-            + (el.className ? '.' + el.className.toString().split(/s+/).join('.') : '');
+            + (el.className ? '.' + el.className.toString().trim().split(/\s+/).filter(Boolean).join('.') : '');
           matches.push({
             selector,
             snippet: snippet.slice(0, 160),
             tag: el.tagName.toLowerCase(),
           });
-          if (matches.length >= ${limit}) break;
+          if (matches.length >= ${safeLimit}) break;
         }
       }
-      return matches.slice(0, ${limit});
+      return matches.slice(0, ${safeLimit});
     })();`);
 	return results;
 }

--- a/tests/unit/practical-tools-search-hardening.test.ts
+++ b/tests/unit/practical-tools-search-hardening.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { searchOnSite } from "../../src/tools/practical-tools.js";
+
+function makeTaloxMock() {
+	return {
+		evaluate: vi.fn().mockResolvedValue([]),
+	};
+}
+
+describe("searchOnSite hardening", () => {
+	it("preserves the whitespace regex in generated browser code", async () => {
+		const talox = makeTaloxMock();
+
+		await searchOnSite(talox as any, "hello");
+
+		const evalArg = talox.evaluate.mock.calls[0]![0] as string;
+		expect(evalArg).toContain("split(/\\s+/)");
+		expect(evalArg).not.toContain("split(/s+/)");
+	});
+
+	it("clamps non-positive and oversized limits before interpolation", async () => {
+		const low = makeTaloxMock();
+		await searchOnSite(low as any, "hello", -20);
+		const lowScript = low.evaluate.mock.calls[0]![0] as string;
+		expect(lowScript).toContain("matches.length >= 1");
+		expect(lowScript).toContain("matches.slice(0, 1)");
+
+		const high = makeTaloxMock();
+		await searchOnSite(high as any, "hello", 500);
+		const highScript = high.evaluate.mock.calls[0]![0] as string;
+		expect(highScript).toContain("matches.length >= 100");
+		expect(highScript).toContain("matches.slice(0, 100)");
+	});
+
+	it("falls back safely for non-finite or runtime-invalid limit values", async () => {
+		const infinite = makeTaloxMock();
+		await searchOnSite(infinite as any, "hello", Number.POSITIVE_INFINITY);
+		const infiniteScript = infinite.evaluate.mock.calls[0]![0] as string;
+		expect(infiniteScript).toContain("matches.length >= 5");
+		expect(infiniteScript).not.toContain("Infinity");
+
+		const injected = makeTaloxMock();
+		await searchOnSite(injected as any, "hello", "1); globalThis.__taloxInjected = true; //" as any);
+		const injectedScript = injected.evaluate.mock.calls[0]![0] as string;
+		expect(injectedScript).toContain("matches.length >= 5");
+		expect(injectedScript).not.toContain("__taloxInjected");
+	});
+});


### PR DESCRIPTION
## Summary
- preserve the intended whitespace regex inside the generated browser-side search script
- trim/filter class tokens before building CSS-like selectors
- clamp search limits to a finite integer range of 1–100 before interpolation
- fall back to 5 for runtime-invalid/non-finite limits
- add regression coverage for regex generation, bounds, and hostile runtime values

## Impact
The existing template literal contained `/\s+/` as source text, which JavaScript consumed while constructing the generated script and effectively emitted `/s+/`. Multi-class values such as `"hero active"` therefore kept whitespace instead of becoming `.hero.active`.

The raw `limit` value was also interpolated directly into executable browser code. TypeScript callers normally pass a number, but runtime-invalid values could produce malformed code or, via an `as any`/untyped boundary, inject source text into the evaluated script.

## Verification
Regression tests assert against the actual string passed to `talox.evaluate()`, including the emitted `/\s+/` regex and sanitized limits. Full CI/Docker remain the merge gates.