### PR TITLE
security: block credential-bearing request headers

### DIFF
--- a/src/core/CredentialLeakGuard.ts
+++ b/src/core/CredentialLeakGuard.ts
@@ -20,6 +20,8 @@ const EXPLICIT_SENSITIVE_HEADERS = new Set([
 	"proxy-authorization",
 	"x-api-key",
 	"api-key",
+	"x-api-token",
+	"api-token",
 	"x-auth-token",
 	"x-access-token",
 	"access-token",
@@ -27,9 +29,9 @@ const EXPLICIT_SENSITIVE_HEADERS = new Set([
 	"x-goog-api-key",
 ]);
 
-const SENSITIVE_HEADER_NAME = /^(?:x[-_])?(?:api[-_]?key|auth[-_]?token|access[-_]?token|secret[-_]?key)$/i;
+const SENSITIVE_HEADER_NAME = /^(?:x[-_])?(?:api[-_]?(?:key|token)|auth[-_]?token|access[-_]?token|secret[-_]?key)$/i;
 const JWT_VALUE = /eyJ[\w-]{10,}\.[\w-]{10,}/i;
-const LABELED_SECRET_VALUE = /(?:api[_-]?key|secret|token|password|bearer)\s*[:=]\s*['"]?[\w-]{8,}/i;
+const LABELED_SECRET_VALUE = /["']?(?:api[_-]?key|api[_-]?token|secret|token|password|authorization)["']?\s*[:=]\s*["']?(?:bearer\s+|basic\s+)?[\w.+/=-]{8,}/i;
 const AUTH_SCHEME_VALUE = /^\s*(?:bearer|basic)\s+\S{8,}/i;
 
 function textContainsCredential(text: string): boolean {
@@ -39,6 +41,16 @@ function textContainsCredential(text: string): boolean {
 function sensitiveHeaderName(name: string): boolean {
 	const normalized = name.trim().toLowerCase();
 	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
+}
+
+/** Return a destination safe for security logs without query, path, or user-info secrets. */
+export function credentialSafeDestination(url: string): string {
+	try {
+		const parsed = new URL(url);
+		return parsed.origin === "null" ? parsed.protocol : parsed.origin;
+	} catch {
+		return "<invalid-url>";
+	}
 }
 
 /**

--- a/src/core/CredentialLeakGuard.ts
+++ b/src/core/CredentialLeakGuard.ts
@@ -5,6 +5,8 @@ export interface CredentialLeakCheckInput {
 	url: string;
 	headers?: Record<string, string>;
 	postData?: string | null;
+	/** Exact header name/value pairs explicitly configured by Talox for this destination. */
+	trustedHeaders?: Record<string, string>;
 }
 
 export interface CredentialLeakDetection {
@@ -43,23 +45,37 @@ function sensitiveHeaderName(name: string): boolean {
 	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
 }
 
+function normalizeHeaders(headers?: Record<string, string>): Map<string, string> {
+	const normalized = new Map<string, string>();
+	for (const [name, value] of Object.entries(headers ?? {})) {
+		normalized.set(name.trim().toLowerCase(), String(value));
+	}
+	return normalized;
+}
+
 /**
  * Detect likely credential exfiltration without returning or logging secret values.
  *
  * Explicit authentication/token headers are treated as credentials whenever they
- * contain a non-empty value. Other header values are inspected only for strong
- * credential shapes so benign application headers are not blocked wholesale.
+ * contain a non-empty value, unless that exact header name/value pair was explicitly
+ * configured by Talox for the current destination. Other header values are inspected
+ * only for strong credential shapes so benign application headers are not blocked wholesale.
  */
 export function detectCredentialLeak(input: CredentialLeakCheckInput): CredentialLeakDetection {
+	const trustedHeaders = normalizeHeaders(input.trustedHeaders);
+
 	for (const [name, rawValue] of Object.entries(input.headers ?? {})) {
 		const value = String(rawValue ?? "");
 		if (!value.trim()) continue;
+
+		const normalizedName = name.trim().toLowerCase();
+		if (trustedHeaders.get(normalizedName) === value) continue;
 
 		if (sensitiveHeaderName(name) || AUTH_SCHEME_VALUE.test(value) || textContainsCredential(`${name}: ${value}`)) {
 			return {
 				blocked: true,
 				source: "header",
-				headerName: name.toLowerCase(),
+				headerName: normalizedName,
 			};
 		}
 	}

--- a/src/core/CredentialLeakGuard.ts
+++ b/src/core/CredentialLeakGuard.ts
@@ -43,16 +43,6 @@ function sensitiveHeaderName(name: string): boolean {
 	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
 }
 
-/** Return a destination safe for security logs without query, path, or user-info secrets. */
-export function credentialSafeDestination(url: string): string {
-	try {
-		const parsed = new URL(url);
-		return parsed.origin === "null" ? parsed.protocol : parsed.origin;
-	} catch {
-		return "<invalid-url>";
-	}
-}
-
 /**
  * Detect likely credential exfiltration without returning or logging secret values.
  *

--- a/src/core/CredentialLeakGuard.ts
+++ b/src/core/CredentialLeakGuard.ts
@@ -5,8 +5,6 @@ export interface CredentialLeakCheckInput {
 	url: string;
 	headers?: Record<string, string>;
 	postData?: string | null;
-	/** Exact header name/value pairs explicitly configured by Talox for this destination. */
-	trustedHeaders?: Record<string, string>;
 }
 
 export interface CredentialLeakDetection {
@@ -45,37 +43,23 @@ function sensitiveHeaderName(name: string): boolean {
 	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
 }
 
-function normalizeHeaders(headers?: Record<string, string>): Map<string, string> {
-	const normalized = new Map<string, string>();
-	for (const [name, value] of Object.entries(headers ?? {})) {
-		normalized.set(name.trim().toLowerCase(), String(value));
-	}
-	return normalized;
-}
-
 /**
  * Detect likely credential exfiltration without returning or logging secret values.
  *
  * Explicit authentication/token headers are treated as credentials whenever they
- * contain a non-empty value, unless that exact header name/value pair was explicitly
- * configured by Talox for the current destination. Other header values are inspected
- * only for strong credential shapes so benign application headers are not blocked wholesale.
+ * contain a non-empty value. Other header values are inspected only for strong
+ * credential shapes so benign application headers are not blocked wholesale.
  */
 export function detectCredentialLeak(input: CredentialLeakCheckInput): CredentialLeakDetection {
-	const trustedHeaders = normalizeHeaders(input.trustedHeaders);
-
 	for (const [name, rawValue] of Object.entries(input.headers ?? {})) {
 		const value = String(rawValue ?? "");
 		if (!value.trim()) continue;
-
-		const normalizedName = name.trim().toLowerCase();
-		if (trustedHeaders.get(normalizedName) === value) continue;
 
 		if (sensitiveHeaderName(name) || AUTH_SCHEME_VALUE.test(value) || textContainsCredential(`${name}: ${value}`)) {
 			return {
 				blocked: true,
 				source: "header",
-				headerName: normalizedName,
+				headerName: name.trim().toLowerCase(),
 			};
 		}
 	}

--- a/src/core/CredentialLeakGuard.ts
+++ b/src/core/CredentialLeakGuard.ts
@@ -1,0 +1,74 @@
+export type CredentialLeakSource = "header" | "body" | "url";
+
+export interface CredentialLeakCheckInput {
+	method: string;
+	url: string;
+	headers?: Record<string, string>;
+	postData?: string | null;
+}
+
+export interface CredentialLeakDetection {
+	blocked: boolean;
+	source?: CredentialLeakSource;
+	headerName?: string;
+}
+
+const BODY_CAPABLE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+const EXPLICIT_SENSITIVE_HEADERS = new Set([
+	"authorization",
+	"proxy-authorization",
+	"x-api-key",
+	"api-key",
+	"x-auth-token",
+	"x-access-token",
+	"access-token",
+	"x-secret-key",
+	"x-goog-api-key",
+]);
+
+const SENSITIVE_HEADER_NAME = /^(?:x[-_])?(?:api[-_]?key|auth[-_]?token|access[-_]?token|secret[-_]?key)$/i;
+const JWT_VALUE = /eyJ[\w-]{10,}\.[\w-]{10,}/i;
+const LABELED_SECRET_VALUE = /(?:api[_-]?key|secret|token|password|bearer)\s*[:=]\s*['"]?[\w-]{8,}/i;
+const AUTH_SCHEME_VALUE = /^\s*(?:bearer|basic)\s+\S{8,}/i;
+
+function textContainsCredential(text: string): boolean {
+	return JWT_VALUE.test(text) || LABELED_SECRET_VALUE.test(text);
+}
+
+function sensitiveHeaderName(name: string): boolean {
+	const normalized = name.trim().toLowerCase();
+	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
+}
+
+/**
+ * Detect likely credential exfiltration without returning or logging secret values.
+ *
+ * Explicit authentication/token headers are treated as credentials whenever they
+ * contain a non-empty value. Other header values are inspected only for strong
+ * credential shapes so benign application headers are not blocked wholesale.
+ */
+export function detectCredentialLeak(input: CredentialLeakCheckInput): CredentialLeakDetection {
+	for (const [name, rawValue] of Object.entries(input.headers ?? {})) {
+		const value = String(rawValue ?? "");
+		if (!value.trim()) continue;
+
+		if (sensitiveHeaderName(name) || AUTH_SCHEME_VALUE.test(value) || textContainsCredential(`${name}: ${value}`)) {
+			return {
+				blocked: true,
+				source: "header",
+				headerName: name.toLowerCase(),
+			};
+		}
+	}
+
+	if (textContainsCredential(input.url)) {
+		return { blocked: true, source: "url" };
+	}
+
+	if (BODY_CAPABLE_METHODS.has(input.method.toUpperCase()) && textContainsCredential(input.postData ?? "")) {
+		return { blocked: true, source: "body" };
+	}
+
+	return { blocked: false };
+}

--- a/src/core/Logger.ts
+++ b/src/core/Logger.ts
@@ -26,6 +26,28 @@ const LEVEL_MAP: Record<LogLevel, number> = {
 	silent: 4,
 };
 
+const SENSITIVE_QUERY_PARAM =
+	/([?&](?:access[_-]?token|auth[_-]?token|api[_-]?key|api[_-]?token|token|secret|password|authorization)=)[^&#\s]*/gi;
+const SENSITIVE_HEADER_VALUE =
+	/(\b(?:authorization|proxy-authorization|x-api-key|api-key|x-api-token|api-token|x-auth-token|x-access-token|access-token|x-secret-key|x-goog-api-key)\b\s*[:=]\s*)(?:bearer\s+|basic\s+)?[^\s,;]+/gi;
+const AUTH_SCHEME_VALUE = /\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
+const JWT_VALUE = /\beyJ[\w-]{10,}\.[\w-]{10,}(?:\.[\w-]{10,})?\b/g;
+const URL_USER_INFO = /(https?:\/\/)[^/@\s]+@/gi;
+
+/** Redact common credential shapes before they reach console output. */
+export function redactLogString(value: string): string {
+	return value
+		.replace(URL_USER_INFO, "$1[REDACTED]@")
+		.replace(SENSITIVE_QUERY_PARAM, "$1[REDACTED]")
+		.replace(SENSITIVE_HEADER_VALUE, "$1[REDACTED]")
+		.replace(AUTH_SCHEME_VALUE, "$1 [REDACTED]")
+		.replace(JWT_VALUE, "[REDACTED_JWT]");
+}
+
+function redactLogArgs(args: unknown[]): unknown[] {
+	return args.map((arg) => (typeof arg === "string" ? redactLogString(arg) : arg));
+}
+
 function resolveLevel(): number {
 	const env = (globalThis as Record<string, unknown>).TALOX_LOG_LEVEL;
 	if (typeof env === "string" && env in LEVEL_MAP) return LEVEL_MAP[env as LogLevel];
@@ -61,16 +83,16 @@ export function createLogger(prefix: string): Logger {
 	const tag = `[Talox ${prefix}]`;
 	return {
 		debug(...args: unknown[]) {
-			if (currentLevel <= LEVEL_MAP.debug) console.log(tag, ...args);
+			if (currentLevel <= LEVEL_MAP.debug) console.log(tag, ...redactLogArgs(args));
 		},
 		info(...args: unknown[]) {
-			if (currentLevel <= LEVEL_MAP.info) console.log(tag, ...args);
+			if (currentLevel <= LEVEL_MAP.info) console.log(tag, ...redactLogArgs(args));
 		},
 		warn(...args: unknown[]) {
-			if (currentLevel <= LEVEL_MAP.warn) console.warn(tag, ...args);
+			if (currentLevel <= LEVEL_MAP.warn) console.warn(tag, ...redactLogArgs(args));
 		},
 		error(...args: unknown[]) {
-			if (currentLevel <= LEVEL_MAP.error) console.error(tag, ...args);
+			if (currentLevel <= LEVEL_MAP.error) console.error(tag, ...redactLogArgs(args));
 		},
 	};
 }

--- a/src/core/Logger.ts
+++ b/src/core/Logger.ts
@@ -30,6 +30,8 @@ const SENSITIVE_QUERY_PARAM =
 	/([?&](?:access[_-]?token|auth[_-]?token|api[_-]?key|api[_-]?token|token|secret|password|authorization)=)[^&#\s]*/gi;
 const SENSITIVE_HEADER_VALUE =
 	/(\b(?:authorization|proxy-authorization|x-api-key|api-key|x-api-token|api-token|x-auth-token|x-access-token|access-token|x-secret-key|x-goog-api-key)\b\s*[:=]\s*)(?:bearer\s+|basic\s+)?[^\s,;]+/gi;
+const LABELED_SECRET_VALUE =
+	/(\b(?:access[_-]?token|auth[_-]?token|api[_-]?key|api[_-]?token|token|secret|password|authorization)\b\s*[:=]\s*["']?)(?:bearer\s+|basic\s+)?[A-Za-z0-9._~+/=-]{8,}/gi;
 const AUTH_SCHEME_VALUE = /\b(bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi;
 const JWT_VALUE = /\beyJ[\w-]{10,}\.[\w-]{10,}(?:\.[\w-]{10,})?\b/g;
 const URL_USER_INFO = /(https?:\/\/)[^/@\s]+@/gi;
@@ -40,6 +42,7 @@ export function redactLogString(value: string): string {
 		.replace(URL_USER_INFO, "$1[REDACTED]@")
 		.replace(SENSITIVE_QUERY_PARAM, "$1[REDACTED]")
 		.replace(SENSITIVE_HEADER_VALUE, "$1[REDACTED]")
+		.replace(LABELED_SECRET_VALUE, "$1[REDACTED]")
 		.replace(AUTH_SCHEME_VALUE, "$1 [REDACTED]")
 		.replace(JWT_VALUE, "[REDACTED_JWT]");
 }

--- a/src/core/OriginHeaders.ts
+++ b/src/core/OriginHeaders.ts
@@ -98,7 +98,7 @@ export class OriginHeaders {
 			const extraHeaders = this.getHeadersForUrl(url);
 
 			if (Object.keys(extraHeaders).length === 0) {
-				await route.continue();
+				await route.fallback();
 				return;
 			}
 
@@ -108,7 +108,9 @@ export class OriginHeaders {
 				...extraHeaders,
 			};
 
-			await route.continue({ headers: mergedHeaders });
+			// Use fallback rather than continue so earlier security/policy routes can
+			// inspect the final injected headers before the request reaches the network.
+			await route.fallback({ headers: mergedHeaders });
 		};
 	}
 

--- a/src/core/controller/SessionManager.ts
+++ b/src/core/controller/SessionManager.ts
@@ -22,6 +22,7 @@ import type { TaloxSettings } from "../../types/settings.js";
 import { ArtifactBuilder } from "../ArtifactBuilder.js";
 import { AutoDialogHandler } from "../AutoDialogHandler.js";
 import { BrowserManager, type BrowserType } from "../BrowserManager.js";
+import { detectCredentialLeak } from "../CredentialLeakGuard.js";
 import { FingerprintGenerator, type FingerprintProfile } from "../FingerprintGenerator.js";
 import { createLogger } from "../Logger.js";
 import { createNetworkGuard, type NetworkGuard } from "../NetworkGuard.js";
@@ -648,28 +649,29 @@ export class SessionManager {
 		if (!this.profile || this.profile.class === "sandbox") return;
 
 		// 1. Outbound Request Guard
-		await page.route("**/*", (route: any) => {
+		await page.route("**/*", async (route: any) => {
 			const request = route.request();
 			const method = request.method();
 			const url = request.url();
 
-			if ((method === "POST" || method === "PUT") && this.profile?.class === "ops") {
-				const postData = request.postData() || "";
-				// Match JWT tokens (eyJ...), API keys, bearer tokens, and common secret patterns
-				const jwtRegex = /(eyJ[\w-]{10,}\.[\w-]{10,})/i;
-				const secretKeyRegex = /(?:api[_-]?key|secret|token|password|bearer)\s*[:=]\s*['"]?[\w-]{8,}/i;
+			if (this.profile?.class === "ops") {
+				const detection = detectCredentialLeak({
+					method,
+					url,
+					headers: request.headers(),
+					postData: request.postData(),
+				});
 
-				if (
-					jwtRegex.test(postData) ||
-					secretKeyRegex.test(postData) ||
-					jwtRegex.test(url) ||
-					secretKeyRegex.test(url)
-				) {
-					this.log.error(`🛡️ SECURITY GUARD BLOCKED REQUEST: Potential credential leak to ${url}`);
+				if (detection.blocked) {
+					const detail =
+						detection.source === "header" && detection.headerName
+							? `header ${detection.headerName}`
+							: detection.source ?? "request";
+					this.log.error(`🛡️ SECURITY GUARD BLOCKED REQUEST: Potential credential leak via ${detail} to ${url}`);
 					return route.abort("accessdenied");
 				}
 			}
-			route.continue();
+			await route.continue();
 		});
 
 		// 2. Per-Tab Behavior Monitoring (Popup Storms / Dialogs)

--- a/tests/unit/CredentialLeakGuard.test.ts
+++ b/tests/unit/CredentialLeakGuard.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { detectCredentialLeak } from "../../src/core/CredentialLeakGuard.js";
+
+describe("detectCredentialLeak", () => {
+	it("blocks bearer authorization headers without exposing the value", () => {
+		const secret = "Bearer very-secret-access-token";
+		const result = detectCredentialLeak({
+			method: "GET",
+			url: "https://example.com/profile",
+			headers: { Authorization: secret },
+		});
+
+		expect(result).toEqual({ blocked: true, source: "header", headerName: "authorization" });
+		expect(JSON.stringify(result)).not.toContain(secret);
+	});
+
+	it("matches API-key header names case-insensitively", () => {
+		const result = detectCredentialLeak({
+			method: "POST",
+			url: "https://example.com/api",
+			headers: { "X-API-KEY": "abc12345secret" },
+			postData: "{}",
+		});
+
+		expect(result).toEqual({ blocked: true, source: "header", headerName: "x-api-key" });
+	});
+
+	it("blocks proxy authorization headers", () => {
+		const result = detectCredentialLeak({
+			method: "GET",
+			url: "https://example.com",
+			headers: { "Proxy-Authorization": "Basic dXNlcjpwYXNzd29yZA==" },
+		});
+
+		expect(result.blocked).toBe(true);
+		expect(result.source).toBe("header");
+	});
+
+	it("scans PATCH request bodies for credentials", () => {
+		const result = detectCredentialLeak({
+			method: "PATCH",
+			url: "https://example.com/account",
+			headers: { "content-type": "application/json" },
+			postData: "api_key=abcdefgh12345678",
+		});
+
+		expect(result).toEqual({ blocked: true, source: "body" });
+	});
+
+	it("scans URLs for credentials regardless of HTTP method", () => {
+		const result = detectCredentialLeak({
+			method: "GET",
+			url: "https://example.com/redirect?token=abcdefgh12345678",
+			headers: { accept: "text/html" },
+		});
+
+		expect(result).toEqual({ blocked: true, source: "url" });
+	});
+
+	it("allows benign requests", () => {
+		const result = detectCredentialLeak({
+			method: "PATCH",
+			url: "https://example.com/profile",
+			headers: {
+				accept: "application/json",
+				"content-type": "application/json",
+				"x-request-id": "request-12345678",
+			},
+			postData: JSON.stringify({ displayName: "Talox User" }),
+		});
+
+		expect(result).toEqual({ blocked: false });
+	});
+});

--- a/tests/unit/CredentialLeakGuard.test.ts
+++ b/tests/unit/CredentialLeakGuard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { credentialSafeDestination, detectCredentialLeak } from "../../src/core/CredentialLeakGuard.js";
+import { detectCredentialLeak } from "../../src/core/CredentialLeakGuard.js";
 
 describe("detectCredentialLeak", () => {
 	it("blocks bearer authorization headers without exposing the value", () => {
@@ -81,20 +81,5 @@ describe("detectCredentialLeak", () => {
 		});
 
 		expect(result).toEqual({ blocked: false });
-	});
-});
-
-describe("credentialSafeDestination", () => {
-	it("keeps only the origin so URL credentials never reach logs", () => {
-		const secret = "super-secret-token";
-		const destination = credentialSafeDestination(`https://user:password@example.com/private/${secret}?token=${secret}`);
-
-		expect(destination).toBe("https://example.com");
-		expect(destination).not.toContain(secret);
-		expect(destination).not.toContain("password");
-	});
-
-	it("fails closed for malformed destinations", () => {
-		expect(credentialSafeDestination("not a URL token=abcdefgh12345678")).toBe("<invalid-url>");
 	});
 });

--- a/tests/unit/CredentialLeakGuard.test.ts
+++ b/tests/unit/CredentialLeakGuard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectCredentialLeak } from "../../src/core/CredentialLeakGuard.js";
+import { credentialSafeDestination, detectCredentialLeak } from "../../src/core/CredentialLeakGuard.js";
 
 describe("detectCredentialLeak", () => {
 	it("blocks bearer authorization headers without exposing the value", () => {
@@ -47,6 +47,17 @@ describe("detectCredentialLeak", () => {
 		expect(result).toEqual({ blocked: true, source: "body" });
 	});
 
+	it("detects quoted JSON credential fields", () => {
+		const result = detectCredentialLeak({
+			method: "POST",
+			url: "https://example.com/session",
+			headers: { "content-type": "application/json" },
+			postData: JSON.stringify({ password: "correct-horse-battery-staple" }),
+		});
+
+		expect(result).toEqual({ blocked: true, source: "body" });
+	});
+
 	it("scans URLs for credentials regardless of HTTP method", () => {
 		const result = detectCredentialLeak({
 			method: "GET",
@@ -70,5 +81,20 @@ describe("detectCredentialLeak", () => {
 		});
 
 		expect(result).toEqual({ blocked: false });
+	});
+});
+
+describe("credentialSafeDestination", () => {
+	it("keeps only the origin so URL credentials never reach logs", () => {
+		const secret = "super-secret-token";
+		const destination = credentialSafeDestination(`https://user:password@example.com/private/${secret}?token=${secret}`);
+
+		expect(destination).toBe("https://example.com");
+		expect(destination).not.toContain(secret);
+		expect(destination).not.toContain("password");
+	});
+
+	it("fails closed for malformed destinations", () => {
+		expect(credentialSafeDestination("not a URL token=abcdefgh12345678")).toBe("<invalid-url>");
 	});
 });

--- a/tests/unit/LoggerSecretRedaction.test.ts
+++ b/tests/unit/LoggerSecretRedaction.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLogger, redactLogString, setLogLevel } from "../../src/core/Logger.js";
+
+describe("Logger credential redaction", () => {
+	afterEach(() => {
+		setLogLevel("info");
+		vi.restoreAllMocks();
+	});
+
+	it("redacts sensitive query parameters and URL user info", () => {
+		const secret = "abcdefgh12345678";
+		const value = redactLogString(`blocked https://user:password@example.com/path?token=${secret}&page=1`);
+
+		expect(value).toContain("https://[REDACTED]@example.com/path?token=[REDACTED]&page=1");
+		expect(value).not.toContain(secret);
+		expect(value).not.toContain("user:password");
+	});
+
+	it("redacts bearer and explicit API-key values", () => {
+		const value = redactLogString("Authorization: Bearer abcdefgh12345678 X-API-Key=supersecret123");
+
+		expect(value).not.toContain("abcdefgh12345678");
+		expect(value).not.toContain("supersecret123");
+		expect(value).toContain("Authorization: [REDACTED]");
+		expect(value).toContain("X-API-Key=[REDACTED]");
+	});
+
+	it("redacts JWT-shaped values", () => {
+		const jwt = "eyJabcdefghij.abcdefghijklmnop.qrstuvwxyz123456";
+		const value = redactLogString(`request ${jwt}`);
+
+		expect(value).toContain("[REDACTED_JWT]");
+		expect(value).not.toContain(jwt);
+	});
+
+	it("redacts strings before console output while preserving benign arguments", () => {
+		setLogLevel("error");
+		const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		const logger = createLogger("SecurityTest");
+		const metadata = { requestId: "safe-123" };
+
+		logger.error("blocked https://example.com/?api_key=abcdefgh12345678", metadata);
+
+		expect(consoleSpy).toHaveBeenCalledWith(
+			"[Talox SecurityTest]",
+			"blocked https://example.com/?api_key=[REDACTED]",
+			metadata,
+		);
+	});
+});

--- a/tests/unit/LoggerSecretRedaction.test.ts
+++ b/tests/unit/LoggerSecretRedaction.test.ts
@@ -16,6 +16,14 @@ describe("Logger credential redaction", () => {
 		expect(value).not.toContain("user:password");
 	});
 
+	it("redacts labeled secrets outside query strings", () => {
+		const secret = "abcdefgh12345678";
+		const value = redactLogString(`blocked https://example.com/redirect/token=${secret}/next`);
+
+		expect(value).not.toContain(secret);
+		expect(value).toContain("token=[REDACTED]");
+	});
+
 	it("redacts bearer and explicit API-key values", () => {
 		const value = redactLogString("Authorization: Bearer abcdefgh12345678 X-API-Key=supersecret123");
 

--- a/tests/unit/OriginHeaders.test.ts
+++ b/tests/unit/OriginHeaders.test.ts
@@ -25,6 +25,7 @@ function createMockRoute(url: string, headers: Record<string, string>) {
 			headers: vi.fn().mockReturnValue(headers),
 		}),
 		continue: vi.fn().mockResolvedValue(undefined),
+		fallback: vi.fn().mockResolvedValue(undefined),
 	};
 }
 
@@ -135,7 +136,7 @@ describe("OriginHeaders", () => {
 			expect(page.route).toHaveBeenCalledWith("**/*", expect.any(Function));
 		});
 
-		it("route handler adds headers for matching URLs", async () => {
+		it("route handler adds headers and falls back to earlier routes", async () => {
 			const oh = new OriginHeaders({
 				"https://example.com": { Authorization: "Bearer tok" },
 			});
@@ -150,15 +151,16 @@ describe("OriginHeaders", () => {
 			await handler(route);
 
 			expect(route.request).toHaveBeenCalled();
-			expect(route.continue).toHaveBeenCalledWith({
+			expect(route.fallback).toHaveBeenCalledWith({
 				headers: {
 					"content-type": "application/json",
 					Authorization: "Bearer tok",
 				},
 			});
+			expect(route.continue).not.toHaveBeenCalled();
 		});
 
-		it("route handler continues without modification for non-matching URLs", async () => {
+		it("route handler falls back without modification for non-matching URLs", async () => {
 			const oh = new OriginHeaders({
 				"https://api.example.com": { Authorization: "Bearer tok" },
 			});
@@ -170,7 +172,8 @@ describe("OriginHeaders", () => {
 
 			await handler(route);
 
-			expect(route.continue).toHaveBeenCalledWith();
+			expect(route.fallback).toHaveBeenCalledWith();
+			expect(route.continue).not.toHaveBeenCalled();
 		});
 
 		it("dispose unroutes and clears config", async () => {

--- a/tests/unit/OriginHeadersSecurityComposition.test.ts
+++ b/tests/unit/OriginHeadersSecurityComposition.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import { OriginHeaders } from "../../src/core/OriginHeaders.js";
+import { SessionManager } from "../../src/core/controller/SessionManager.js";
+import type { ProfileClass } from "../../src/types/index.js";
+
+function createManager(profileClass: ProfileClass) {
+	const manager = new SessionManager({ verbosity: 0 } as any, { emit: vi.fn() } as any, "/tmp/talox-route-chain");
+	manager.profile = {
+		id: `${profileClass}-route-chain`,
+		class: profileClass,
+		purpose: "route composition test",
+		userDataDir: `/tmp/talox-route-chain/${profileClass}`,
+		metadata: { createdAt: "", lastUsed: "" },
+	};
+	return manager;
+}
+
+async function runComposedRequest(profileClass: ProfileClass) {
+	const handlers: Array<(route: any) => Promise<void>> = [];
+	const page = {
+		route: vi.fn(async (_pattern: string, handler: (route: any) => Promise<void>) => {
+			handlers.push(handler);
+		}),
+		unroute: vi.fn().mockResolvedValue(undefined),
+		on: vi.fn(),
+	};
+
+	const manager = createManager(profileClass);
+	await (manager as any).attachSecurityHooks(page);
+
+	const originHeaders = new OriginHeaders({
+		"https://api.example.com": { Authorization: "Bearer configured-token-12345678" },
+	});
+	await originHeaders.install(page as any);
+
+	// Security is registered first and OriginHeaders second. Playwright executes
+	// matching routes in reverse registration order, so OriginHeaders must fall
+	// back for the security handler to inspect the injected request.
+	const state = {
+		headers: { accept: "application/json" } as Record<string, string>,
+		continued: 0,
+		aborted: 0,
+	};
+
+	const invoke = async (index: number): Promise<void> => {
+		const route = {
+			request: () => ({
+				method: () => "GET",
+				url: () => "https://api.example.com/data",
+				headers: () => state.headers,
+				postData: () => null,
+			}),
+			fallback: async (options?: { headers?: Record<string, string> }) => {
+				if (options?.headers) state.headers = options.headers;
+				if (index > 0) await invoke(index - 1);
+				else state.continued++;
+			},
+			continue: async () => {
+				state.continued++;
+			},
+			abort: async (reason?: string) => {
+				expect(reason).toBe("accessdenied");
+				state.aborted++;
+			},
+		};
+
+		await handlers[index]!(route);
+	};
+
+	expect(handlers).toHaveLength(profileClass === "sandbox" ? 1 : 2);
+	await invoke(handlers.length - 1);
+	return state;
+}
+
+describe("OriginHeaders security route composition", () => {
+	it("lets the ops security handler inspect and block injected credentials", async () => {
+		const state = await runComposedRequest("ops");
+
+		expect(state.headers.Authorization).toBe("Bearer configured-token-12345678");
+		expect(state.aborted).toBe(1);
+		expect(state.continued).toBe(0);
+	});
+
+	it("preserves configured OriginHeaders for qa profiles", async () => {
+		const state = await runComposedRequest("qa");
+
+		expect(state.headers.Authorization).toBe("Bearer configured-token-12345678");
+		expect(state.aborted).toBe(0);
+		expect(state.continued).toBe(1);
+	});
+
+	it("preserves configured OriginHeaders for sandbox profiles", async () => {
+		const state = await runComposedRequest("sandbox");
+
+		expect(state.headers.Authorization).toBe("Bearer configured-token-12345678");
+		expect(state.aborted).toBe(0);
+		expect(state.continued).toBe(1);
+	});
+});

--- a/tests/unit/SessionManagerCredentialGuard.test.ts
+++ b/tests/unit/SessionManagerCredentialGuard.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../src/core/controller/SessionManager.js";
+
+function createManager() {
+	const manager = new SessionManager({ verbosity: 0 } as any, { emit: vi.fn() } as any, "/tmp/talox-credential-guard");
+	manager.profile = {
+		id: "ops-test",
+		class: "ops",
+		purpose: "credential guard test",
+		userDataDir: "/tmp/talox-credential-guard/profile",
+		metadata: { createdAt: "", lastUsed: "" },
+	};
+	return manager;
+}
+
+async function installRouteHandler(manager: SessionManager) {
+	let handler: ((route: any) => Promise<void>) | undefined;
+	const page = {
+		route: vi.fn(async (_pattern: string, routeHandler: (route: any) => Promise<void>) => {
+			handler = routeHandler;
+		}),
+		on: vi.fn(),
+	};
+
+	await (manager as any).attachSecurityHooks(page);
+	expect(page.route).toHaveBeenCalledWith("**/*", expect.any(Function));
+	if (!handler) throw new Error("Security route handler was not installed");
+	return handler;
+}
+
+function createRoute(overrides: {
+	method?: string;
+	url?: string;
+	headers?: Record<string, string>;
+	postData?: string | null;
+} = {}) {
+	const request = {
+		method: vi.fn(() => overrides.method ?? "GET"),
+		url: vi.fn(() => overrides.url ?? "https://example.com/health"),
+		headers: vi.fn(() => overrides.headers ?? { accept: "application/json" }),
+		postData: vi.fn(() => overrides.postData ?? null),
+	};
+	return {
+		request: vi.fn(() => request),
+		abort: vi.fn().mockResolvedValue(undefined),
+		continue: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+describe("SessionManager credential protocol guard", () => {
+	it("aborts credential-bearing authorization headers", async () => {
+		const handler = await installRouteHandler(createManager());
+		const route = createRoute({ headers: { Authorization: "Bearer abcdefgh12345678" } });
+
+		await handler(route);
+
+		expect(route.abort).toHaveBeenCalledWith("accessdenied");
+		expect(route.continue).not.toHaveBeenCalled();
+	});
+
+	it("continues benign requests", async () => {
+		const handler = await installRouteHandler(createManager());
+		const route = createRoute({
+			method: "PATCH",
+			url: "https://example.com/profile",
+			headers: { "content-type": "application/json", "x-request-id": "request-12345678" },
+			postData: JSON.stringify({ displayName: "Talox User" }),
+		});
+
+		await handler(route);
+
+		expect(route.continue).toHaveBeenCalledTimes(1);
+		expect(route.abort).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary
- inspect outbound request headers in the ops-profile protocol guard
- block explicit authorization/API-key/token headers without logging secret values
- scan request URLs for credentials on every HTTP method
- extend body scanning to PATCH and DELETE in addition to POST/PUT
- make the Playwright route callback await benign continuations
- compose `OriginHeaders` with earlier security routes via `route.fallback()` so injected headers cannot bypass the ops guard
- preserve existing `OriginHeaders` behavior for qa/sandbox while making ops security intentionally fail closed
- add centralized logger redaction for credential-shaped strings, URL user-info, auth schemes, JWTs, and sensitive query/labeled values
- add focused detector, logger, route-composition, and real SessionManager route-handler regression coverage

## Security impact
The previous guard inspected only POST/PUT bodies and URLs and never inspected request headers. Credential-bearing GET requests or headers such as `Authorization` and `X-API-Key` could therefore bypass this boundary when the optional page-context NetworkGuard was disabled.

`OriginHeaders` also registered after the SessionManager security route and used `route.continue()`. Playwright executes the most recently registered matching route first, and `continue()` skips earlier matching handlers, so configured header injection could bypass the protocol security route entirely. It now uses `fallback()` so earlier security/policy routes inspect the final injected request.

For `ops`, credential safety deliberately takes precedence over injected credential headers. `qa` and `sandbox` retain their existing configured-header behavior.

A self-review also found that blocking a credential embedded in a URL could reproduce that URL in the security log. Talox now redacts common credential shapes centrally before string arguments reach console output. Detector results themselves contain only leak source and normalized header name, never credential values.

## Verification
Coverage proves:
- bearer, proxy-authorization, and case-insensitive API-key headers are detected
- PATCH bodies and quoted JSON credential fields are detected
- credential-bearing GET URLs are detected
- benign requests remain allowed by the detector
- the actual SessionManager protocol route aborts credential-bearing requests and continues benign ones
- OriginHeaders falls through to earlier routes with its final merged headers
- composed OriginHeaders + SessionManager routing blocks injected credentials for ops and preserves them for qa/sandbox
- logger output redacts query/path secrets, URL user-info, auth values, and JWT-shaped values

Full CI and Docker on the latest head remain merge gates.

Closes #113