### PR TITLE
reliability: diff interactive elements by stable id

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -350,6 +350,11 @@ export function diffPageState(prev: TaloxPageState, curr: TaloxPageState): Talox
 		}
 	}
 
+	const prevInteractiveIds = new Set(prev.interactiveElements.map((element) => element.id));
+	const currInteractiveIds = new Set(curr.interactiveElements.map((element) => element.id));
+	const interactiveAdded = Array.from(currInteractiveIds).filter((id) => !prevInteractiveIds.has(id)).length;
+	const interactiveRemoved = Array.from(prevInteractiveIds).filter((id) => !currInteractiveIds.has(id)).length;
+
 	const prevBugIds = new Set(prev.bugs.map((b) => b.id));
 	const currBugIds = new Set(curr.bugs.map((b) => b.id));
 	const bugsAdded = curr.bugs.filter((b) => !prevBugIds.has(b.id));
@@ -357,7 +362,6 @@ export function diffPageState(prev: TaloxPageState, curr: TaloxPageState): Talox
 
 	const prevErrors = new Set(prev.console.errors);
 	const newConsoleErrors = curr.console.errors.filter((e) => !prevErrors.has(e));
-
 	const prevFailedUrls = new Set(prev.network.failedRequests.map((r) => `${r.url}::${r.status}`));
 	const newFailedRequests = curr.network.failedRequests
 		.filter((r) => !prevFailedUrls.has(`${r.url}::${r.status}`))
@@ -376,8 +380,8 @@ export function diffPageState(prev: TaloxPageState, curr: TaloxPageState): Talox
 		nodesAdded,
 		nodesRemoved,
 		nodesChanged,
-		interactiveAdded: Math.max(0, curr.interactiveElements.length - prev.interactiveElements.length),
-		interactiveRemoved: Math.max(0, prev.interactiveElements.length - curr.interactiveElements.length),
+		interactiveAdded,
+		interactiveRemoved,
 		bugsAdded,
 		bugsResolved,
 		newConsoleErrors,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -362,6 +362,7 @@ export function diffPageState(prev: TaloxPageState, curr: TaloxPageState): Talox
 
 	const prevErrors = new Set(prev.console.errors);
 	const newConsoleErrors = curr.console.errors.filter((e) => !prevErrors.has(e));
+
 	const prevFailedUrls = new Set(prev.network.failedRequests.map((r) => `${r.url}::${r.status}`));
 	const newFailedRequests = curr.network.failedRequests
 		.filter((r) => !prevFailedUrls.has(`${r.url}::${r.status}`))

--- a/tests/unit/StateDiffInteractiveElements.test.ts
+++ b/tests/unit/StateDiffInteractiveElements.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { diffPageState, type TaloxPageState } from "../../src/types/index.js";
+
+function interactive(id: string) {
+	return {
+		id,
+		tagName: "button",
+		boundingBox: { x: 0, y: 0, width: 100, height: 40 },
+	};
+}
+
+function state(ids: string[]): TaloxPageState {
+	return {
+		url: "https://example.com",
+		title: "Example",
+		timestamp: "2026-08-27T10:00:00.000Z",
+		console: { errors: [] },
+		network: { failedRequests: [] },
+		nodes: [],
+		interactiveElements: ids.map(interactive),
+		bugs: [],
+	};
+}
+
+describe("diffPageState interactive-element deltas", () => {
+	it("detects equal-count replacement", () => {
+		const diff = diffPageState(state(["#old"]), state(["#new"]));
+		expect(diff.interactiveAdded).toBe(1);
+		expect(diff.interactiveRemoved).toBe(1);
+	});
+
+	it("detects pure additions", () => {
+		const diff = diffPageState(state(["#a"]), state(["#a", "#b"]));
+		expect(diff.interactiveAdded).toBe(1);
+		expect(diff.interactiveRemoved).toBe(0);
+	});
+
+	it("detects pure removals", () => {
+		const diff = diffPageState(state(["#a", "#b"]), state(["#a"]));
+		expect(diff.interactiveAdded).toBe(0);
+		expect(diff.interactiveRemoved).toBe(1);
+	});
+
+	it("reports no delta when IDs are unchanged", () => {
+		const diff = diffPageState(state(["#a", "#b"]), state(["#a", "#b"]));
+		expect(diff.interactiveAdded).toBe(0);
+		expect(diff.interactiveRemoved).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- make `diffPageState()` compare interactive elements by stable `id` rather than list cardinality
- correctly report equal-count replacements as one addition and one removal
- preserve the public v1 diff shape (`interactiveAdded` / `interactiveRemoved` remain numbers)
- keep the operation O(n) with two ID sets
- add regression coverage for replacement, pure add/remove, and unchanged IDs

Closes #133.

## Verification plan
- audit the exact PR diff for unrelated full-file changes
- require Unit Tests, including the existing performance benchmark suite, to pass
- require full CI + Docker before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive-element change tracking by identifying which elements were added or removed between page snapshots.
  * Correctly handles replacements where the total number of interactive elements stays the same.

* **Tests**
  * Added coverage for additions, removals, replacements, and unchanged interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->