### PR TITLE
real-world: wait for Grok SPA hydration before hard-block assertion

### DIFF
--- a/tests/real/06b-grok-agent-to-agent.spec.ts
+++ b/tests/real/06b-grok-agent-to-agent.spec.ts
@@ -18,10 +18,18 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { TaloxController } from "../../src/index.js";
+import { waitFor } from "./helpers.js";
 
 let talox: TaloxController;
 let profileDir: string;
 const adaptedEvents: any[] = [];
+
+function hasInteractiveControl(state: any): boolean {
+	return (state?.nodes ?? []).some((node: any) => {
+		const role = (node.role ?? "").toLowerCase();
+		return role === "button" || ["textbox", "input", "searchbox"].includes(role);
+	});
+}
 
 test.describe("Scenario 6b — Grok agent-to-agent (free mode)", () => {
 	test.setTimeout(180_000);
@@ -74,12 +82,25 @@ test.describe("Scenario 6b — Grok agent-to-agent (free mode)", () => {
 	// ── Step 2: Verify interactive page ─────────────────────────────────────────
 
 	test("Step 2 — page has interactive elements (not a hard block)", async () => {
-		// Re-navigate for worker-restart resilience
+		// Re-navigate for worker-restart resilience. Grok hydrates asynchronously,
+		// so the state returned by navigate() can legitimately be an app shell.
 		let state: any;
 		try {
 			await talox.waitForTimeout(1000);
 			state = await talox.navigate("https://grok.com");
-			await talox.waitForTimeout(2000);
+			try {
+				await waitFor(
+					async () => {
+						state = await talox.getState();
+						return hasInteractiveControl(state);
+					},
+					20_000,
+					1000,
+				);
+			} catch {
+				// Keep the last sampled state. The assertion below should still fail
+				// when a loaded Grok/X page remains genuinely non-interactive.
+			}
 		} catch {
 			try {
 				state = await talox.getState();


### PR DESCRIPTION
## Summary
- fix the Grok real-world readiness check exposed by scheduled CI run `32927488883`
- re-sample Talox state after navigation while Grok's SPA hydrates instead of asserting against the stale navigation-time snapshot
- reuse the existing bounded `waitFor` helper with a 20s readiness window
- keep the hard-block assertion strict when a loaded Grok/X state remains non-interactive

Closes #135.

## Evidence
The failed nightly Step 2 saw one non-interactive node, but Step 3 in the same job later successfully typed into `textarea[placeholder]`. The test waited after `navigate()` but never refreshed the captured state.

## Verification plan
- exact diff audit
- PR CI/Docker and Playwright discovery
- targeted workflow-dispatch Grok real-world run if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by waiting for interactive controls to become available instead of relying on a fixed delay.
  * Added polling with a timeout to better handle variable loading times and preserve diagnostic state when the wait fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->