### PR TITLE
security: sanitize persisted network recordings

### DIFF
--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -1,8 +1,14 @@
 import type { BrowserContext, Page, Request, Response, Route } from "playwright-core";
+import {
+	sanitizeCredentialText,
+	sanitizeRecordingHeaders,
+	sanitizeRecordingUrl,
+} from "./NetworkRecordingSanitizer.js";
 
 export interface NetworkRecording {
 	id: string;
 	url: string;
+	replayUrl?: string;
 	method: string;
 	status: number;
 	requestHeaders: Record<string, string>;
@@ -35,9 +41,9 @@ interface MockRouteRegistration {
 
 /**
  * Records and replays network traffic for testing and replay scenarios.
- * Captures full request/response pairs (headers, bodies), replays saved
- * recordings by intercepting and fulfilling matching requests, and supports
- * adding individual mock responses with configurable URL patterns and delays.
+ * Captures full request/response pairs in memory, persists credential-sanitized
+ * recordings, replays saved recordings, and supports individual mock responses
+ * with configurable URL patterns and delays.
  */
 export class NetworkMocker {
 	private readonly context: BrowserContext;
@@ -183,7 +189,14 @@ export class NetworkMocker {
 				return;
 			}
 
-			const matchingRecording = this.recordings.find((r) => r.url === request.url() && r.method === request.method());
+			const requestUrl = request.url();
+			const requestReplayUrl = sanitizeRecordingUrl(requestUrl);
+			const requestMethod = request.method();
+			const matchingRecording = this.recordings.find((recording) => {
+				const comparableRequestUrl = recording.replayUrl === undefined ? requestUrl : requestReplayUrl;
+				const recordedUrl = recording.replayUrl ?? recording.url;
+				return recordedUrl === comparableRequestUrl && recording.method === requestMethod;
+			});
 
 			if (matchingRecording) {
 				const fulfillOptions: {
@@ -285,7 +298,31 @@ export class NetworkMocker {
 
 	async saveToFile(filePath: string): Promise<void> {
 		const fs = await import("node:fs/promises");
-		const data = JSON.stringify(this.recordings, null, 2);
+		const persistedRecordings = this.recordings.map((recording) => {
+			const replayUrl = sanitizeRecordingUrl(recording.replayUrl ?? recording.url);
+			const responseHeaders = sanitizeRecordingHeaders(recording.responseHeaders);
+			const requestBody =
+				recording.requestBody === undefined ? undefined : sanitizeCredentialText(recording.requestBody);
+			const responseBody =
+				recording.responseBody === undefined ? undefined : sanitizeCredentialText(recording.responseBody);
+
+			if (responseBody !== recording.responseBody) {
+				for (const headerName of Object.keys(responseHeaders)) {
+					if (headerName.toLowerCase() === "content-length") delete responseHeaders[headerName];
+				}
+			}
+
+			return {
+				...recording,
+				url: replayUrl,
+				replayUrl,
+				requestHeaders: sanitizeRecordingHeaders(recording.requestHeaders),
+				responseHeaders,
+				...(requestBody === undefined ? {} : { requestBody }),
+				...(responseBody === undefined ? {} : { responseBody }),
+			};
+		});
+		const data = JSON.stringify(persistedRecordings, null, 2);
 		await fs.writeFile(filePath, data, "utf-8");
 	}
 

--- a/src/core/NetworkMocker.ts
+++ b/src/core/NetworkMocker.ts
@@ -298,7 +298,7 @@ export class NetworkMocker {
 
 	async saveToFile(filePath: string): Promise<void> {
 		const fs = await import("node:fs/promises");
-		const persistedRecordings = this.recordings.map((recording) => {
+		const persistedRecordings = this.recordings.map((recording): NetworkRecording => {
 			const replayUrl = sanitizeRecordingUrl(recording.replayUrl ?? recording.url);
 			const responseHeaders = sanitizeRecordingHeaders(recording.responseHeaders);
 			const requestBody =
@@ -312,15 +312,19 @@ export class NetworkMocker {
 				}
 			}
 
-			return {
-				...recording,
+			const persisted: NetworkRecording = {
+				id: recording.id,
 				url: replayUrl,
 				replayUrl,
+				method: recording.method,
+				status: recording.status,
 				requestHeaders: sanitizeRecordingHeaders(recording.requestHeaders),
 				responseHeaders,
-				...(requestBody === undefined ? {} : { requestBody }),
-				...(responseBody === undefined ? {} : { responseBody }),
+				timestamp: recording.timestamp,
 			};
+			if (requestBody !== undefined) persisted.requestBody = requestBody;
+			if (responseBody !== undefined) persisted.responseBody = responseBody;
+			return persisted;
 		});
 		const data = JSON.stringify(persistedRecordings, null, 2);
 		await fs.writeFile(filePath, data, "utf-8");

--- a/src/core/NetworkRecordingSanitizer.ts
+++ b/src/core/NetworkRecordingSanitizer.ts
@@ -1,0 +1,133 @@
+const REDACTED = "[REDACTED]";
+
+const EXPLICIT_SENSITIVE_HEADERS = new Set([
+	"authorization",
+	"proxy-authorization",
+	"cookie",
+	"cookie2",
+	"set-cookie",
+	"set-cookie2",
+	"www-authenticate",
+	"proxy-authenticate",
+	"x-api-key",
+	"api-key",
+	"x-api-token",
+	"api-token",
+	"x-auth-token",
+	"x-access-token",
+	"access-token",
+	"x-secret-key",
+	"x-goog-api-key",
+	"client-secret",
+	"x-client-secret",
+]);
+
+const SENSITIVE_HEADER_NAME =
+	/^(?:x[-_])?(?:api[-_]?(?:key|token)|auth[-_]?token|access[-_]?token|secret[-_]?key|client[-_]?secret)$/i;
+const SENSITIVE_FIELD_NAME =
+	/^(?:access[-_]?token|auth[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|cookie|set[-_]?cookie)$/i;
+const SENSITIVE_QUERY_NAME =
+	/^(?:access[-_]?token|auth[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization)$/i;
+const LABELED_SECRET_VALUE =
+	/(\b(?:access[_-]?token|auth[_-]?token|api[_-]?(?:key|token)|client[_-]?secret|secret|token|password|passwd|authorization)\b\s*[:=]\s*["']?)(?:bearer\s+|basic\s+)?[^\s,;&}"']+/gi;
+const AUTH_SCHEME_VALUE = /\b(bearer|basic)\s+[^\s,;&}"']+/gi;
+const JWT_VALUE = /\beyJ[\w-]{10,}\.[\w-]{10,}(?:\.[\w-]{10,})?\b/g;
+const URL_USER_INFO = /(https?:\/\/)[^/@\s]+@/gi;
+
+function isSensitiveHeaderName(name: string): boolean {
+	const normalized = name.trim().toLowerCase();
+	return EXPLICIT_SENSITIVE_HEADERS.has(normalized) || SENSITIVE_HEADER_NAME.test(normalized);
+}
+
+function sanitizeJsonValue(value: unknown): { value: unknown; changed: boolean } {
+	if (Array.isArray(value)) {
+		let changed = false;
+		const sanitized = value.map((entry) => {
+			const result = sanitizeJsonValue(entry);
+			changed ||= result.changed;
+			return result.value;
+		});
+		return { value: changed ? sanitized : value, changed };
+	}
+
+	if (value && typeof value === "object") {
+		let changed = false;
+		const sanitized: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+			if (SENSITIVE_FIELD_NAME.test(key)) {
+				sanitized[key] = REDACTED;
+				changed = true;
+				continue;
+			}
+			const result = sanitizeJsonValue(entry);
+			sanitized[key] = result.value;
+			changed ||= result.changed;
+		}
+		return { value: changed ? sanitized : value, changed };
+	}
+
+	if (typeof value === "string") {
+		const sanitized = sanitizeCredentialTextFallback(value);
+		return { value: sanitized, changed: sanitized !== value };
+	}
+
+	return { value, changed: false };
+}
+
+function sanitizeCredentialTextFallback(value: string): string {
+	return value
+		.replace(URL_USER_INFO, `$1${REDACTED}@`)
+		.replace(LABELED_SECRET_VALUE, `$1${REDACTED}`)
+		.replace(AUTH_SCHEME_VALUE, `$1 ${REDACTED}`)
+		.replace(JWT_VALUE, REDACTED);
+}
+
+/**
+ * Redact common credential shapes from persisted request/response bodies while
+ * preserving non-sensitive payloads byte-for-byte whenever possible.
+ */
+export function sanitizeCredentialText(value: string): string {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		const result = sanitizeJsonValue(parsed);
+		if (result.changed) return JSON.stringify(result.value);
+	} catch {
+		// Non-JSON payloads are handled by the conservative text redactor below.
+	}
+	return sanitizeCredentialTextFallback(value);
+}
+
+/**
+ * Remove credential-bearing headers entirely. For otherwise-benign headers,
+ * redact credential-shaped values rather than persisting them verbatim.
+ */
+export function sanitizeRecordingHeaders(headers: Record<string, string>): Record<string, string> {
+	const sanitized: Record<string, string> = {};
+	for (const [name, value] of Object.entries(headers)) {
+		if (isSensitiveHeaderName(name)) continue;
+		const redactedValue = sanitizeCredentialText(String(value ?? ""));
+		sanitized[name] = redactedValue;
+	}
+	return sanitized;
+}
+
+/**
+ * Produce the explicit URL representation used by safe persisted recordings.
+ * Sensitive query values and URL user-info are removed, while path, host,
+ * query ordering, and non-sensitive query values remain stable for replay.
+ */
+export function sanitizeRecordingUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		if (parsed.username || parsed.password) {
+			parsed.username = REDACTED;
+			parsed.password = REDACTED;
+		}
+		for (const [name] of parsed.searchParams) {
+			if (SENSITIVE_QUERY_NAME.test(name)) parsed.searchParams.set(name, REDACTED);
+		}
+		return sanitizeCredentialTextFallback(parsed.toString());
+	} catch {
+		return sanitizeCredentialTextFallback(url);
+	}
+}

--- a/src/core/NetworkRecordingSanitizer.ts
+++ b/src/core/NetworkRecordingSanitizer.ts
@@ -20,16 +20,22 @@ const EXPLICIT_SENSITIVE_HEADERS = new Set([
 	"x-goog-api-key",
 	"client-secret",
 	"x-client-secret",
+	"x-amz-security-token",
+	"x-aws-ec2-metadata-token",
+	"x-csrf-token",
+	"x-xsrf-token",
 ]);
 
 const SENSITIVE_HEADER_NAME =
-	/^(?:x[-_])?(?:api[-_]?(?:key|token)|auth[-_]?token|access[-_]?token|secret[-_]?key|client[-_]?secret)$/i;
+	/^(?:x[-_])?(?:api[-_]?(?:key|token)|auth[-_]?token|(?:access|refresh|id)[-_]?token|secret[-_]?key|client[-_]?secret)$/i;
 const SENSITIVE_FIELD_NAME =
-	/^(?:access[-_]?token|auth[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|cookie|set[-_]?cookie)$/i;
+	/^(?:(?:access|refresh|id|auth)[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|cookie|set[-_]?cookie|session(?:[-_]?id)?|sid)$/i;
 const SENSITIVE_QUERY_NAME =
-	/^(?:access[-_]?token|auth[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization)$/i;
+	/^(?:(?:access|refresh|id|auth)[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|session(?:[-_]?id)?|sid|code)$/i;
 const LABELED_SECRET_VALUE =
-	/(\b(?:access[_-]?token|auth[_-]?token|api[_-]?(?:key|token)|client[_-]?secret|secret|token|password|passwd|authorization)\b\s*[:=]\s*["']?)(?:bearer\s+|basic\s+)?[^\s,;&}"']+/gi;
+	/(\b(?:(?:access|refresh|id|auth)[_-]?token|api[_-]?(?:key|token)|client[_-]?secret|secret|token|password|passwd|authorization|session(?:[_-]?id)?|sid)\b\s*[:=]\s*["']?)(?:bearer\s+|basic\s+)?[^\s,;&}"']+/gi;
+const SENSITIVE_PATH_VALUE =
+	/(\/(?:(?:access|refresh|id|auth)[_-]?token|api[_-]?(?:key|token)|client[_-]?secret|secret|token|password|passwd|authorization|session(?:[_-]?id)?)\/)[^/?#\s]+/gi;
 const AUTH_SCHEME_VALUE = /\b(bearer|basic)\s+[^\s,;&}"']+/gi;
 const JWT_VALUE = /\beyJ[\w-]{10,}\.[\w-]{10,}(?:\.[\w-]{10,})?\b/g;
 const URL_USER_INFO = /(https?:\/\/)[^/@\s]+@/gi;
@@ -77,6 +83,7 @@ function sanitizeJsonValue(value: unknown): { value: unknown; changed: boolean }
 function sanitizeCredentialTextFallback(value: string): string {
 	return value
 		.replace(URL_USER_INFO, `$1${REDACTED}@`)
+		.replace(SENSITIVE_PATH_VALUE, `$1${REDACTED}`)
 		.replace(LABELED_SECRET_VALUE, `$1${REDACTED}`)
 		.replace(AUTH_SCHEME_VALUE, `$1 ${REDACTED}`)
 		.replace(JWT_VALUE, REDACTED);
@@ -113,8 +120,8 @@ export function sanitizeRecordingHeaders(headers: Record<string, string>): Recor
 
 /**
  * Produce the explicit URL representation used by safe persisted recordings.
- * Sensitive query values and URL user-info are removed, while path, host,
- * query ordering, and non-sensitive query values remain stable for replay.
+ * Sensitive URL values are normalized while host, route shape, query ordering,
+ * and non-sensitive query values remain stable for replay.
  */
 export function sanitizeRecordingUrl(url: string): string {
 	try {

--- a/tests/unit/NetworkMockerPersistenceSecurity.test.ts
+++ b/tests/unit/NetworkMockerPersistenceSecurity.test.ts
@@ -28,7 +28,7 @@ function makeRoute() {
 }
 
 const credentialUrl =
-	"https://api-user:url-password-secret@example.com/api?token=query-secret-value&mode=full";
+	"https://api-user:url-password-secret@example.com/token/path-token-secret/api?token=query-secret-value&code=oauth-code-secret&mode=full";
 
 function rawRecording(): NetworkRecording {
 	return {
@@ -41,6 +41,7 @@ function rawRecording(): NetworkRecording {
 			cookie: "session=cookie-secret-value",
 			"content-type": "application/json",
 			"x-custom": "Bearer custom-header-secret-value",
+			"x-amz-security-token": "aws-session-secret-value",
 		},
 		responseHeaders: {
 			"content-type": "application/json",
@@ -50,6 +51,7 @@ function rawRecording(): NetworkRecording {
 		},
 		requestBody: JSON.stringify({
 			password: "body-password-secret",
+			refresh_token: "refresh-token-secret",
 			nested: { api_key: "nested-api-secret" },
 			keep: "visible",
 		}),
@@ -80,11 +82,15 @@ describe("NetworkMocker persisted credential safety", () => {
 
 		for (const secret of [
 			"url-password-secret",
+			"path-token-secret",
 			"query-secret-value",
+			"oauth-code-secret",
 			"request-secret-value",
 			"cookie-secret-value",
 			"custom-header-secret-value",
+			"aws-session-secret-value",
 			"body-password-secret",
+			"refresh-token-secret",
 			"nested-api-secret",
 			"response-token-secret",
 			"response-cookie-secret-value",
@@ -100,6 +106,7 @@ describe("NetworkMocker persisted credential safety", () => {
 		expect(recording.url).toContain("REDACTED");
 		expect(recording.requestHeaders.authorization).toBeUndefined();
 		expect(recording.requestHeaders.cookie).toBeUndefined();
+		expect(recording.requestHeaders["x-amz-security-token"]).toBeUndefined();
 		expect(recording.requestHeaders["x-custom"]).toBe("Bearer [REDACTED]");
 		expect(recording.responseHeaders["set-cookie"]).toBeUndefined();
 		expect(recording.responseHeaders["www-authenticate"]).toBeUndefined();

--- a/tests/unit/NetworkMockerPersistenceSecurity.test.ts
+++ b/tests/unit/NetworkMockerPersistenceSecurity.test.ts
@@ -57,7 +57,8 @@ function rawRecording(): NetworkRecording {
 		}),
 		responseBody: JSON.stringify({ token: "response-token-secret", ok: true }),
 		timestamp: 1,
-	};
+		futureCredential: "future-field-secret",
+	} as NetworkRecording;
 }
 
 describe("NetworkMocker persisted credential safety", () => {
@@ -94,6 +95,7 @@ describe("NetworkMocker persisted credential safety", () => {
 			"nested-api-secret",
 			"response-token-secret",
 			"response-cookie-secret-value",
+			"future-field-secret",
 		]) {
 			expect(persistedText).not.toContain(secret);
 		}
@@ -101,6 +103,7 @@ describe("NetworkMocker persisted credential safety", () => {
 		const persisted = JSON.parse(persistedText) as NetworkRecording[];
 		expect(persisted).toHaveLength(1);
 		const recording = persisted[0]!;
+		expect(recording).not.toHaveProperty("futureCredential");
 		expect(recording.replayUrl).toBe(recording.url);
 		expect(recording.url).toContain("mode=full");
 		expect(recording.url).toContain("REDACTED");

--- a/tests/unit/NetworkMockerPersistenceSecurity.test.ts
+++ b/tests/unit/NetworkMockerPersistenceSecurity.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { NetworkRecording } from "../../src/core/NetworkMocker.js";
+import { NetworkMocker } from "../../src/core/NetworkMocker.js";
+
+const fsMocks = vi.hoisted(() => ({
+	readFile: vi.fn(),
+	writeFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => fsMocks);
+
+function makePage() {
+	const handlers: Array<(route: any, request: any) => Promise<void>> = [];
+	return {
+		route: vi.fn(async (_pattern: string | RegExp, handler: (route: any, request: any) => Promise<void>) => {
+			handlers.push(handler);
+		}),
+		unroute: vi.fn(async () => {}),
+		_handlers: handlers,
+	};
+}
+
+function makeRoute() {
+	return {
+		fallback: vi.fn(async () => {}),
+		fulfill: vi.fn(async () => {}),
+	};
+}
+
+const credentialUrl =
+	"https://api-user:url-password-secret@example.com/api?token=query-secret-value&mode=full";
+
+function rawRecording(): NetworkRecording {
+	return {
+		id: "credential-recording",
+		url: credentialUrl,
+		method: "POST",
+		status: 200,
+		requestHeaders: {
+			authorization: "Bearer request-secret-value",
+			cookie: "session=cookie-secret-value",
+			"content-type": "application/json",
+			"x-custom": "Bearer custom-header-secret-value",
+		},
+		responseHeaders: {
+			"content-type": "application/json",
+			"content-length": "58",
+			"set-cookie": "session=response-cookie-secret-value; HttpOnly",
+			"www-authenticate": "Bearer realm=private",
+		},
+		requestBody: JSON.stringify({
+			password: "body-password-secret",
+			nested: { api_key: "nested-api-secret" },
+			keep: "visible",
+		}),
+		responseBody: JSON.stringify({ token: "response-token-secret", ok: true }),
+		timestamp: 1,
+	};
+}
+
+describe("NetworkMocker persisted credential safety", () => {
+	beforeEach(() => {
+		fsMocks.readFile.mockReset();
+		fsMocks.writeFile.mockReset();
+		fsMocks.writeFile.mockResolvedValue(undefined);
+	});
+
+	it("removes credential material from persisted recording JSON by default", async () => {
+		const page = makePage();
+		const mocker = new NetworkMocker({ context: {} as any, page: page as any });
+		fsMocks.readFile.mockResolvedValue(JSON.stringify([rawRecording()]));
+
+		await mocker.loadFromFile("/tmp/raw-recording.json");
+		await mocker.saveToFile("/tmp/safe-recording.json");
+
+		expect(fsMocks.writeFile).toHaveBeenCalledOnce();
+		const written = fsMocks.writeFile.mock.calls[0]?.[1];
+		expect(typeof written).toBe("string");
+		const persistedText = String(written);
+
+		for (const secret of [
+			"url-password-secret",
+			"query-secret-value",
+			"request-secret-value",
+			"cookie-secret-value",
+			"custom-header-secret-value",
+			"body-password-secret",
+			"nested-api-secret",
+			"response-token-secret",
+			"response-cookie-secret-value",
+		]) {
+			expect(persistedText).not.toContain(secret);
+		}
+
+		const persisted = JSON.parse(persistedText) as NetworkRecording[];
+		expect(persisted).toHaveLength(1);
+		const recording = persisted[0]!;
+		expect(recording.replayUrl).toBe(recording.url);
+		expect(recording.url).toContain("mode=full");
+		expect(recording.url).toContain("REDACTED");
+		expect(recording.requestHeaders.authorization).toBeUndefined();
+		expect(recording.requestHeaders.cookie).toBeUndefined();
+		expect(recording.requestHeaders["x-custom"]).toBe("Bearer [REDACTED]");
+		expect(recording.responseHeaders["set-cookie"]).toBeUndefined();
+		expect(recording.responseHeaders["www-authenticate"]).toBeUndefined();
+		expect(recording.responseHeaders["content-length"]).toBeUndefined();
+		expect(recording.requestBody).toContain("[REDACTED]");
+		expect(recording.requestBody).toContain("visible");
+		expect(recording.responseBody).toBe('{"token":"[REDACTED]","ok":true}');
+	});
+
+	it("replays a sanitized persisted recording for the original credential-bearing URL", async () => {
+		const sourcePage = makePage();
+		const sourceMocker = new NetworkMocker({ context: {} as any, page: sourcePage as any });
+		fsMocks.readFile.mockResolvedValue(JSON.stringify([rawRecording()]));
+		await sourceMocker.loadFromFile("/tmp/raw-recording.json");
+		await sourceMocker.saveToFile("/tmp/safe-recording.json");
+		const persistedText = String(fsMocks.writeFile.mock.calls[0]?.[1]);
+
+		const replayPage = makePage();
+		const replayMocker = new NetworkMocker({ context: {} as any, page: replayPage as any });
+		fsMocks.readFile.mockResolvedValue(persistedText);
+		await replayMocker.loadFromFile("/tmp/safe-recording.json");
+		await replayMocker.startReplaying();
+
+		const route = makeRoute();
+		const request = {
+			url: vi.fn(() => credentialUrl),
+			method: vi.fn(() => "POST"),
+		};
+		const handler = replayPage._handlers[0]!;
+		await handler(route, request);
+
+		expect(route.fulfill).toHaveBeenCalledOnce();
+		expect(route.fallback).not.toHaveBeenCalled();
+		expect(route.fulfill).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: 200,
+				body: '{"token":"[REDACTED]","ok":true}',
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- sanitize credential-bearing URLs, headers, and bodies before `NetworkMocker.saveToFile()` writes recordings
- persist an explicit sanitized `replayUrl` so credential-bearing requests still match after loading a safe recording
- remove sensitive request/response auth and cookie headers instead of persisting placeholder credential material
- drop stale `content-length` when response-body sanitization changes bytes
- add regression coverage proving raw secrets are absent from persisted JSON and sanitized recordings still replay

Closes #116.

## Security model
In-memory recordings remain unchanged for the active runtime. Persistence is safe-by-default: credential values are discarded, not moved to a sidecar or log. Sensitive URL values are normalized to a redacted replay representation so persisted recordings can match the same credential-shaped route without storing the original credential.

## Verification
CI + Docker are merge gates for this PR.