### PR TITLE
reliability: report bounding-box state changes

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -338,6 +338,16 @@ export function diffPageState(prev: TaloxPageState, curr: TaloxPageState): Talox
 		if (p.role !== c.role) {
 			nodesChanged.push({ id, field: "role", prev: p.role, curr: c.role });
 		}
+		const pBox = p.boundingBox;
+		const cBox = c.boundingBox;
+		if (pBox.x !== cBox.x || pBox.y !== cBox.y || pBox.width !== cBox.width || pBox.height !== cBox.height) {
+			nodesChanged.push({
+				id,
+				field: "boundingBox",
+				prev: JSON.stringify(pBox),
+				curr: JSON.stringify(cBox),
+			});
+		}
 	}
 
 	const prevBugIds = new Set(prev.bugs.map((b) => b.id));

--- a/tests/unit/StateDiffBoundingBox.test.ts
+++ b/tests/unit/StateDiffBoundingBox.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { diffPageState, type TaloxNode, type TaloxPageState } from "../../src/types/index.js";
+
+function pageState(node: TaloxNode): TaloxPageState {
+	return {
+		url: "https://example.com",
+		title: "Example",
+		timestamp: "2026-08-27T10:00:00.000Z",
+		console: { errors: [] },
+		network: { failedRequests: [] },
+		nodes: [node],
+		interactiveElements: [],
+		bugs: [],
+	};
+}
+
+const baseNode: TaloxNode = {
+	id: "stable-submit",
+	role: "button",
+	name: "Submit",
+	boundingBox: { x: 10, y: 20, width: 100, height: 40 },
+};
+
+describe("diffPageState bounding-box changes", () => {
+	it("reports movement or resize of a stable node", () => {
+		const prev = pageState(baseNode);
+		const curr = pageState({
+			...baseNode,
+			boundingBox: { x: 16, y: 24, width: 120, height: 44 },
+		});
+
+		const diff = diffPageState(prev, curr);
+
+		expect(diff.nodesChanged).toEqual([
+			{
+				id: "stable-submit",
+				field: "boundingBox",
+				prev: JSON.stringify(baseNode.boundingBox),
+				curr: JSON.stringify(curr.nodes[0]!.boundingBox),
+			},
+		]);
+	});
+
+	it("does not report identical bounding boxes", () => {
+		const prev = pageState(baseNode);
+		const curr = pageState({ ...baseNode, boundingBox: { ...baseNode.boundingBox } });
+
+		const diff = diffPageState(prev, curr);
+
+		expect(diff.nodesChanged).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary
- make `diffPageState()` honor the existing `TaloxStateDiff.nodesChanged` contract for `boundingBox`
- detect stable-node movement and resize by comparing x/y/width/height in O(n)
- preserve the v1 public diff shape by serializing previous/current boxes into the existing string fields
- add regression coverage for moved/resized and unchanged boxes

Closes #131.

## Evidence
The public contract already advertises `field: "boundingBox"` and documents name/role/bounding-box changes, but the implementation only compared name and role. That made layout movement invisible to first-class state diffs.

## Verification
- branch starts at current `main` (`63ef4a1`)
- full-file source rewrite audited: `src/types/index.ts` is exactly +10/-0
- dedicated regression test added
- existing `test:perf` gate remains a merge requirement alongside full CI + Docker