### PR TITLE
security: keep DOM fallback input values out of page state

### DIFF
--- a/src/core/PageStateCollector.ts
+++ b/src/core/PageStateCollector.ts
@@ -31,6 +31,18 @@ const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 	backoffMultiplier: 2,
 };
 
+const TEXT_ENTRY_ROLES = new Set(["textbox", "searchbox"]);
+
+function sanitizeNodeAttributes(
+	role: string,
+	attributes: Record<string, string | boolean>,
+): Record<string, string | boolean> {
+	if (!TEXT_ENTRY_ROLES.has(role.toLowerCase()) || attributes.value === undefined) return attributes;
+	const sanitized = { ...attributes };
+	delete sanitized.value;
+	return sanitized;
+}
+
 /**
  * Collects the full state of a Playwright page: URL, title, accessibility-tree
  * nodes (with retry and DOM-based fallback), interactive elements (including
@@ -168,7 +180,6 @@ export class PageStateCollector {
 					(e as HTMLInputElement).labels?.[0]?.textContent?.trim() ||
 					(e as HTMLInputElement).placeholder ||
 					e.getAttribute("aria-label")?.trim() ||
-					(e as HTMLInputElement).value ||
 					""
 				);
 			}
@@ -710,13 +721,14 @@ export class PageStateCollector {
 		if (typeof value === "string") {
 			const descriptor = this.parseAriaDescriptor(value);
 			if (descriptor?.boundingBox) {
+				const attributes = sanitizeNodeAttributes(descriptor.role, descriptor.attributes);
 				result.push({
 					id: `aria-${result.length}`,
 					role: descriptor.role,
 					name: descriptor.name,
 					description: "",
 					boundingBox: descriptor.boundingBox,
-					...(Object.keys(descriptor.attributes).length > 0 && { attributes: descriptor.attributes }),
+					...(Object.keys(attributes).length > 0 && { attributes }),
 					trust: "first-party",
 				});
 			}
@@ -728,10 +740,10 @@ export class PageStateCollector {
 		for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
 			const descriptor = this.parseAriaDescriptor(key);
 			if (descriptor?.boundingBox) {
-				const attributes = {
+				const attributes = sanitizeNodeAttributes(descriptor.role, {
 					...descriptor.attributes,
 					...this.collectAriaDirectiveAttributes(child),
-				};
+				});
 				if (typeof child === "string" && child.trim()) attributes.text = child.trim();
 
 				result.push({
@@ -776,7 +788,7 @@ export class PageStateCollector {
 					},
 					trust: "first-party",
 				};
-				if (node.value !== undefined) {
+				if (node.value !== undefined && !TEXT_ENTRY_ROLES.has(String(node.role).toLowerCase())) {
 					newNode.attributes = { value: String(node.value) };
 				}
 				result.push(newNode);

--- a/src/core/PageStateCollector.ts
+++ b/src/core/PageStateCollector.ts
@@ -31,18 +31,6 @@ const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 	backoffMultiplier: 2,
 };
 
-const TEXT_ENTRY_ROLES = new Set(["textbox", "searchbox"]);
-
-function sanitizeNodeAttributes(
-	role: string,
-	attributes: Record<string, string | boolean>,
-): Record<string, string | boolean> {
-	if (!TEXT_ENTRY_ROLES.has(role.toLowerCase()) || attributes.value === undefined) return attributes;
-	const sanitized = { ...attributes };
-	delete sanitized.value;
-	return sanitized;
-}
-
 /**
  * Collects the full state of a Playwright page: URL, title, accessibility-tree
  * nodes (with retry and DOM-based fallback), interactive elements (including
@@ -721,14 +709,13 @@ export class PageStateCollector {
 		if (typeof value === "string") {
 			const descriptor = this.parseAriaDescriptor(value);
 			if (descriptor?.boundingBox) {
-				const attributes = sanitizeNodeAttributes(descriptor.role, descriptor.attributes);
 				result.push({
 					id: `aria-${result.length}`,
 					role: descriptor.role,
 					name: descriptor.name,
 					description: "",
 					boundingBox: descriptor.boundingBox,
-					...(Object.keys(attributes).length > 0 && { attributes }),
+					...(Object.keys(descriptor.attributes).length > 0 && { attributes: descriptor.attributes }),
 					trust: "first-party",
 				});
 			}
@@ -740,10 +727,10 @@ export class PageStateCollector {
 		for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
 			const descriptor = this.parseAriaDescriptor(key);
 			if (descriptor?.boundingBox) {
-				const attributes = sanitizeNodeAttributes(descriptor.role, {
+				const attributes = {
 					...descriptor.attributes,
 					...this.collectAriaDirectiveAttributes(child),
-				});
+				};
 				if (typeof child === "string" && child.trim()) attributes.text = child.trim();
 
 				result.push({
@@ -788,7 +775,7 @@ export class PageStateCollector {
 					},
 					trust: "first-party",
 				};
-				if (node.value !== undefined && !TEXT_ENTRY_ROLES.has(String(node.role).toLowerCase())) {
+				if (node.value !== undefined) {
 					newNode.attributes = { value: String(node.value) };
 				}
 				result.push(newNode);

--- a/tests/unit/PageStateCollectorCredentialSafety.test.ts
+++ b/tests/unit/PageStateCollectorCredentialSafety.test.ts
@@ -63,8 +63,8 @@ function makeInputHandle(options: { value: string; label?: string; placeholder?:
 	};
 }
 
-describe("PageStateCollector credential value safety", () => {
-	it("does not expose an unlabeled password input live value through DOM fallback", async () => {
+describe("PageStateCollector DOM fallback credential safety", () => {
+	it("does not expose an unlabeled password input live value", async () => {
 		const secret = "correct-horse-battery-staple";
 		const input = makeInputHandle({ value: secret });
 		const page = makeBasePage({ $$: vi.fn(async () => [input]) });
@@ -74,11 +74,11 @@ describe("PageStateCollector credential value safety", () => {
 
 		expect(state.nodes).toHaveLength(1);
 		expect(state.nodes[0]?.name).toBe("");
-		expect(state.interactiveElements[0]?.text).toBe("");
+		expect((state.interactiveElements[0] as any)?.text).toBe("");
 		expect(JSON.stringify(state)).not.toContain(secret);
 	});
 
-	it("preserves useful DOM labels without exposing the live input value", async () => {
+	it("preserves useful labels without exposing the live input value", async () => {
 		const secret = "typed-user-value";
 		const input = makeInputHandle({ value: secret, label: "Account password" });
 		const page = makeBasePage({ $$: vi.fn(async () => [input]) });
@@ -87,74 +87,7 @@ describe("PageStateCollector credential value safety", () => {
 		const state = await collector.collect();
 
 		expect(state.nodes[0]?.name).toBe("Account password");
-		expect(state.interactiveElements[0]?.text).toBe("Account password");
+		expect((state.interactiveElements[0] as any)?.text).toBe("Account password");
 		expect(JSON.stringify(state)).not.toContain(secret);
-	});
-
-	it("omits legacy AX values for text-entry controls", async () => {
-		const secret = "legacy-ax-secret";
-		const page = makeBasePage({
-			accessibility: {
-				snapshot: vi.fn(async () => ({
-					role: "WebArea",
-					name: "",
-					children: [
-						{
-							role: "textbox",
-							name: "Password",
-							value: secret,
-							box: { x: 0, y: 0, width: 200, height: 30 },
-						},
-					],
-				})),
-			},
-		});
-		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
-
-		const state = await collector.collect();
-
-		expect(state.nodes[0]?.name).toBe("Password");
-		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
-		expect(JSON.stringify(state)).not.toContain(secret);
-	});
-
-	it("omits modern ARIA /value directives for text-entry controls", async () => {
-		const secret = "modern-aria-secret";
-		const ariaSnapshot = `- textbox "Password" [box=0,0,200,30]:\n  - /value: ${secret}`;
-		const page = makeBasePage({
-			ariaSnapshot: vi.fn(async () => ariaSnapshot),
-			accessibility: undefined,
-		});
-		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
-
-		const state = await collector.collect();
-
-		expect(state.nodes[0]?.name).toBe("Password");
-		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
-		expect(JSON.stringify(state)).not.toContain(secret);
-	});
-
-	it("keeps non-text semantic AX values such as slider position", async () => {
-		const page = makeBasePage({
-			accessibility: {
-				snapshot: vi.fn(async () => ({
-					role: "WebArea",
-					name: "",
-					children: [
-						{
-							role: "slider",
-							name: "Volume",
-							value: 42,
-							box: { x: 0, y: 0, width: 200, height: 30 },
-						},
-					],
-				})),
-			},
-		});
-		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
-
-		const state = await collector.collect();
-
-		expect(state.nodes[0]?.attributes?.value).toBe("42");
 	});
 });

--- a/tests/unit/PageStateCollectorCredentialSafety.test.ts
+++ b/tests/unit/PageStateCollectorCredentialSafety.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PageStateCollector } from "../../src/core/PageStateCollector.js";
+
+const FAST_OPTS = {
+	retry: { maxRetries: 0, initialDelayMs: 1, maxDelayMs: 1, backoffMultiplier: 1 },
+	useDomFallback: true,
+	domFallbackThreshold: 1,
+};
+
+function makeBasePage(overrides: Record<string, unknown> = {}) {
+	return {
+		url: vi.fn(() => "https://example.com/login"),
+		title: vi.fn(async () => "Login"),
+		isClosed: vi.fn(() => false),
+		on: vi.fn(),
+		accessibility: { snapshot: vi.fn(async () => null) },
+		$$: vi.fn(async () => []),
+		$$eval: vi.fn(async () => []),
+		evaluate: vi.fn(async () => []),
+		...overrides,
+	};
+}
+
+const previousInput = globalThis.HTMLInputElement;
+const previousTextarea = globalThis.HTMLTextAreaElement;
+
+afterEach(() => {
+	if (previousInput === undefined) delete (globalThis as Record<string, unknown>).HTMLInputElement;
+	else globalThis.HTMLInputElement = previousInput;
+	if (previousTextarea === undefined) delete (globalThis as Record<string, unknown>).HTMLTextAreaElement;
+	else globalThis.HTMLTextAreaElement = previousTextarea;
+});
+
+function installFormControlGlobals() {
+	class FakeInputElement {}
+	class FakeTextAreaElement {}
+	globalThis.HTMLInputElement = FakeInputElement as unknown as typeof HTMLInputElement;
+	globalThis.HTMLTextAreaElement = FakeTextAreaElement as unknown as typeof HTMLTextAreaElement;
+	return { FakeInputElement };
+}
+
+function makeInputHandle(options: { value: string; label?: string; placeholder?: string; ariaLabel?: string; name?: string }) {
+	const { FakeInputElement } = installFormControlGlobals();
+	const input = new FakeInputElement() as FakeInputElement & Record<string, any>;
+	input.id = "";
+	input.tagName = "INPUT";
+	input.labels = options.label ? [{ textContent: options.label }] : [];
+	input.placeholder = options.placeholder ?? "";
+	input.value = options.value;
+	input.parentElement = null;
+	input.getAttribute = (name: string) => {
+		if (name === "aria-label") return options.ariaLabel ?? null;
+		if (name === "name") return options.name ?? "password";
+		if (name === "type") return "password";
+		return null;
+	};
+
+	return {
+		evaluate: vi.fn(async (callback: (element: any) => unknown) => callback(input)),
+		isVisible: vi.fn(async () => true),
+		boundingBox: vi.fn(async () => ({ x: 1, y: 2, width: 160, height: 32 })),
+		isDisabled: vi.fn(async () => false),
+	};
+}
+
+describe("PageStateCollector credential value safety", () => {
+	it("does not expose an unlabeled password input live value through DOM fallback", async () => {
+		const secret = "correct-horse-battery-staple";
+		const input = makeInputHandle({ value: secret });
+		const page = makeBasePage({ $$: vi.fn(async () => [input]) });
+		const collector = new PageStateCollector(page as any, FAST_OPTS);
+
+		const state = await collector.collect();
+
+		expect(state.nodes).toHaveLength(1);
+		expect(state.nodes[0]?.name).toBe("");
+		expect(state.interactiveElements[0]?.text).toBe("");
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("preserves useful DOM labels without exposing the live input value", async () => {
+		const secret = "typed-user-value";
+		const input = makeInputHandle({ value: secret, label: "Account password" });
+		const page = makeBasePage({ $$: vi.fn(async () => [input]) });
+		const collector = new PageStateCollector(page as any, FAST_OPTS);
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.name).toBe("Account password");
+		expect(state.interactiveElements[0]?.text).toBe("Account password");
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("omits legacy AX values for text-entry controls", async () => {
+		const secret = "legacy-ax-secret";
+		const page = makeBasePage({
+			accessibility: {
+				snapshot: vi.fn(async () => ({
+					role: "WebArea",
+					name: "",
+					children: [
+						{
+							role: "textbox",
+							name: "Password",
+							value: secret,
+							box: { x: 0, y: 0, width: 200, height: 30 },
+						},
+					],
+				})),
+			},
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.name).toBe("Password");
+		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("omits modern ARIA /value directives for text-entry controls", async () => {
+		const secret = "modern-aria-secret";
+		const ariaSnapshot = `- textbox "Password" [box=0,0,200,30]:\n  - /value: ${secret}`;
+		const page = makeBasePage({
+			ariaSnapshot: vi.fn(async () => ariaSnapshot),
+			accessibility: undefined,
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.name).toBe("Password");
+		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("keeps non-text semantic AX values such as slider position", async () => {
+		const page = makeBasePage({
+			accessibility: {
+				snapshot: vi.fn(async () => ({
+					role: "WebArea",
+					name: "",
+					children: [
+						{
+							role: "slider",
+							name: "Volume",
+							value: 42,
+							box: { x: 0, y: 0, width: 200, height: 30 },
+						},
+					],
+				})),
+			},
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.attributes?.value).toBe("42");
+	});
+});


### PR DESCRIPTION
## Summary
- stop `PageStateCollector` DOM fallback from using a live input/textarea `.value` as the node name
- keep labels, placeholders, and `aria-label` context unchanged
- add regression coverage for an unlabeled password input and a labeled password input
- keep the existing accessibility snapshot value contract unchanged; adjacent AX/ARIA value persistence is tracked separately in #120

Closes #118.

## Security impact
An unlabeled form control could previously fall through to its current `.value`, which meant a password or other typed secret could enter `TaloxNode.name` and then `interactiveElements[].text`. DOM fallback is now metadata-only for form-control naming.

## Scope
The production diff is intentionally one deletion. This avoids silently breaking the existing `TaloxNode.attributes.value` behavior used by accessibility snapshots while still closing the confirmed DOM fallback leak.

## Verification
- branch is based directly on current `main`
- source diff checked against `main`: exactly one production-line deletion
- new test file passes TypeScript transpile/syntax validation
- full repository CI + Docker remain merge gates