### PR TITLE
fix: keep per-page mouse positions aligned after tab close

### DIFF
--- a/src/core/controller/SessionManager.ts
+++ b/src/core/controller/SessionManager.ts
@@ -324,6 +324,12 @@ export class SessionManager {
 
 		this.pages.splice(index, 1);
 		this.pageMousePositions.delete(index);
+		for (let pageIndex = index + 1; pageIndex <= this.pages.length; pageIndex++) {
+			const position = this.pageMousePositions.get(pageIndex);
+			if (position) this.pageMousePositions.set(pageIndex - 1, position);
+			else this.pageMousePositions.delete(pageIndex - 1);
+		}
+		this.pageMousePositions.delete(this.pages.length);
 
 		if (this.activePageIndex === index) {
 			this.activePageIndex = this.pages.length > 0 ? 0 : -1;

--- a/tests/unit/SessionManagerMousePositionReindex.test.ts
+++ b/tests/unit/SessionManagerMousePositionReindex.test.ts
@@ -11,7 +11,11 @@ function makeCollector() {
 
 describe("SessionManager page mouse position reindexing", () => {
 	it("preserves the surviving page position when closing a middle page", async () => {
-		const session = new SessionManager({ automaticThinkingEnabled: false, verbosity: 0 } as any, { emit: vi.fn() } as any, ".");
+		const session = new SessionManager(
+			{ automaticThinkingEnabled: false, verbosity: 0 } as any,
+			{ emit: vi.fn() } as any,
+			".",
+		);
 		const first = makeCollector();
 		const middle = makeCollector();
 		const last = makeCollector();

--- a/tests/unit/SessionManagerMousePositionReindex.test.ts
+++ b/tests/unit/SessionManagerMousePositionReindex.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../src/core/controller/SessionManager.js";
+
+function makeCollector() {
+	const close = vi.fn().mockResolvedValue(undefined);
+	return {
+		collector: { getPage: () => ({ close }) } as any,
+		close,
+	};
+}
+
+describe("SessionManager page mouse position reindexing", () => {
+	it("preserves the surviving page position when closing a middle page", async () => {
+		const session = new SessionManager({ automaticThinkingEnabled: false, verbosity: 0 } as any, { emit: vi.fn() } as any, ".");
+		const first = makeCollector();
+		const middle = makeCollector();
+		const last = makeCollector();
+		const positions = session.pageMousePositions;
+
+		session.pages = [first.collector, middle.collector, last.collector];
+		session.activePageIndex = 2;
+		positions.set(0, { x: 10, y: 20 });
+		positions.set(1, { x: 30, y: 40 });
+		positions.set(2, { x: 50, y: 60 });
+
+		await session.closePage(1);
+
+		expect(middle.close).toHaveBeenCalledOnce();
+		expect(session.activePageIndex).toBe(1);
+		expect(session.pageMousePositions).toBe(positions);
+		expect([...positions.entries()]).toEqual([
+			[0, { x: 10, y: 20 }],
+			[1, { x: 50, y: 60 }],
+		]);
+		expect(positions.has(2)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- reindex `pageMousePositions` after closing a page so surviving tabs keep their cursor state
- preserve the existing `Map` identity
- add focused regression coverage for closing a middle tab while a later tab is active

Closes #139.

## Expected behavior
With pages `[0, 1, 2]` and positions `{0→A, 1→B, 2→C}`, closing page `1` now leaves pages `[0, old-2]` and positions `{0→A, 1→C}` with no stale key `2`.

## Verification
- focused unit regression added first
- full CI / browser matrix and Docker must pass before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mouse-position tracking when closing a page, keeping positions aligned with the remaining page indices.
  * Corrected active-page selection after closing a page in the middle of the page list.

* **Tests**
  * Added coverage for page closing, position reindexing, active-page updates, and removal of obsolete entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->