### PR TITLE
security: sanitize ActionExecutor credential paths

### DIFF
--- a/src/core/controller/ActionExecutor.ts
+++ b/src/core/controller/ActionExecutor.ts
@@ -19,6 +19,7 @@ import type { ArtifactBuilder } from "../ArtifactBuilder.js";
 import { type CursorStepCallback, HumanMouse } from "../HumanMouse.js";
 import { InteractionReliability } from "../InteractionReliability.js";
 import { createLogger } from "../Logger.js";
+import { sanitizeRecordingUrl } from "../NetworkRecordingSanitizer.js";
 import type { PageStateCollector } from "../PageStateCollector.js";
 import type { PolicyEngine } from "../PolicyEngine.js";
 import type { SemanticEntityType, SemanticMapper } from "../SemanticMapper.js";
@@ -145,7 +146,7 @@ export class ActionExecutor {
 
 	private enforcePolicy(profile: any, url: string): void {
 		if (profile && !this.policyEngine.isAllowed(profile.class, url)) {
-			throw new Error(`Policy Violation: URL ${url} not allowed for ${profile.class} profile`);
+			throw new Error(`Policy Violation: URL ${sanitizeRecordingUrl(url)} not allowed for ${profile.class} profile`);
 		}
 	}
 
@@ -177,7 +178,7 @@ export class ActionExecutor {
 				error.name === "TimeoutError" || error.message.includes("timeout") || error.message.includes("Timeout");
 			if (waitState === "networkidle" && isTimeout) {
 				if (this.settings.verbosity >= 1) {
-					console.warn(`[Talox] networkidle navigation timed out for ${url}. Falling back to load.`);
+					this.log.warn(`networkidle navigation timed out for ${sanitizeRecordingUrl(url)}. Falling back to load.`);
 				}
 				await page.goto(url, { waitUntil: "load", timeout: 30000 });
 			} else {
@@ -400,7 +401,7 @@ export class ActionExecutor {
 			/* NOSONAR */
 			// intentionally ignored: collection failure returns minimal state
 			return {
-				url: page.url(),
+				url: sanitizeRecordingUrl(page.url()),
 				title: "Navigating...",
 				timestamp: new Date().toISOString(),
 				console: { errors: [] },
@@ -470,7 +471,7 @@ export class ActionExecutor {
 		const profile = this.getProfile();
 		const settings = this.settings;
 
-		await this.checkRiskyAction("type", `${selector} (text: ${text})`);
+		await this.checkRiskyAction("type", `${selector} (text length: ${text.length})`);
 
 		if (profile && !this.policyEngine.canPerform(profile.class, "type", selector)) {
 			throw new Error(`Policy Violation: Action 'type' on '${selector}' blocked for ${profile.class} profile`);
@@ -886,9 +887,10 @@ export class ActionExecutor {
 	private async checkRiskyAction(action: string, target: string): Promise<void> {
 		const profile = this.getProfile();
 		if (profile?.class === "ops" && this.riskyActionHook) {
-			const isApproved = await this.riskyActionHook(action, target);
+			const safeTarget = action === "navigate" ? sanitizeRecordingUrl(target) : target;
+			const isApproved = await this.riskyActionHook(action, safeTarget);
 			if (!isApproved) {
-				throw new Error(`Human-in-the-Loop blocked risky action: ${action} on ${target}`);
+				throw new Error(`Human-in-the-Loop blocked risky action: ${action} on ${safeTarget}`);
 			}
 		}
 	}

--- a/tests/unit/ActionExecutorCredentialSafety.test.ts
+++ b/tests/unit/ActionExecutorCredentialSafety.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ActionExecutor } from "../../src/core/controller/ActionExecutor.js";
+import { setLogLevel } from "../../src/core/Logger.js";
+
+function makeState() {
+	return {
+		url: "https://example.com",
+		title: "Test",
+		timestamp: new Date().toISOString(),
+		console: { errors: [] },
+		network: { failedRequests: [] },
+		nodes: [],
+		interactiveElements: [],
+		bugs: [],
+	};
+}
+
+function makeExecutor(options: {
+	url?: string;
+	collector?: { collect: ReturnType<typeof vi.fn> };
+	profile?: any;
+	policyAllowed?: boolean;
+	riskyActionHook?: (action: string, target: string) => Promise<boolean>;
+	verbosity?: number;
+} = {}) {
+	const page = {
+		url: vi.fn(() => options.url ?? "https://example.com"),
+		goto: vi.fn().mockResolvedValue(undefined),
+		waitForLoadState: vi.fn().mockResolvedValue(undefined),
+		type: vi.fn().mockResolvedValue(undefined),
+		keyboard: { type: vi.fn().mockResolvedValue(undefined) },
+		mouse: { click: vi.fn().mockResolvedValue(undefined) },
+	};
+	const collector = options.collector ?? { collect: vi.fn().mockResolvedValue(makeState()) };
+	const policyEngine = {
+		isAllowed: vi.fn().mockReturnValue(options.policyAllowed ?? true),
+		canPerform: vi.fn().mockReturnValue(true),
+	};
+	const artifactBuilder = { addAction: vi.fn() };
+	const executor = new ActionExecutor(
+		{
+			humanStealth: 0,
+			safeMode: true,
+			actionTimeoutMs: 5000,
+			navigationWaitUntil: "networkidle",
+			verbosity: options.verbosity ?? 0,
+			mouseSpeed: 1,
+			typingDelayMin: 10,
+			typingDelayMax: 20,
+			typoProbability: 0,
+			fidgetEnabled: false,
+			automaticThinkingEnabled: false,
+			adaptiveStealthEnabled: false,
+			adaptiveStealthSensitivity: 0.5,
+			adaptiveStealthRadius: 100,
+			precisionDecay: 0.1,
+		} as any,
+		{ emit: vi.fn() } as any,
+		artifactBuilder as any,
+		policyEngine as any,
+		{ mapNodes: vi.fn().mockReturnValue([]), filterByType: vi.fn().mockReturnValue([]) } as any,
+		() => page as any,
+		() => collector as any,
+		() => options.profile ?? null,
+		() => ({ x: 0, y: 0 }),
+		vi.fn(),
+		() => null,
+		(x: number, y: number) => ({ x, y }),
+		vi.fn().mockResolvedValue(null),
+		options.riskyActionHook,
+		vi.fn(),
+		undefined,
+		undefined,
+	);
+	return { executor, page, collector, policyEngine, artifactBuilder };
+}
+
+const credentialUrl =
+	"https://agent-user:page-password@example.com/callback?token=query-token&X-Amz-Signature=signed-url-secret&mode=debug";
+const urlSecrets = ["page-password", "query-token", "signed-url-secret"];
+
+function expectCredentialSafe(value: unknown, secrets = urlSecrets): void {
+	const serialized = typeof value === "string" ? value : JSON.stringify(value);
+	for (const secret of secrets) expect(serialized).not.toContain(secret);
+	expect(serialized).toContain("REDACTED");
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	setLogLevel("info");
+});
+
+describe("ActionExecutor credential-safe error and approval paths", () => {
+	it("sanitizes the synthesized click fallback state URL", async () => {
+		vi.useFakeTimers();
+		const collector = { collect: vi.fn().mockRejectedValue(new Error("collector unavailable")) };
+		const { executor, page } = makeExecutor({ url: credentialUrl, collector });
+
+		const pending = (executor as any).collectStateAfterClick(page);
+		await vi.advanceTimersByTimeAsync(500);
+		const state = await pending;
+
+		expectCredentialSafe(state.url);
+		expect(state.url).toContain("mode=debug");
+	});
+
+	it("sanitizes networkidle timeout diagnostics while preserving the raw navigation request", async () => {
+		setLogLevel("debug");
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const { executor, page } = makeExecutor({ verbosity: 1 });
+		page.goto
+			.mockRejectedValueOnce(Object.assign(new Error("navigation timeout"), { name: "TimeoutError" }))
+			.mockResolvedValueOnce(undefined);
+
+		await (executor as any).performNavigation(page, credentialUrl);
+
+		expect(page.goto).toHaveBeenNthCalledWith(1, credentialUrl, { waitUntil: "networkidle" });
+		expect(page.goto).toHaveBeenNthCalledWith(2, credentialUrl, { waitUntil: "load", timeout: 30000 });
+		const diagnostic = JSON.stringify(warn.mock.calls);
+		expectCredentialSafe(diagnostic);
+		expect(diagnostic).toContain("mode=debug");
+	});
+
+	it("sanitizes credential-bearing URLs in policy violation errors", () => {
+		const { executor } = makeExecutor({ policyAllowed: false });
+
+		expect(() => (executor as any).enforcePolicy({ class: "ops" }, credentialUrl)).toThrowError(
+			expect.objectContaining({
+				message: expect.not.stringContaining("signed-url-secret"),
+			}),
+		);
+		try {
+			(executor as any).enforcePolicy({ class: "ops" }, credentialUrl);
+		} catch (error) {
+			expectCredentialSafe((error as Error).message);
+		}
+	});
+
+	it("passes credential-safe navigation targets to risky-action approval and blocked errors", async () => {
+		const hook = vi.fn().mockResolvedValue(false);
+		const { executor } = makeExecutor({ profile: { class: "ops" }, riskyActionHook: hook });
+
+		let message = "";
+		try {
+			await (executor as any).checkRiskyAction("navigate", credentialUrl);
+		} catch (error) {
+			message = (error as Error).message;
+		}
+
+		expect(hook).toHaveBeenCalledTimes(1);
+		const approvedTarget = hook.mock.calls[0]![1];
+		expectCredentialSafe(approvedTarget);
+		expect(approvedTarget).toContain("mode=debug");
+		expectCredentialSafe(message);
+	});
+
+	it("never sends literal typed text to risky-action approval or blocked errors", async () => {
+		const typedSecret = "opaque-password-value-7391";
+		const hook = vi.fn().mockResolvedValue(false);
+		const { executor } = makeExecutor({ profile: { class: "ops" }, riskyActionHook: hook });
+
+		let message = "";
+		try {
+			await (executor as any)._typeInternal("#password", typedSecret);
+		} catch (error) {
+			message = (error as Error).message;
+		}
+
+		const approvalTarget = hook.mock.calls[0]![1];
+		expect(approvalTarget).toContain("#password");
+		expect(approvalTarget).toContain(String(typedSecret.length));
+		expect(approvalTarget).not.toContain(typedSecret);
+		expect(message).not.toContain(typedSecret);
+	});
+});


### PR DESCRIPTION
## Summary
- sanitize synthesized click fallback-state URLs before returning agent-facing state
- route networkidle timeout diagnostics through the scoped redacting logger and sanitize the displayed URL
- sanitize credential-bearing URLs in policy violation errors
- sanitize navigation targets before risky-action approval and blocked-action errors
- never send literal typed text to risky-action approval; retain selector + character count instead
- add dedicated regression coverage for fallback state, timeout logging, policy errors, approval targets, and opaque typed secrets

Closes #127.
Closes #129.

## Security model
The live browser still receives the original URL and typed value where execution requires them. Only diagnostic, approval, fallback-state, and error surfaces are sanitized. URL redaction reuses the shared `sanitizeRecordingUrl()` boundary, including signed-URL credentials added in #125.

## Verification
- branch starts from current `main` (`5914d88`)
- production diff audited after full-file write: `ActionExecutor.ts` +8/-6 only
- dedicated credential-safety test file added
- full CI + Docker and review are merge gates