### PR TITLE
fix: keep policy amount context scoped

### DIFF
--- a/src/core/PolicyEngine.ts
+++ b/src/core/PolicyEngine.ts
@@ -49,7 +49,7 @@ export class PolicyEngine {
 	};
 
 	private yamlLoaded = false;
-	private _currentAmount = 0;
+	private _currentAmount: number | null = null;
 
 	async loadPolicyFromYAML(filePath: string): Promise<void> {
 		try {
@@ -104,6 +104,9 @@ export class PolicyEngine {
 				!rule.domains || rule.domains.length === 0 || rule.domains.some((domain) => this.urlMatchesDomain(url, domain));
 			if (!domainMatch) continue;
 
+			const requiresAmount = rule.conditions?.some((condition) => condition.field === "amount") ?? false;
+			if (requiresAmount && this._currentAmount === null) return false;
+
 			const conditionsMet =
 				!rule.conditions || rule.conditions.every((condition) => this.evaluateCondition(condition, url, action));
 			if (!conditionsMet) continue;
@@ -127,9 +130,12 @@ export class PolicyEngine {
 			case "action":
 				fieldValue = action;
 				break;
-			case "amount":
-				fieldValue = this.extractAmountFromContext();
+			case "amount": {
+				const amount = this.extractAmountFromContext();
+				if (amount === null) return false;
+				fieldValue = amount;
 				break;
+			}
 			default:
 				return false;
 		}
@@ -201,7 +207,7 @@ export class PolicyEngine {
 		}
 	}
 
-	private extractAmountFromContext(): number {
+	private extractAmountFromContext(): number | null {
 		return this._currentAmount;
 	}
 
@@ -233,10 +239,14 @@ export class PolicyEngine {
 
 	isActionAllowed(profileClass: ProfileClass, action: string, context?: Record<string, any>): boolean {
 		if (this.yamlLoaded && this.yamlPolicies[profileClass]) {
-			if (context?.amount !== undefined) {
-				this._currentAmount = context.amount;
+			const hasScopedAmount = context?.amount !== undefined;
+			const previousAmount = this._currentAmount;
+			if (hasScopedAmount) this._currentAmount = context.amount;
+			try {
+				return this.evaluateYAMLPolicy(profileClass, context?.url || "", action);
+			} finally {
+				if (hasScopedAmount) this._currentAmount = previousAmount;
 			}
-			return this.evaluateYAMLPolicy(profileClass, context?.url || "", action);
 		}
 
 		if (profileClass === "ops" && this.isDestructiveAction(action)) {
@@ -258,5 +268,6 @@ export class PolicyEngine {
 			this.yamlPolicies[key] = null;
 		}
 		this.yamlLoaded = false;
+		this._currentAmount = null;
 	}
 }

--- a/tests/unit/PolicyEngineAmountScope.test.ts
+++ b/tests/unit/PolicyEngineAmountScope.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { PolicyEngine } from "../../src/core/PolicyEngine.js";
+
+function configurePurchaseLimit(engine: PolicyEngine): void {
+	engine.setPolicyForProfile("ops", {
+		defaultEffect: "deny",
+		rules: [
+			{
+				action: "purchase",
+				effect: "allow",
+				conditions: [{ field: "amount", operator: "<=", value: 100 }],
+			},
+		],
+	});
+}
+
+describe("PolicyEngine scoped amount context", () => {
+	it("does not let a previous per-action amount leak into the next action", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 50 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("fails closed when an amount condition has no amount context", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("denies missing amount even when the policy default is allow", () => {
+		const engine = new PolicyEngine();
+		engine.setPolicyForProfile("ops", {
+			defaultEffect: "allow",
+			rules: [
+				{
+					action: "purchase",
+					effect: "deny",
+					conditions: [{ field: "amount", operator: ">=", value: 0 }],
+				},
+			],
+		});
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 25 })).toBe(false);
+	});
+
+	it("restores an explicit persistent amount after a scoped override", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(500);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 50 })).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+
+	it("restores an explicitly allowed amount after a denied scoped override", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(50);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+		expect(engine.isActionAllowed("ops", "purchase", { amount: 500 })).toBe(false);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+	});
+
+	it("clears persistent amount context when policies are reset", () => {
+		const engine = new PolicyEngine();
+		configurePurchaseLimit(engine);
+		engine.setAmountContext(50);
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(true);
+
+		engine.clearPolicies();
+		configurePurchaseLimit(engine);
+
+		expect(engine.isActionAllowed("ops", "purchase")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- make per-action `context.amount` temporary instead of mutating persistent policy state
- restore an explicit `setAmountContext()` value after each scoped override
- fail closed when amount-conditioned rules have no amount context
- clear persistent amount state when policies are reset

## Security impact
A low amount supplied to one action previously leaked into later checks. A subsequent action with no amount could inherit that stale value and satisfy an `amount <= limit` allow rule. The implicit zero default had the same fail-open behavior.

Persistent `setAmountContext()` state also survived `clearPolicies()`, so clearing and later reconfiguring policies could resurrect an amount from the previous policy lifecycle.

## Verification
Regression coverage includes stale per-action amount leakage, missing amount context, restoration of explicit persistent context after scoped overrides, and clearing amount state across policy resets.

This final PR supersedes #107 and #110. It is a single commit directly on the current `main` so CI evaluates the exact merge candidate.