### PR TITLE
fix: keep policy amount context scoped

### DIFF
--- a/src/core/PolicyEngine.ts
+++ b/src/core/PolicyEngine.ts
@@ -49,7 +49,7 @@ export class PolicyEngine {
 	};
 
 	private yamlLoaded = false;
-	private _currentAmount = 0;
+	private _currentAmount: number | null = null;
 
 	async loadPolicyFromYAML(filePath: string): Promise<void> {
 		try {
@@ -104,6 +104,9 @@ export class PolicyEngine {
 				!rule.domains || rule.domains.length === 0 || rule.domains.some((domain) => this.urlMatchesDomain(url, domain));
 			if (!domainMatch) continue;
 
+			const requiresAmount = rule.conditions?.some((condition) => condition.field === "amount") ?? false;
+			if (requiresAmount && this._currentAmount === null) return false;
+
 			const conditionsMet =
 				!rule.conditions || rule.conditions.every((condition) => this.evaluateCondition(condition, url, action));
 			if (!conditionsMet) continue;
@@ -127,9 +130,12 @@ export class PolicyEngine {
 			case "action":
 				fieldValue = action;
 				break;
-			case "amount":
-				fieldValue = this.extractAmountFromContext();
+			case "amount": {
+				const amount = this.extractAmountFromContext();
+				if (amount === null) return false;
+				fieldValue = amount;
 				break;
+			}
 			default:
 				return false;
 		}
@@ -201,7 +207,7 @@ export class PolicyEngine {
 		}
 	}
 
-	private extractAmountFromContext(): number {
+	private extractAmountFromContext(): number | null {
 		return this._currentAmount;
 	}
 
@@ -233,10 +239,14 @@ export class PolicyEngine {
 
 	isActionAllowed(profileClass: ProfileClass, action: string, context?: Record<string, any>): boolean {
 		if (this.yamlLoaded && this.yamlPolicies[profileClass]) {
-			if (context?.amount !== undefined) {
-				this._currentAmount = context.amount;
+			const hasScopedAmount = context?.amount !== undefined;
+			const previousAmount = this._currentAmount;
+			if (hasScopedAmount) this._currentAmount = context.amount;
+			try {
+				return this.evaluateYAMLPolicy(profileClass, context?.url || "", action);
+			} finally {
+				if (hasScopedAmount) this._currentAmount = previousAmount;
 			}
-			return this.evaluateYAMLPolicy(profileClass, context?.url || "", action);
 		}
 
 		if (profileClass === "ops" && this.isDestructiveAction(action)) {

--- a/src/core/PolicyEngine.ts
+++ b/src/core/PolicyEngine.ts
@@ -268,5 +268,6 @@ export class PolicyEngine {
 			this.yamlPolicies[key] = null;
 		}
 		this.yamlLoaded = false;
+		this._currentAmount = null;
 	}
 }

--- a/tests/unit/PolicyEngineAmountScope.test.ts
+++ b/tests/unit/PolicyEngineAmountScope.test.ts
@@ -66,4 +66,16 @@ describe("PolicyEngine scoped amount context", () => {
 		expect(engine.isActionAllowed("ops", "purchase", { amount: 500 })).toBe(false);
 		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
 	});
+
+	it("clears persistent amount context when policies are reset", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(50);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+
+		engine.clearPolicies();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
 });

--- a/tests/unit/PolicyEngineAmountScope.test.ts
+++ b/tests/unit/PolicyEngineAmountScope.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { PolicyEngine } from "../../src/core/PolicyEngine.js";
+
+function configurePurchaseLimit(engine: PolicyEngine): void {
+	engine.setPolicyForProfile("ops", {
+		defaultEffect: "deny",
+		rules: [
+			{
+				action: "purchase",
+				effect: "allow",
+				conditions: [{ field: "amount", operator: "<=", value: 100 }],
+			},
+		],
+	});
+}
+
+describe("PolicyEngine scoped amount context", () => {
+	it("does not let a previous per-action amount leak into the next action", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 50 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("fails closed when an amount condition has no amount context", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("denies missing amount even when the policy default is allow", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("ops", {
+			defaultEffect: "allow",
+			rules: [
+				{
+					action: "purchase",
+					effect: "deny",
+					conditions: [{ field: "amount", operator: ">=", value: 0 }],
+				},
+			],
+		});
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 25 })).toBe(false);
+	});
+
+	it("restores an explicit persistent amount after a scoped override", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(500);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 50 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("restores an explicitly allowed amount after a denied scoped override", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(50);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 500 })).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- make per-action `context.amount` temporary instead of mutating persistent policy state
- restore an explicit `setAmountContext()` value after each scoped override
- treat amount conditions without any amount context as non-matching instead of assuming zero

## Security impact
A low amount supplied to one action previously leaked into later checks. A subsequent action with no amount could therefore inherit that stale value and satisfy an `amount <= limit` allow rule. With no prior amount at all, the implicit zero default had the same fail-open behavior.

## Verification
Adds regression coverage for stale per-action amount leakage, missing amount context, and restoration of persistent amount context after both allowed and denied scoped overrides.

This supersedes #107, whose original Actions runs were stuck from the earlier runner outage. The change has been rebuilt as one commit directly on the current `main` so CI evaluates the actual merge candidate.