### PR TITLE
security: keep typed secrets out of action artifacts

### DIFF
--- a/src/core/ArtifactBuilder.ts
+++ b/src/core/ArtifactBuilder.ts
@@ -1,3 +1,8 @@
+import { sanitizeSessionArtifact } from "./SessionArtifactSanitizer.js";
+
+const REDACTED = "[REDACTED]";
+const TEXT_ENTRY_ACTIONS = new Set(["type", "input", "fill"]);
+
 export interface VisualContext {
 	mouseX?: number;
 	mouseY?: number;
@@ -44,7 +49,7 @@ export class ArtifactBuilder {
 	addAction(type: string, payload: any, durationMs?: number, visualContext?: VisualContext) {
 		const action: StoredAction = {
 			type,
-			payload,
+			payload: this.sanitizeActionPayload(type, payload),
 			timestamp: new Date().toISOString(),
 		};
 		if (durationMs !== undefined) {
@@ -89,7 +94,7 @@ export class ArtifactBuilder {
 	getTrace() {
 		return {
 			id: `trace-${Date.now()}`,
-			actions: [...this.actions],
+			actions: sanitizeSessionArtifact(this.actions),
 		};
 	}
 
@@ -142,22 +147,24 @@ export class ArtifactBuilder {
 		return typeMap[type] || type;
 	}
 
-	private sanitizePayload(payload: any): Record<string, any> {
-		if (!payload) return {};
-
-		const sensitiveKeys = ["password", "token", "secret", "apiKey", "authorization", "cookie"];
-		const sanitized: Record<string, any> = {};
-
-		for (const [key, value] of Object.entries(payload)) {
-			const lowerKey = key.toLowerCase();
-			if (sensitiveKeys.some((sk) => lowerKey.includes(sk))) {
-				sanitized[key] = "[REDACTED]";
-			} else {
-				sanitized[key] = value;
-			}
+	private sanitizeActionPayload(type: string, payload: any): Record<string, any> {
+		const sanitized = this.sanitizePayload(payload);
+		if (!TEXT_ENTRY_ACTIONS.has(type.toLowerCase()) || !payload || typeof payload !== "object" || Array.isArray(payload)) {
+			return sanitized;
 		}
 
+		for (const field of ["text", "value"] as const) {
+			const originalValue = payload[field];
+			if (typeof originalValue !== "string") continue;
+			sanitized[field] = REDACTED;
+			sanitized[`${field}Length`] = originalValue.length;
+		}
 		return sanitized;
+	}
+
+	private sanitizePayload(payload: any): Record<string, any> {
+		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return {};
+		return sanitizeSessionArtifact(payload) as Record<string, any>;
 	}
 
 	exportAsJSON(options: ExportOptions = {}): string {

--- a/src/core/ArtifactBuilder.ts
+++ b/src/core/ArtifactBuilder.ts
@@ -2,6 +2,31 @@ import { sanitizeSessionArtifact } from "./SessionArtifactSanitizer.js";
 
 const REDACTED = "[REDACTED]";
 const TEXT_ENTRY_ACTIONS = new Set(["type", "input", "fill", "change"]);
+const SENSITIVE_KEY_FRAGMENTS = [
+	"password",
+	"passwd",
+	"token",
+	"secret",
+	"apikey",
+	"api-key",
+	"api_key",
+	"authorization",
+	"cookie",
+];
+
+function redactCompositeSensitiveFields(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map((entry) => redactCompositeSensitiveFields(entry));
+	if (!value || typeof value !== "object") return value;
+
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		const normalizedKey = key.toLowerCase();
+		sanitized[key] = SENSITIVE_KEY_FRAGMENTS.some((fragment) => normalizedKey.includes(fragment))
+			? REDACTED
+			: redactCompositeSensitiveFields(entry);
+	}
+	return sanitized;
+}
 
 export interface VisualContext {
 	mouseX?: number;
@@ -164,7 +189,8 @@ export class ArtifactBuilder {
 
 	private sanitizePayload(payload: any): Record<string, any> {
 		if (!payload || typeof payload !== "object" || Array.isArray(payload)) return {};
-		return sanitizeSessionArtifact(payload) as Record<string, any>;
+		const sanitized = sanitizeSessionArtifact(payload) as Record<string, any>;
+		return redactCompositeSensitiveFields(sanitized) as Record<string, any>;
 	}
 
 	exportAsJSON(options: ExportOptions = {}): string {

--- a/src/core/ArtifactBuilder.ts
+++ b/src/core/ArtifactBuilder.ts
@@ -1,7 +1,7 @@
 import { sanitizeSessionArtifact } from "./SessionArtifactSanitizer.js";
 
 const REDACTED = "[REDACTED]";
-const TEXT_ENTRY_ACTIONS = new Set(["type", "input", "fill"]);
+const TEXT_ENTRY_ACTIONS = new Set(["type", "input", "fill", "change"]);
 
 export interface VisualContext {
 	mouseX?: number;

--- a/tests/unit/ArtifactBuilderCredentialSafety.test.ts
+++ b/tests/unit/ArtifactBuilderCredentialSafety.test.ts
@@ -43,6 +43,18 @@ describe("ArtifactBuilder credential safety", () => {
 		expectAbsentEverywhere(builder, [typedSecret]);
 	});
 
+	it("treats CHANGE values as text-entry material too", () => {
+		const builder = new ArtifactBuilder();
+		const typedSecret = "change-action-secret";
+
+		builder.addAction("CHANGE", { selector: "#credential", value: typedSecret });
+
+		const action = builder.getTrace().actions[0]!;
+		expect(action.payload.value).toBe(REDACTED);
+		expect(action.payload.valueLength).toBe(typedSecret.length);
+		expectAbsentEverywhere(builder, [typedSecret]);
+	});
+
 	it("recursively sanitizes URL, nested, and credential-shaped payload values", () => {
 		const builder = new ArtifactBuilder();
 		const urlPassword = "url-password-secret";

--- a/tests/unit/ArtifactBuilderCredentialSafety.test.ts
+++ b/tests/unit/ArtifactBuilderCredentialSafety.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { ArtifactBuilder } from "../../src/core/ArtifactBuilder.js";
+
+const REDACTED = "[REDACTED]";
+
+function expectAbsentEverywhere(builder: ArtifactBuilder, secrets: string[]): void {
+	const surfaces = [
+		JSON.stringify(builder.getTrace()),
+		JSON.stringify(builder.toActionFrames()),
+		builder.exportAsJSON(),
+		builder.exportAsText(),
+		builder.exportAsActionFrames(),
+	];
+	for (const surface of surfaces) {
+		for (const secret of secrets) expect(surface).not.toContain(secret);
+	}
+}
+
+describe("ArtifactBuilder credential safety", () => {
+	it("never retains literal text for type/input actions", () => {
+		const builder = new ArtifactBuilder();
+		const typedSecret = "correct-horse-battery-staple";
+
+		builder.addAction("type", { selector: "#password", text: typedSecret, hasAttentionFrame: false });
+
+		const action = builder.getTrace().actions[0]!;
+		expect(action.payload.text).toBe(REDACTED);
+		expect(action.payload.textLength).toBe(typedSecret.length);
+		expect(action.payload.selector).toBe("#password");
+		expectAbsentEverywhere(builder, [typedSecret]);
+	});
+
+	it("redacts value-style input payloads while preserving useful metadata", () => {
+		const builder = new ArtifactBuilder();
+		const typedSecret = "plain-input-secret";
+
+		builder.addAction("INPUT", { selector: "input[name=secret]", value: typedSecret, source: "agent" });
+
+		const action = builder.getTrace().actions[0]!;
+		expect(action.payload.value).toBe(REDACTED);
+		expect(action.payload.valueLength).toBe(typedSecret.length);
+		expect(action.payload.source).toBe("agent");
+		expectAbsentEverywhere(builder, [typedSecret]);
+	});
+
+	it("recursively sanitizes URL, nested, and credential-shaped payload values", () => {
+		const builder = new ArtifactBuilder();
+		const urlPassword = "url-password-secret";
+		const queryToken = "query-token-secret";
+		const bearer = "bearer-action-secret";
+		const nestedPassword = "nested-password-secret";
+		const url = `https://user:${urlPassword}@example.com/callback?token=${queryToken}&mode=debug`;
+
+		builder.addAction("openPage", {
+			url,
+			nested: { password: nestedPassword },
+			diagnostic: `Authorization: Bearer ${bearer}`,
+		});
+
+		const action = builder.getTrace().actions[0]!;
+		expect(action.payload.url).toContain("mode=debug");
+		expect(action.payload.nested.password).toBe(REDACTED);
+		expectAbsentEverywhere(builder, [urlPassword, queryToken, bearer, nestedPassword]);
+	});
+});

--- a/tests/unit/ArtifactBuilderCredentialSafety.test.ts
+++ b/tests/unit/ArtifactBuilderCredentialSafety.test.ts
@@ -55,6 +55,27 @@ describe("ArtifactBuilder credential safety", () => {
 		expectAbsentEverywhere(builder, [typedSecret]);
 	});
 
+	it("preserves broad redaction for composite sensitive field names recursively", () => {
+		const builder = new ArtifactBuilder();
+		const secrets = ["user-password-secret", "csrf-token-secret", "cookie-value-secret"];
+
+		builder.addAction("custom", {
+			userPassword: secrets[0],
+			nested: {
+				csrfToken: secrets[1],
+				cookieValue: secrets[2],
+				label: "safe-metadata",
+			},
+		});
+
+		const action = builder.getTrace().actions[0]!;
+		expect(action.payload.userPassword).toBe(REDACTED);
+		expect(action.payload.nested.csrfToken).toBe(REDACTED);
+		expect(action.payload.nested.cookieValue).toBe(REDACTED);
+		expect(action.payload.nested.label).toBe("safe-metadata");
+		expectAbsentEverywhere(builder, secrets);
+	});
+
 	it("recursively sanitizes URL, nested, and credential-shaped payload values", () => {
 		const builder = new ArtifactBuilder();
 		const urlPassword = "url-password-secret";


### PR DESCRIPTION
## Summary
- sanitize action payloads before storing them in `ArtifactBuilder`
- never retain literal `text` / `value` for `type`, `input`, or `fill` actions; retain length metadata instead
- recursively sanitize nested secret fields, credential-shaped strings, and URL-bearing fields through the shared session-artifact sanitizer
- make `getTrace()` return a detached credential-safe trace rather than exposing stored payload objects directly
- keep all JSON/text/ActionFrame exports behind the same shared sanitizer boundary
- add regression coverage for typed passwords, input values, nested secrets, Bearer strings, and tokenized URLs

Closes #126.

## Security model
Action artifacts are sanitized at ingestion, not only when exported. This matters for arbitrary typed passwords because a generic payload key such as `text` does not reveal whether the literal value is sensitive after the fact. The stored artifact keeps selector/action metadata and character counts without retaining the secret itself.

## Verification
- branch is based on current `main`
- pre-PR compare: `ArtifactBuilder.ts` +22/-15, dedicated security tests +65
- exact PR diff will be audited for behavior changes
- full CI + Docker are merge gates