### PR TITLE
fix: compose NetworkMocker with route security

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -86,11 +86,13 @@ export class NetworkMocker {
 
 		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.isRecording) {
-				await route.continue();
+				await route.fallback();
 				return;
 			}
 
-			await route.continue();
+			// Recording is observational. Fall through so earlier security/policy routes
+			// can still inspect or block the request before it reaches the network.
+			await route.fallback();
 
 			try {
 				const response: Response | null = await request.response();
@@ -135,7 +137,7 @@ export class NetworkMocker {
 					this.recordingHandler(recording);
 				}
 			} catch {
-				// Recording is best-effort after the request has already continued.
+				// Recording is best-effort after the request has already fallen through.
 			}
 		};
 
@@ -177,7 +179,7 @@ export class NetworkMocker {
 
 		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.isReplaying) {
-				await route.continue();
+				await route.fallback();
 				return;
 			}
 
@@ -199,7 +201,7 @@ export class NetworkMocker {
 
 				await route.fulfill(fulfillOptions);
 			} else {
-				await route.continue();
+				await route.fallback();
 			}
 		};
 
@@ -224,7 +226,7 @@ export class NetworkMocker {
 		const routePattern = this.createStatelessRoutePattern(mock.urlPattern);
 		const handler: RouteHandler = async (route: Route, request: Request) => {
 			if (!this.matchesPattern(request.url(), routePattern)) {
-				await route.continue();
+				await route.fallback();
 				return;
 			}
 

--- a/tests/unit/NetworkMocker.test.ts
+++ b/tests/unit/NetworkMocker.test.ts
@@ -27,6 +27,7 @@ function makeMockContext() {
 function makeRoute(overrides: Record<string, any> = {}) {
 	return {
 		continue: vi.fn(async () => {}),
+		fallback: vi.fn(async () => {}),
 		fulfill: vi.fn(async () => {}),
 		...overrides,
 	};
@@ -94,7 +95,7 @@ describe("NetworkMocker", () => {
 	});
 
 	describe("recording handler captures request data", () => {
-		it("records a request when handler is invoked", async () => {
+		it("records a request while falling through to earlier routes", async () => {
 			const onRecording = vi.fn();
 			await mocker.startRecording(onRecording);
 			const handler = mockPage._handlers[0]!;
@@ -114,7 +115,8 @@ describe("NetworkMocker", () => {
 
 			await handler(route, request);
 
-			expect(route.continue).toHaveBeenCalled();
+			expect(route.fallback).toHaveBeenCalled();
+			expect(route.continue).not.toHaveBeenCalled();
 			const recordings = mocker.getRecordings();
 			expect(recordings).toHaveLength(1);
 			expect(recordings[0]!.url).toBe("https://example.com/page");
@@ -141,7 +143,7 @@ describe("NetworkMocker", () => {
 			expect(recordings[0]!.requestBody).toBe('{"key":"value"}');
 		});
 
-		it("stops recording when handler is called after stop", async () => {
+		it("falls through when a stale recording handler is called after stop", async () => {
 			await mocker.startRecording();
 			const handler = mockPage._handlers[0]!;
 
@@ -152,6 +154,8 @@ describe("NetworkMocker", () => {
 			await handler(route, request);
 
 			expect(mocker.getRecordings()).toEqual([]);
+			expect(route.fallback).toHaveBeenCalled();
+			expect(route.continue).not.toHaveBeenCalled();
 		});
 	});
 
@@ -188,9 +192,10 @@ describe("NetworkMocker", () => {
 					body: '{"result":true}',
 				}),
 			);
+			expect(route.fallback).not.toHaveBeenCalled();
 		});
 
-		it("continues request when no matching recording", async () => {
+		it("falls through when no recording matches", async () => {
 			await mocker.startReplaying([]);
 			const handler = mockPage._handlers[mockPage._handlers.length - 1]!;
 
@@ -201,7 +206,8 @@ describe("NetworkMocker", () => {
 			});
 
 			await handler(route, request);
-			expect(route.continue).toHaveBeenCalled();
+			expect(route.fallback).toHaveBeenCalled();
+			expect(route.continue).not.toHaveBeenCalled();
 		});
 
 		it("stopReplaying resets state", async () => {
@@ -231,6 +237,19 @@ describe("NetworkMocker", () => {
 			const routePattern = mockPage.route.mock.calls[0]?.[0];
 			expect(routePattern).toBeInstanceOf(RegExp);
 			expect((routePattern as RegExp).test("https://api.example.com/data")).toBe(true);
+		});
+
+		it("falls through instead of terminating the route chain when a mock does not match", async () => {
+			await mocker.addMock({ urlPattern: "api.example.com", status: 200 });
+			const handler = mockPage._handlers[0]!;
+			const route = makeRoute();
+			const request = makeRequest({ url: vi.fn(() => "https://other.example.com/data") });
+
+			await handler(route, request);
+
+			expect(route.fallback).toHaveBeenCalled();
+			expect(route.fulfill).not.toHaveBeenCalled();
+			expect(route.continue).not.toHaveBeenCalled();
 		});
 
 		it("clears all mocks", async () => {

--- a/tests/unit/NetworkMockerRecordingErrorPaths.test.ts
+++ b/tests/unit/NetworkMockerRecordingErrorPaths.test.ts
@@ -34,54 +34,54 @@ function createRequest(overrides: Record<string, unknown> = {}) {
 }
 
 describe("NetworkMocker recording route error paths", () => {
-	it("does not continue a request twice when response inspection fails", async () => {
+	it("does not fall through a request twice when response inspection fails", async () => {
 		const { mocker, getHandler } = createMocker();
 		await mocker.startRecording();
 
-		const continueRequest = vi.fn(async () => {});
+		const fallbackRequest = vi.fn(async () => {});
 		const response = vi.fn(async () => {
 			throw new Error("response unavailable");
 		});
 		const request = createRequest({ response });
 
-		await expect(getHandler()({ continue: continueRequest }, request)).resolves.toBeUndefined();
+		await expect(getHandler()({ fallback: fallbackRequest }, request)).resolves.toBeUndefined();
 
-		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(fallbackRequest).toHaveBeenCalledTimes(1);
 		expect(response).toHaveBeenCalledTimes(1);
 		expect(mocker.getRecordings()).toEqual([]);
 	});
 
-	it("does not continue a request twice when the recording callback throws", async () => {
+	it("does not fall through a request twice when the recording callback throws", async () => {
 		const { mocker, getHandler } = createMocker();
 		const onRecording = vi.fn(() => {
 			throw new Error("consumer callback failed");
 		});
 		await mocker.startRecording(onRecording);
 
-		const continueRequest = vi.fn(async () => {});
+		const fallbackRequest = vi.fn(async () => {});
 		const request = createRequest();
 
-		await expect(getHandler()({ continue: continueRequest }, request)).resolves.toBeUndefined();
+		await expect(getHandler()({ fallback: fallbackRequest }, request)).resolves.toBeUndefined();
 
-		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(fallbackRequest).toHaveBeenCalledTimes(1);
 		expect(onRecording).toHaveBeenCalledTimes(1);
 		expect(mocker.getRecordings()).toHaveLength(1);
 	});
 
-	it("surfaces a continue failure without retrying the same route", async () => {
+	it("surfaces a fallback failure without inspecting or retrying the same route", async () => {
 		const { mocker, getHandler } = createMocker();
 		await mocker.startRecording();
 
-		const failure = new Error("route continue failed");
-		const continueRequest = vi.fn(async () => {
+		const failure = new Error("route fallback failed");
+		const fallbackRequest = vi.fn(async () => {
 			throw failure;
 		});
 		const response = vi.fn(async () => null);
 		const request = createRequest({ response });
 
-		await expect(getHandler()({ continue: continueRequest }, request)).rejects.toBe(failure);
+		await expect(getHandler()({ fallback: fallbackRequest }, request)).rejects.toBe(failure);
 
-		expect(continueRequest).toHaveBeenCalledTimes(1);
+		expect(fallbackRequest).toHaveBeenCalledTimes(1);
 		expect(response).not.toHaveBeenCalled();
 		expect(mocker.getRecordings()).toEqual([]);
 	});

--- a/tests/unit/NetworkMockerRegexPatternOwnership.test.ts
+++ b/tests/unit/NetworkMockerRegexPatternOwnership.test.ts
@@ -20,6 +20,7 @@ function makePage() {
 function makeRoute() {
 	return {
 		continue: vi.fn(async () => {}),
+		fallback: vi.fn(async () => {}),
 		fulfill: vi.fn(async () => {}),
 	};
 }
@@ -51,6 +52,8 @@ describe("NetworkMocker stateful RegExp ownership", () => {
 		expect(secondRoute.fulfill).toHaveBeenCalledOnce();
 		expect(firstRoute.continue).not.toHaveBeenCalled();
 		expect(secondRoute.continue).not.toHaveBeenCalled();
+		expect(firstRoute.fallback).not.toHaveBeenCalled();
+		expect(secondRoute.fallback).not.toHaveBeenCalled();
 		expect(original.lastIndex).toBe(0);
 	});
 
@@ -72,7 +75,8 @@ describe("NetworkMocker stateful RegExp ownership", () => {
 
 		expect(matchingRoute.fulfill).toHaveBeenCalledOnce();
 		expect(shiftedRoute.fulfill).not.toHaveBeenCalled();
-		expect(shiftedRoute.continue).toHaveBeenCalledOnce();
+		expect(shiftedRoute.fallback).toHaveBeenCalledOnce();
+		expect(shiftedRoute.continue).not.toHaveBeenCalled();
 		expect(original.lastIndex).toBe(0);
 	});
 

--- a/tests/unit/NetworkMockerStringPatternSemantics.test.ts
+++ b/tests/unit/NetworkMockerStringPatternSemantics.test.ts
@@ -20,6 +20,7 @@ function makePage() {
 function makeRoute() {
 	return {
 		continue: vi.fn(async () => {}),
+		fallback: vi.fn(async () => {}),
 		fulfill: vi.fn(async () => {}),
 	};
 }
@@ -48,8 +49,10 @@ describe("NetworkMocker string pattern semantics", () => {
 
 		expect(matchingRoute.fulfill).toHaveBeenCalledOnce();
 		expect(matchingRoute.continue).not.toHaveBeenCalled();
+		expect(matchingRoute.fallback).not.toHaveBeenCalled();
 		expect(nonMatchingRoute.fulfill).not.toHaveBeenCalled();
-		expect(nonMatchingRoute.continue).toHaveBeenCalledOnce();
+		expect(nonMatchingRoute.fallback).toHaveBeenCalledOnce();
+		expect(nonMatchingRoute.continue).not.toHaveBeenCalled();
 	});
 
 	it("keeps the caller-visible mock pattern unchanged while owning the registered matcher", async () => {


### PR DESCRIPTION
## Summary
- replace `route.continue()` with `route.fallback()` whenever NetworkMocker is observing or declining to handle a request
- keep matching replay/mock responses locally fulfilled
- preserve earlier Playwright security/policy routes in the handler chain
- add regression coverage for recording fallthrough, stale handlers, unmatched replay, and unmatched mocks

## Impact
Playwright invokes matching page routes in reverse registration order, and `route.continue()` immediately sends the request without invoking earlier matching handlers. A NetworkMocker recorder or unmatched replay/mock registered after a security/policy route could therefore bypass that earlier route.

Recording is observational and now falls through. Unmatched replay/mock handlers also fall through. Matched replay/mock handlers still `fulfill()` locally because no outbound request is sent.

## Verification
Tests assert that observational/unmatched paths call `fallback()` and never `continue()`, while matching replay responses remain fulfilled locally. Full CI and Docker on the PR head remain merge gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network request handling so unmatched, inactive, or unavailable mock and replay requests correctly fall through to other handlers.
  * Ensured requests continue to be processed normally after recording is stopped or when no replay match is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->