### PR TITLE
security: scrub accessibility password values

### DIFF
--- a/src/core/PageStateCollector.ts
+++ b/src/core/PageStateCollector.ts
@@ -31,6 +31,8 @@ const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 	backoffMultiplier: 2,
 };
 
+const TEXT_ENTRY_ROLES = new Set(["textbox", "searchbox"]);
+
 /**
  * Collects the full state of a Playwright page: URL, title, accessibility-tree
  * nodes (with retry and DOM-based fallback), interactive elements (including
@@ -281,7 +283,6 @@ export class PageStateCollector {
 							queryShadowHosts(host.shadowRoot, currentPath);
 						}
 					}
-				}
 
 				queryShadowHosts(document);
 				return results;
@@ -790,6 +791,68 @@ export class PageStateCollector {
 		return result;
 	}
 
+	private stripTextEntryValueAttributes(node: TaloxNode): TaloxNode {
+		if (!TEXT_ENTRY_ROLES.has(node.role.toLowerCase()) || !node.attributes) return node;
+		if (node.attributes.value === undefined && node.attributes.text === undefined) return node;
+
+		const attributes = { ...node.attributes };
+		delete attributes.value;
+		delete attributes.text;
+		const sanitized = { ...node };
+		if (Object.keys(attributes).length > 0) sanitized.attributes = attributes;
+		else delete sanitized.attributes;
+		return sanitized;
+	}
+
+	private boxesMatch(
+		first: { x: number; y: number; width: number; height: number },
+		second: { x: number; y: number; width: number; height: number },
+	): boolean {
+		const intersectionWidth = Math.max(
+			0,
+			Math.min(first.x + first.width, second.x + second.width) - Math.max(first.x, second.x),
+		);
+		const intersectionHeight = Math.max(
+			0,
+			Math.min(first.y + first.height, second.y + second.height) - Math.max(first.y, second.y),
+		);
+		const intersectionArea = intersectionWidth * intersectionHeight;
+		const smallerArea = Math.min(first.width * first.height, second.width * second.height);
+		return smallerArea > 0 && intersectionArea / smallerArea >= 0.8;
+	}
+
+	private async scrubPasswordInputValues(nodes: TaloxNode[]): Promise<TaloxNode[]> {
+		const hasTextEntryValues = nodes.some(
+			(node) =>
+				TEXT_ENTRY_ROLES.has(node.role.toLowerCase()) &&
+				(node.attributes?.value !== undefined || node.attributes?.text !== undefined),
+		);
+		if (!hasTextEntryValues) return nodes;
+
+		let passwordBoxes: Array<{ x: number; y: number; width: number; height: number }>;
+		try {
+			passwordBoxes = await this.page.$$eval('input[type="password"]', (elements) =>
+				elements
+					.map((element) => {
+						const rect = element.getBoundingClientRect();
+						return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+					})
+					.filter((box) => box.width > 0 && box.height > 0),
+			);
+		} catch {
+			// If DOM classification fails after an accessibility snapshot already
+			// captured live values, fail closed rather than returning unknown secrets.
+			return nodes.map((node) => this.stripTextEntryValueAttributes(node));
+		}
+
+		if (passwordBoxes.length === 0) return nodes;
+		return nodes.map((node) => {
+			if (!TEXT_ENTRY_ROLES.has(node.role.toLowerCase())) return node;
+			if (!passwordBoxes.some((box) => this.boxesMatch(node.boundingBox, box))) return node;
+			return this.stripTextEntryValueAttributes(node);
+		});
+	}
+
 	private async collectWithRetry(
 		nodeThreshold: number,
 		maxRetriesOverride?: number,
@@ -905,6 +968,10 @@ export class PageStateCollector {
 			// Wait for 500ms before retrying (SPA hydration/loading gap)
 			await this.sleep(500);
 			collectionAttempts++;
+		}
+
+		if (!shouldUseFallback && nodes.length > 0) {
+			nodes = await this.scrubPasswordInputValues(nodes);
 		}
 
 		let interactiveElements: Array<{ id: string; tagName: string; boundingBox: any }> = [];

--- a/src/core/PageStateCollector.ts
+++ b/src/core/PageStateCollector.ts
@@ -283,6 +283,7 @@ export class PageStateCollector {
 							queryShadowHosts(host.shadowRoot, currentPath);
 						}
 					}
+				}
 
 				queryShadowHosts(document);
 				return results;

--- a/tests/unit/PageStateCollectorCredentialSafety.test.ts
+++ b/tests/unit/PageStateCollectorCredentialSafety.test.ts
@@ -7,6 +7,8 @@ const FAST_OPTS = {
 	domFallbackThreshold: 1,
 };
 
+type Box = { x: number; y: number; width: number; height: number };
+
 function makeBasePage(overrides: Record<string, unknown> = {}) {
 	return {
 		url: vi.fn(() => "https://example.com/login"),
@@ -19,6 +21,10 @@ function makeBasePage(overrides: Record<string, unknown> = {}) {
 		evaluate: vi.fn(async () => []),
 		...overrides,
 	};
+}
+
+function makePasswordAwareDollarEval(passwordBoxes: Box[]) {
+	return vi.fn(async (selector: string) => (selector === 'input[type="password"]' ? passwordBoxes : []));
 }
 
 const previousInput = globalThis.HTMLInputElement;
@@ -88,6 +94,77 @@ describe("PageStateCollector DOM fallback credential safety", () => {
 
 		expect(state.nodes[0]?.name).toBe("Account password");
 		expect((state.interactiveElements[0] as any)?.text).toBe("Account password");
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+});
+
+describe("PageStateCollector accessibility credential safety", () => {
+	const passwordBox = { x: 10, y: 20, width: 200, height: 30 };
+	const emailBox = { x: 10, y: 70, width: 200, height: 30 };
+
+	it("scrubs legacy AX password values while preserving ordinary textbox values", async () => {
+		const secret = "legacy-password-secret";
+		const axSnapshot = {
+			role: "WebArea",
+			name: "",
+			children: [
+				{ role: "textbox", name: "Password", value: secret, box: passwordBox },
+				{ role: "textbox", name: "Email", value: "user@test.com", box: emailBox },
+			],
+		};
+		const page = makeBasePage({
+			accessibility: { snapshot: vi.fn(async () => axSnapshot) },
+			$$eval: makePasswordAwareDollarEval([passwordBox]),
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.name).toBe("Password");
+		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
+		expect(state.nodes[1]?.attributes?.value).toBe("user@test.com");
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("scrubs modern ARIA textbox text for the matching password DOM box", async () => {
+		const secret = "modern-password-secret";
+		const ariaSnapshot = [
+			`- textbox "Password" [box=10,20,200,30]: ${secret}`,
+			'- textbox "Email" [box=10,70,200,30]: user@test.com',
+		].join("\n");
+		const page = makeBasePage({
+			ariaSnapshot: vi.fn(async () => ariaSnapshot),
+			accessibility: undefined,
+			$$eval: makePasswordAwareDollarEval([passwordBox]),
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.name).toBe("Password");
+		expect(state.nodes[0]?.attributes?.text).toBeUndefined();
+		expect(state.nodes[1]?.attributes?.text).toBe("user@test.com");
+		expect(JSON.stringify(state)).not.toContain(secret);
+	});
+
+	it("fails closed for text-entry values when password DOM detection errors", async () => {
+		const secret = "password-during-dom-error";
+		const axSnapshot = {
+			role: "WebArea",
+			name: "",
+			children: [{ role: "textbox", name: "Password", value: secret, box: passwordBox }],
+		};
+		const page = makeBasePage({
+			accessibility: { snapshot: vi.fn(async () => axSnapshot) },
+			$$eval: vi.fn(async () => {
+				throw new Error("DOM unavailable");
+			}),
+		});
+		const collector = new PageStateCollector(page as any, { ...FAST_OPTS, useDomFallback: false });
+
+		const state = await collector.collect();
+
+		expect(state.nodes[0]?.attributes?.value).toBeUndefined();
 		expect(JSON.stringify(state)).not.toContain(secret);
 	});
 });


### PR DESCRIPTION
## Summary
- classify real `input[type="password"]` elements from the DOM by bounding box
- scrub only overlapping accessibility text-entry values from legacy AX and modern ARIA state
- preserve ordinary textbox values such as email addresses for compatibility
- fail closed by stripping text-entry values when password DOM classification itself fails
- add regression coverage for legacy AX, modern ARIA, preserved non-password values, and DOM-classification failure

Closes #120.

## Why this shape
Talox currently uses Playwright 1.62.1. Its ARIA snapshot implementation places `element.value` into text-entry nodes and does not exclude password inputs. Talox also already has a contract test preserving ordinary textbox values, so deleting all textbox values would trade a security fix for a compatibility regression.

This patch uses DOM element type as the authority and bounding-box overlap to identify the corresponding accessibility node. That closes the password leak without heuristically guessing from field names or removing useful non-sensitive values.

## Verification
- branch is directly based on current `main`
- diff against `main`: 68 production additions / 1 deletion, 77 test additions
- full CI + Docker are merge gates
- PR diff will be checked for accidental full-file changes before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Password values are now removed from accessibility snapshots when they overlap password input fields.
  * Credential values are scrubbed across legacy and modern accessibility output, including fallback scenarios.

* **Bug Fixes**
  * Ordinary text field values remain available while password values are protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->