### PR TITLE
security: sanitize agent-facing page state credentials

### DIFF
--- a/src/core/NetworkRecordingSanitizer.ts
+++ b/src/core/NetworkRecordingSanitizer.ts
@@ -31,7 +31,7 @@ const SENSITIVE_HEADER_NAME =
 const SENSITIVE_FIELD_NAME =
 	/^(?:(?:access|refresh|id|auth)[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|cookie|set[-_]?cookie|session(?:[-_]?id)?|sid)$/i;
 const SENSITIVE_QUERY_NAME =
-	/^(?:(?:access|refresh|id|auth)[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|session(?:[-_]?id)?|sid|code)$/i;
+	/^(?:(?:access|refresh|id|auth)[-_]?token|api[-_]?(?:key|token)|client[-_]?secret|secret|token|password|passwd|authorization|session(?:[-_]?id)?|sid|code|credential|sig(?:nature)?|policy|key[-_]?pair[-_]?id|googleaccessid|awsaccesskeyid|x[-_]?(?:amz|goog)[-_]?(?:signature|credential|security[-_]?token))$/i;
 const LABELED_SECRET_VALUE =
 	/(\b(?:(?:access|refresh|id|auth)[_-]?token|api[_-]?(?:key|token)|client[_-]?secret|secret|token|password|passwd|authorization|session(?:[_-]?id)?|sid)\b\s*[:=]\s*["']?)(?:bearer\s+|basic\s+)?[^\s,;&}"']+/gi;
 const SENSITIVE_PATH_VALUE =

--- a/src/core/NetworkRecordingSanitizer.ts
+++ b/src/core/NetworkRecordingSanitizer.ts
@@ -121,20 +121,29 @@ export function sanitizeRecordingHeaders(headers: Record<string, string>): Recor
 /**
  * Produce the explicit URL representation used by safe persisted recordings.
  * Sensitive URL values are normalized while host, route shape, query ordering,
- * and non-sensitive query values remain stable for replay.
+ * and non-sensitive query values remain stable for replay. Benign URLs are
+ * returned byte-for-byte so redaction does not introduce unrelated URL
+ * canonicalization (for example adding a trailing slash to a bare origin).
  */
 export function sanitizeRecordingUrl(url: string): string {
+	const fallbackSanitized = sanitizeCredentialTextFallback(url);
 	try {
 		const parsed = new URL(url);
+		let changed = fallbackSanitized !== url;
 		if (parsed.username || parsed.password) {
 			parsed.username = REDACTED;
 			parsed.password = REDACTED;
+			changed = true;
 		}
 		for (const [name] of parsed.searchParams) {
-			if (SENSITIVE_QUERY_NAME.test(name)) parsed.searchParams.set(name, REDACTED);
+			if (SENSITIVE_QUERY_NAME.test(name)) {
+				parsed.searchParams.set(name, REDACTED);
+				changed = true;
+			}
 		}
+		if (!changed) return url;
 		return sanitizeCredentialTextFallback(parsed.toString());
 	} catch {
-		return sanitizeCredentialTextFallback(url);
+		return fallbackSanitized;
 	}
 }

--- a/src/core/PageStateCollector.ts
+++ b/src/core/PageStateCollector.ts
@@ -1,6 +1,8 @@
 import { load as loadYaml } from "js-yaml";
 import type { Page, Response } from "playwright-core";
 import type { CursorDetectionMethod, TaloxNode, TaloxPageState } from "../types/index.js";
+import { sanitizeRecordingUrl } from "./NetworkRecordingSanitizer.js";
+import { sanitizeSessionArtifact } from "./SessionArtifactSanitizer.js";
 
 export interface RetryOptions {
 	maxRetries: number;
@@ -935,7 +937,7 @@ export class PageStateCollector {
 		}
 
 		const collectStart = Date.now();
-		const url = this.page.url();
+		const url = sanitizeRecordingUrl(this.page.url());
 		const title = await this.page.title();
 		// Browser-synthetic documents do not have an application hydration lifecycle.
 		// Retrying an empty AX tree here only adds deterministic backoff delay. Keep
@@ -1017,8 +1019,13 @@ export class PageStateCollector {
 			url,
 			title,
 			timestamp: collectedAt,
-			console: { errors: [...this.consoleErrors] },
-			network: { failedRequests: [...this.failedRequests] },
+			console: { errors: sanitizeSessionArtifact([...this.consoleErrors]) },
+			network: {
+				failedRequests: this.failedRequests.map((request) => ({
+					...request,
+					url: sanitizeRecordingUrl(request.url),
+				})),
+			},
 			nodes,
 			interactiveElements: allInteractiveElements,
 			bugs: [],

--- a/tests/unit/NetworkRecordingSanitizerUrl.test.ts
+++ b/tests/unit/NetworkRecordingSanitizerUrl.test.ts
@@ -19,4 +19,32 @@ describe("sanitizeRecordingUrl representation stability", () => {
 		expect(sanitized).toContain("mode=debug");
 		expect(sanitizeRecordingUrl(raw)).toBe(sanitized);
 	});
+
+	it("redacts common cloud signed-URL credentials", () => {
+		const cases = [
+			{
+				url: "https://s3.example.com/file?X-Amz-Signature=aws-signature-secret&X-Amz-Credential=aws-credential-secret&X-Amz-Security-Token=aws-session-secret&mode=download",
+				secrets: ["aws-signature-secret", "aws-credential-secret", "aws-session-secret"],
+			},
+			{
+				url: "https://storage.googleapis.com/bucket/file?X-Goog-Signature=gcs-signature-secret&X-Goog-Credential=gcs-credential-secret&mode=download",
+				secrets: ["gcs-signature-secret", "gcs-credential-secret"],
+			},
+			{
+				url: "https://account.blob.core.windows.net/container/file?sv=2026-01-01&sig=azure-signature-secret&sp=r&mode=download",
+				secrets: ["azure-signature-secret"],
+			},
+			{
+				url: "https://cdn.example.com/file?Signature=cloudfront-signature-secret&Key-Pair-Id=cloudfront-key-id&Policy=cloudfront-policy-secret&mode=download",
+				secrets: ["cloudfront-signature-secret", "cloudfront-key-id", "cloudfront-policy-secret"],
+			},
+		];
+
+		for (const { url, secrets } of cases) {
+			const sanitized = sanitizeRecordingUrl(url);
+			for (const secret of secrets) expect(sanitized).not.toContain(secret);
+			expect(sanitized).toContain("mode=download");
+			expect(sanitized).toContain("REDACTED");
+		}
+	});
 });

--- a/tests/unit/NetworkRecordingSanitizerUrl.test.ts
+++ b/tests/unit/NetworkRecordingSanitizerUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeRecordingUrl } from "../../src/core/NetworkRecordingSanitizer.js";
+
+describe("sanitizeRecordingUrl representation stability", () => {
+	it("preserves benign URLs byte-for-byte", () => {
+		expect(sanitizeRecordingUrl("https://example.com")).toBe("https://example.com");
+		expect(sanitizeRecordingUrl("https://example.com/path?mode=debug#section")).toBe(
+			"https://example.com/path?mode=debug#section",
+		);
+	});
+
+	it("still redacts credential-bearing URLs deterministically", () => {
+		const raw = "https://user:password-secret@example.com/callback?token=query-secret&code=oauth-secret&mode=debug";
+		const sanitized = sanitizeRecordingUrl(raw);
+
+		expect(sanitized).not.toContain("password-secret");
+		expect(sanitized).not.toContain("query-secret");
+		expect(sanitized).not.toContain("oauth-secret");
+		expect(sanitized).toContain("mode=debug");
+		expect(sanitizeRecordingUrl(raw)).toBe(sanitized);
+	});
+});

--- a/tests/unit/PageStateCredentialBoundary.test.ts
+++ b/tests/unit/PageStateCredentialBoundary.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { PageStateCollector } from "../../src/core/PageStateCollector.js";
+import { PerceptionStack } from "../../src/core/PerceptionStack.js";
+
+const secrets = {
+	userInfo: "page-url-password",
+	queryToken: "page-query-token",
+	oauthCode: "page-oauth-code",
+	consoleBearer: "console-bearer-secret",
+};
+
+function credentialUrl(): string {
+	return `https://agent-user:${secrets.userInfo}@example.com/callback?token=${secrets.queryToken}&code=${secrets.oauthCode}&mode=debug`;
+}
+
+function makePage() {
+	const handlers = new Map<string, (payload: any) => void>();
+	const page = {
+		url: vi.fn(() => credentialUrl()),
+		title: vi.fn(async () => "Credential callback"),
+		isClosed: vi.fn(() => false),
+		on: vi.fn((event: string, handler: (payload: any) => void) => {
+			handlers.set(event, handler);
+		}),
+		accessibility: {
+			snapshot: vi.fn(async () => ({ role: "WebArea", name: "", children: [] })),
+		},
+		$$: vi.fn(async () => []),
+		$$eval: vi.fn(async () => []),
+		evaluate: vi.fn(async () => []),
+	};
+	return { page, handlers };
+}
+
+function emitCredentialBearingDiagnostics(handlers: Map<string, (payload: any) => void>): void {
+	handlers.get("console")?.({
+		type: () => "error",
+		text: () => `Authorization: Bearer ${secrets.consoleBearer} callback=${credentialUrl()}`,
+	});
+	handlers.get("response")?.({
+		status: () => 401,
+		url: () => credentialUrl(),
+		request: () => ({ resourceType: () => "xhr" }),
+	});
+}
+
+function expectCredentialSafeState(state: unknown): void {
+	const serialized = JSON.stringify(state);
+	for (const secret of Object.values(secrets)) expect(serialized).not.toContain(secret);
+	expect(serialized).toContain("REDACTED");
+	expect(serialized).toContain("mode=debug");
+}
+
+describe("agent-facing page state credential boundary", () => {
+	it("sanitizes current URL, failed request URLs, and console diagnostics", async () => {
+		const { page, handlers } = makePage();
+		const collector = new PageStateCollector(page as any, {
+			useDomFallback: false,
+			domFallbackThreshold: 0,
+			retry: { maxRetries: 0 },
+		});
+		emitCredentialBearingDiagnostics(handlers);
+
+		const state = await collector.collect();
+
+		expectCredentialSafeState(state);
+		expect(state.url).toContain("mode=debug");
+		expect(state.console.errors).toHaveLength(1);
+		expect(state.network.failedRequests).toHaveLength(1);
+	});
+
+	it("keeps medium perception output credential-safe", async () => {
+		const { page, handlers } = makePage();
+		const collector = new PageStateCollector(page as any, {
+			useDomFallback: false,
+			domFallbackThreshold: 0,
+			retry: { maxRetries: 0 },
+		});
+		emitCredentialBearingDiagnostics(handlers);
+		const stack = new PerceptionStack(collector, null);
+
+		const state = await stack.collect("medium");
+
+		expectCredentialSafeState(state);
+		expect(state.perceptionLayers.network).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- sanitize the current page URL before it enters `TaloxPageState`
- sanitize failed-request URLs at the browser→agent state boundary
- redact credential-shaped console diagnostics with the existing shared session-artifact sanitizer
- keep the live browser URL, console events, and request/response objects unchanged internally
- preserve non-sensitive route/query context such as `mode=debug`
- add regression coverage for direct `PageStateCollector.collect()` and `PerceptionStack` medium output

Closes #124.

## Security model
This hardens the agent-facing structured-state contract rather than mutating browser runtime state. Existing shared sanitizers are reused, so URL/query/Bearer/Basic/JWT redaction stays consistent with network recordings and observe artifacts.

## Verification
- branch is based directly on current `main`
- pre-PR compare: 10 production additions / 3 intended replacements, plus 87 test lines
- full CI + Docker are merge gates
- exact PR diff will be audited before merge for accidental full-file changes